### PR TITLE
fix: fall back safely on selector feed failures

### DIFF
--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -18,6 +18,11 @@ npm run selectors:validate -- ..\tutti-site\selectors.json
 Published schema-v1 selector keys are persistent wire IDs. Add new keys when
 needed; never rename, repurpose, or delete an existing key.
 
+Runtime clients apply only schema v1. Fetch, JSON, schema, or known-value
+validation failures clear both remote selector and video-constraint caches so
+bundled defaults win. Additive unknown entries are ignored and recorded in
+manual diagnostics, while the publish command above rejects them.
+
 ## 1. API E2E (GitHub-hosted runner)
 
 The API path (`src/api/{bluesky,mastodon,misskey}.ts`) is independent of any

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -15,7 +15,7 @@ import {
   pruneInteractionSnapshots,
   runPollCycle as runInteractionPollCycle,
 } from '../src/utils/interaction-notify';
-import { fetchOverridesFrom } from '../src/utils/selector-overrides';
+import { fetchOverridesFrom } from '../src/utils/selector-feed-runtime';
 import { notifyResults, clearBadge, updateProgressBadge } from '../src/background/post-status-ui';
 import { runPostScheduler } from '../src/background/post-scheduler';
 import { buildDiagnosticsReport } from '../src/background/diagnostics';

--- a/entrypoints/options/Options.svelte
+++ b/entrypoints/options/Options.svelte
@@ -8,10 +8,10 @@
     TERMS_URL,
   } from '../../src/storage';
   import {
-    fetchOverridesFrom,
     getFetchedAt,
     getOverrides,
   } from '../../src/utils/selector-overrides';
+  import { fetchOverridesFrom } from '../../src/utils/selector-feed-runtime';
   import {
     getApiCredentials,
     setApiCredentials,
@@ -147,6 +147,10 @@
       overrideCount = result.count ?? 0;
     } else {
       overrideStatus = `✗ ${result.error}`;
+      // Runtime contract: any failed refresh clears remote caches so bundled
+      // selectors win. Keep the visible state aligned with that fallback.
+      overrideFetchedAt = null;
+      overrideCount = 0;
     }
   }
 

--- a/src/background/diagnostics-selector-feed.test.ts
+++ b/src/background/diagnostics-selector-feed.test.ts
@@ -33,6 +33,7 @@ describe('selector feed manual diagnostics', () => {
         getManifest: vi.fn(() => ({ version: '0.5.49' })),
       },
     });
+    vi.stubGlobal('navigator', { userAgent: 'diagnostics-test-agent' });
     mocks.getSettings.mockResolvedValue({ selectorOverrideUrl: '<redacted in fixture>' });
     mocks.getLastSeenUsers.mockResolvedValue({});
     mocks.getPostHistory.mockResolvedValue([]);

--- a/src/background/diagnostics-selector-feed.test.ts
+++ b/src/background/diagnostics-selector-feed.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildDiagnosticsReport } from './diagnostics';
+
+const mocks = vi.hoisted(() => ({
+  getLastSeenUsers: vi.fn(),
+  getPostHistory: vi.fn(),
+  getSettings: vi.fn(),
+  getSelectorFeedDiagnostics: vi.fn(),
+}));
+
+vi.mock('../storage', () => ({
+  getLastSeenUsers: mocks.getLastSeenUsers,
+  getPostHistory: mocks.getPostHistory,
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock('../utils/selector-feed-runtime', () => ({
+  getSelectorFeedDiagnostics: mocks.getSelectorFeedDiagnostics,
+}));
+
+vi.mock('../adapters/registry', () => ({
+  adapters: {},
+  getAdapter: vi.fn(),
+}));
+
+describe('selector feed manual diagnostics', () => {
+  beforeEach(() => {
+    vi.stubGlobal('browser', {
+      tabs: {
+        query: vi.fn(async () => []),
+      },
+      runtime: {
+        getManifest: vi.fn(() => ({ version: '0.5.49' })),
+      },
+    });
+    mocks.getSettings.mockResolvedValue({ selectorOverrideUrl: '<redacted in fixture>' });
+    mocks.getLastSeenUsers.mockResolvedValue({});
+    mocks.getPostHistory.mockResolvedValue([]);
+    mocks.getSelectorFeedDiagnostics.mockResolvedValue({
+      status: 'fallback',
+      reason: 'unsupported-schema',
+      checkedAt: 123,
+      schemaVersion: 2,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('includes the PII-safe last feed outcome', async () => {
+    const report = await buildDiagnosticsReport();
+
+    expect(report.selectorFeed).toEqual({
+      status: 'fallback',
+      reason: 'unsupported-schema',
+      checkedAt: 123,
+      schemaVersion: 2,
+    });
+  });
+});

--- a/src/background/diagnostics.ts
+++ b/src/background/diagnostics.ts
@@ -3,6 +3,10 @@ import type { HistoryEntry, HistoryPlatformResult } from '../storage';
 import { getLastSeenUsers, getPostHistory, getSettings } from '../storage';
 import { adapters, getAdapter } from '../adapters/registry';
 import { isKnownComposeUrl } from '../utils/compose-url';
+import {
+  getSelectorFeedDiagnostics,
+  type SelectorFeedDiagnostics,
+} from '../utils/selector-feed-runtime';
 
 export interface DiagnosticsReport {
   version: string;
@@ -27,6 +31,8 @@ export interface DiagnosticsReport {
   }>;
   /** PII 除去済。detectedUser は '<present>' or null */
   platforms: DiagnosePlatformResult[];
+  /** URL や selector 値を含まない remote feed の最終適用結果 */
+  selectorFeed: SelectorFeedDiagnostics | null;
 }
 
 export interface DiagnosticsReportOptions {
@@ -71,6 +77,7 @@ export async function buildDiagnosticsReport(
     lastSeenUsers: redactLastSeenUsers(await getLastSeenUsers()),
     recentHistory: redactHistoryForDiagnostics((await getPostHistory()).slice(0, 5)),
     platforms: redactDiagnosticPlatformResults(platformResults),
+    selectorFeed: await getSelectorFeedDiagnostics(),
   };
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -123,8 +123,8 @@ const DEFAULT_SETTINGS: Settings = {
   misskeyInstance: 'https://misskey.io',
   autoPost: false,
   // hot-fix endpoint: public site repo で配信される `selectors.json`。
-  // 各 SNS の UI 変更で selector が壊れたとき、拡張更新を待たず自動 PR
-  // (auto-triage.yml) のマージで全ユーザーに反映される。
+  // 各 SNS の UI 変更時は maintainer が adapter / feed を手動 review・validate
+  // して publish し、拡張更新を待たずに修正を配信する。
   // 自分の運用 (selectorOverrideUrl 空・自社相当) ではない一般ユーザーは
   // この default を継続使用する想定。
   selectorOverrideUrl: 'https://tutti.komm64.com/selectors.json',

--- a/src/utils/selector-feed-runtime.test.ts
+++ b/src/utils/selector-feed-runtime.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchOverridesFrom,
+  getSelectorFeedDiagnostics,
+} from './selector-feed-runtime';
+import {
+  getOverrides,
+  getVideoConstraintsOverrides,
+  resolveSelectors,
+} from './selector-overrides';
+
+const validMetadata = {
+  schemaVersion: 1,
+  description: 'Tutti selector feed',
+  homepage: 'https://github.com/komm64/tutti',
+};
+
+describe('selector override feed runtime contract', () => {
+  let store: Record<string, unknown>;
+
+  beforeEach(() => {
+    store = {
+      selectorOverrides: {
+        x: { textarea: '.stale-selector' },
+      },
+      selectorOverridesFetchedAt: 123,
+      videoConstraintsOverrides: {
+        bluesky: { maxBytes: 1 },
+      },
+    };
+    vi.stubGlobal('browser', {
+      storage: {
+        local: {
+          get: vi.fn(async (key: string) => ({ [key]: store[key] })),
+          set: vi.fn(async (values: Record<string, unknown>) => {
+            Object.assign(store, values);
+          }),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('atomically stores a supported schema-v1 feed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      _meta: validMetadata,
+      x: { textarea: '[data-testid="tweetTextarea_0"]' },
+      _videoConstraints: {
+        bluesky: { maxBytes: 200_000_000 },
+      },
+    })));
+
+    const result = await fetchOverridesFrom('https://example.com/selectors.json');
+
+    expect(result).toEqual({ ok: true, count: 1 });
+    expect(await getOverrides()).toEqual({
+      x: { textarea: '[data-testid="tweetTextarea_0"]' },
+    });
+    expect(await getVideoConstraintsOverrides()).toEqual({
+      bluesky: { maxBytes: 200_000_000 },
+    });
+    expect(await getSelectorFeedDiagnostics()).toEqual({
+      status: 'applied',
+      reason: 'applied',
+      checkedAt: expect.any(Number),
+      schemaVersion: 1,
+    });
+    expect(store.selectorOverridesFetchedAt).not.toBe(123);
+  });
+
+  it('applies known entries and records sanitized additive unknown-entry warnings', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      _meta: validMetadata,
+      x: {
+        textarea: 'textarea',
+        futureSelector: '[data-future]',
+        '<private>': 'ignored',
+      },
+      futureNetwork: {
+        textarea: 'textarea',
+      },
+    })));
+
+    const result = await fetchOverridesFrom('https://example.com/selectors.json');
+
+    expect(result).toMatchObject({
+      ok: true,
+      count: 1,
+      warnings: [
+        'x.futureSelector: unknown schema-v1 selector wire key',
+        '<invalid feed entry>',
+        'futureNetwork: unknown platform',
+      ],
+    });
+    expect(await getOverrides()).toEqual({
+      x: { textarea: 'textarea' },
+    });
+    expect(await getSelectorFeedDiagnostics()).toEqual({
+      status: 'applied',
+      reason: 'applied-with-unknown-entries',
+      checkedAt: expect.any(Number),
+      schemaVersion: 1,
+      unknownEntries: [
+        'x.futureSelector: unknown schema-v1 selector wire key',
+        '<invalid feed entry>',
+        'futureNetwork: unknown platform',
+      ],
+    });
+  });
+
+  it('clears stale caches and uses bundled defaults for unsupported schemas', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      _meta: { ...validMetadata, schemaVersion: 2 },
+      x: { textarea: '.remote-selector' },
+    })));
+
+    const result = await fetchOverridesFrom('https://example.com/selectors.json');
+
+    expect(result).toEqual({
+      ok: false,
+      error: '_meta.schemaVersion: unsupported schema 2; expected 1',
+    });
+    expect(await getOverrides()).toEqual({});
+    expect(await getVideoConstraintsOverrides()).toEqual({});
+    expect(store.selectorOverridesFetchedAt).toBeNull();
+    await expect(resolveSelectors('x', {
+      textarea: '.bundled-selector',
+    })).resolves.toEqual({
+      textarea: '.bundled-selector',
+    });
+    expect(await getSelectorFeedDiagnostics()).toEqual({
+      status: 'fallback',
+      reason: 'unsupported-schema',
+      checkedAt: expect.any(Number),
+      schemaVersion: 2,
+    });
+  });
+
+  it('rejects malformed known entries instead of partially applying the feed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      _meta: validMetadata,
+      x: {
+        textarea: 42,
+        postButton: '[data-testid="tweetButton"]',
+      },
+    })));
+
+    const result = await fetchOverridesFrom('https://example.com/selectors.json');
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'x.textarea: selector must be a non-empty string',
+    });
+    expect(await getOverrides()).toEqual({});
+    expect(await getSelectorFeedDiagnostics()).toEqual({
+      status: 'fallback',
+      reason: 'invalid-feed',
+      checkedAt: expect.any(Number),
+      schemaVersion: 1,
+    });
+  });
+
+  it.each([
+    {
+      name: 'HTTP failure',
+      fetchImpl: async () => jsonResponse({}, 503),
+      reason: 'http-error',
+      error: 'HTTP 503',
+      diagnostic: { httpStatus: 503 },
+    },
+    {
+      name: 'invalid JSON',
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: vi.fn(async () => {
+          throw new SyntaxError('invalid JSON');
+        }),
+      } as unknown as Response),
+      reason: 'invalid-json',
+      error: 'invalid JSON',
+      diagnostic: {},
+    },
+    {
+      name: 'network failure',
+      fetchImpl: async () => {
+        throw new TypeError('network unavailable');
+      },
+      reason: 'network-error',
+      error: 'network unavailable',
+      diagnostic: {},
+    },
+  ])('clears stale caches on $name', async ({
+    fetchImpl,
+    reason,
+    error,
+    diagnostic,
+  }) => {
+    vi.stubGlobal('fetch', vi.fn(fetchImpl));
+
+    await expect(fetchOverridesFrom('https://example.com/selectors.json'))
+      .resolves.toEqual({ ok: false, error });
+    expect(await getOverrides()).toEqual({});
+    expect(await getVideoConstraintsOverrides()).toEqual({});
+    expect(store.selectorOverridesFetchedAt).toBeNull();
+    expect(await getSelectorFeedDiagnostics()).toEqual({
+      status: 'fallback',
+      reason,
+      checkedAt: expect.any(Number),
+      ...diagnostic,
+    });
+  });
+});
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => value),
+  } as unknown as Response;
+}

--- a/src/utils/selector-feed-runtime.ts
+++ b/src/utils/selector-feed-runtime.ts
@@ -1,0 +1,214 @@
+import { t } from './i18n';
+import {
+  SELECTOR_OVERRIDE_STORAGE_KEYS,
+  type SelectorOverrides,
+  type VideoConstraintsOverrides,
+} from './selector-overrides';
+import { validateSelectorFeed } from './selector-feed';
+
+export type SelectorFeedDiagnosticReason =
+  | 'applied'
+  | 'applied-with-unknown-entries'
+  | 'invalid-url'
+  | 'http-error'
+  | 'invalid-json'
+  | 'unsupported-schema'
+  | 'invalid-feed'
+  | 'network-error'
+  | 'storage-error';
+
+export interface SelectorFeedDiagnostics {
+  status: 'applied' | 'fallback';
+  reason: SelectorFeedDiagnosticReason;
+  checkedAt: number;
+  schemaVersion?: number;
+  httpStatus?: number;
+  unknownEntries?: string[];
+}
+
+export interface FetchSelectorOverridesResult {
+  ok: boolean;
+  error?: string;
+  count?: number;
+  warnings?: string[];
+}
+
+/**
+ * Fetches and atomically stores a remote selector feed.
+ *
+ * Fetch, schema, or known-value failures clear old remote caches so bundled
+ * defaults win. Unknown schema-v1 entries remain additive: known entries are
+ * applied and a PII-safe diagnostic warning is recorded.
+ */
+export async function fetchOverridesFrom(url: string): Promise<FetchSelectorOverridesResult> {
+  if (!isHttpsUrl(url)) {
+    return persistBundledFallback(
+      'invalid-url',
+      t('runtimeSelectorUrlHttpsRequired'),
+    );
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, { cache: 'no-store' });
+  } catch (e) {
+    return persistBundledFallback('network-error', errorMessage(e));
+  }
+  if (!res.ok) {
+    return persistBundledFallback('http-error', `HTTP ${res.status}`, {
+      httpStatus: res.status,
+    });
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch (e) {
+    return persistBundledFallback('invalid-json', errorMessage(e));
+  }
+
+  const parsed = validateSelectorFeed(data, { unknownEntryPolicy: 'warn' });
+  if (!parsed.ok) {
+    const error = parsed.errors.length > 0
+      ? parsed.errors.join('; ')
+      : t('runtimeSelectorJsonObjectRequired');
+    return persistBundledFallback(parsed.kind, error, {
+      schemaVersion: readSchemaVersion(data),
+    });
+  }
+
+  const diagnostics: SelectorFeedDiagnostics = {
+    status: 'applied',
+    reason: parsed.warnings.length > 0 ? 'applied-with-unknown-entries' : 'applied',
+    checkedAt: Date.now(),
+    schemaVersion: parsed.feed._meta.schemaVersion,
+    ...(parsed.warnings.length > 0
+      ? { unknownEntries: sanitizeDiagnosticWarnings(parsed.warnings) }
+      : {}),
+  };
+  try {
+    await browser.storage.local.set({
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.selectors]: parsed.selectors as SelectorOverrides,
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.fetchedAt]: diagnostics.checkedAt,
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.videoConstraints]:
+        parsed.videoConstraints as VideoConstraintsOverrides,
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.diagnostics]: diagnostics,
+    });
+  } catch (e) {
+    return persistBundledFallback(
+      'storage-error',
+      `selector feed storage failed: ${errorMessage(e)}`,
+    );
+  }
+
+  return {
+    ok: true,
+    count: parsed.selectorCount,
+    ...(diagnostics.unknownEntries ? { warnings: diagnostics.unknownEntries } : {}),
+  };
+}
+
+export async function getSelectorFeedDiagnostics(): Promise<SelectorFeedDiagnostics | null> {
+  const stored = await browser.storage.local.get(SELECTOR_OVERRIDE_STORAGE_KEYS.diagnostics);
+  return normalizeDiagnostics(stored[SELECTOR_OVERRIDE_STORAGE_KEYS.diagnostics]);
+}
+
+async function persistBundledFallback(
+  reason: Exclude<SelectorFeedDiagnosticReason, 'applied' | 'applied-with-unknown-entries'>,
+  error: string,
+  details: Pick<SelectorFeedDiagnostics, 'schemaVersion' | 'httpStatus'> = {},
+): Promise<FetchSelectorOverridesResult> {
+  const diagnostics: SelectorFeedDiagnostics = {
+    status: 'fallback',
+    reason,
+    checkedAt: Date.now(),
+    ...details,
+  };
+  try {
+    await browser.storage.local.set({
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.selectors]: {},
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.fetchedAt]: null,
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.videoConstraints]: {},
+      [SELECTOR_OVERRIDE_STORAGE_KEYS.diagnostics]: diagnostics,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: `${error}; bundled fallback storage failed: ${errorMessage(e)}`,
+    };
+  }
+  return { ok: false, error };
+}
+
+function readSchemaVersion(value: unknown): number | undefined {
+  if (!isRecord(value) || !isRecord(value._meta)) return undefined;
+  return typeof value._meta.schemaVersion === 'number'
+    ? value._meta.schemaVersion
+    : undefined;
+}
+
+function sanitizeDiagnosticWarnings(warnings: readonly string[]): string[] {
+  return warnings.slice(0, 20).map((warning) => (
+    warning.length <= 160 && /^[A-Za-z0-9_.: -]+$/.test(warning)
+      ? warning
+      : '<invalid feed entry>'
+  ));
+}
+
+function normalizeDiagnostics(value: unknown): SelectorFeedDiagnostics | null {
+  if (!isRecord(value)) return null;
+  if (value.status !== 'applied' && value.status !== 'fallback') return null;
+  if (
+    typeof value.reason !== 'string'
+    || !diagnosticReasons.has(value.reason as SelectorFeedDiagnosticReason)
+  ) return null;
+  if (typeof value.checkedAt !== 'number' || !Number.isFinite(value.checkedAt)) return null;
+
+  return {
+    status: value.status,
+    reason: value.reason as SelectorFeedDiagnosticReason,
+    checkedAt: value.checkedAt,
+    ...(typeof value.schemaVersion === 'number' && Number.isFinite(value.schemaVersion)
+      ? { schemaVersion: value.schemaVersion }
+      : {}),
+    ...(typeof value.httpStatus === 'number' && Number.isInteger(value.httpStatus)
+      ? { httpStatus: value.httpStatus }
+      : {}),
+    ...(Array.isArray(value.unknownEntries)
+      ? {
+        unknownEntries: sanitizeDiagnosticWarnings(
+          value.unknownEntries.filter((entry): entry is string => typeof entry === 'string'),
+        ),
+      }
+      : {}),
+  };
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' && parsed.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const diagnosticReasons = new Set<SelectorFeedDiagnosticReason>([
+  'applied',
+  'applied-with-unknown-entries',
+  'invalid-url',
+  'http-error',
+  'invalid-json',
+  'unsupported-schema',
+  'invalid-feed',
+  'network-error',
+  'storage-error',
+]);

--- a/src/utils/selector-feed.test.ts
+++ b/src/utils/selector-feed.test.ts
@@ -36,6 +36,7 @@ describe('validateSelectorFeed', () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: 'unsupported-schema',
       errors: ['_meta.schemaVersion: unsupported schema 2; expected 1'],
     });
   });
@@ -51,6 +52,7 @@ describe('validateSelectorFeed', () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: 'invalid-feed',
       errors: [
         '_meta.description: required non-empty string is missing',
         '_meta.homepage: required HTTPS URL is missing',
@@ -68,10 +70,65 @@ describe('validateSelectorFeed', () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: 'invalid-feed',
       errors: [
         'unknownNetwork: unknown platform',
         'x.renamedTextarea: unknown schema-v1 selector wire key',
         '_futureMetadata: unknown reserved namespace',
+      ],
+    });
+  });
+
+  it('keeps known entries and reports additive unknown entries in runtime mode', () => {
+    const result = validateSelectorFeed({
+      _meta: validMetadata,
+      x: {
+        textarea: 'textarea',
+        futureSelector: '[data-future]',
+      },
+      futureNetwork: {
+        textarea: 'textarea',
+      },
+      _futureMetadata: {},
+      _videoConstraints: {
+        bluesky: {
+          maxBytes: 200_000_000,
+          futureLimit: 1,
+        },
+      },
+    }, { unknownEntryPolicy: 'warn' });
+
+    expect(result).toEqual({
+      ok: true,
+      feed: {
+        _meta: validMetadata,
+        x: {
+          textarea: 'textarea',
+          futureSelector: '[data-future]',
+        },
+        futureNetwork: {
+          textarea: 'textarea',
+        },
+        _futureMetadata: {},
+        _videoConstraints: {
+          bluesky: {
+            maxBytes: 200_000_000,
+            futureLimit: 1,
+          },
+        },
+      },
+      selectors: {
+        x: { textarea: 'textarea' },
+      },
+      videoConstraints: {
+        bluesky: { maxBytes: 200_000_000 },
+      },
+      selectorCount: 1,
+      warnings: [
+        'x.futureSelector: unknown schema-v1 selector wire key',
+        'futureNetwork: unknown platform',
+        '_futureMetadata: unknown reserved namespace',
+        '_videoConstraints.bluesky.futureLimit: unknown constraint',
       ],
     });
   });
@@ -87,6 +144,7 @@ describe('validateSelectorFeed', () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: 'invalid-feed',
       errors: [
         '_meta: required metadata object is missing',
         'x.textarea: selector must be a non-empty string',

--- a/src/utils/selector-feed.ts
+++ b/src/utils/selector-feed.ts
@@ -17,14 +17,32 @@ export interface SelectorFeedV1 {
   [platform: string]: unknown;
 }
 
+export interface SelectorFeedValidationOptions {
+  /**
+   * Publish validation rejects unknown entries. Runtime parsing keeps schema-v1
+   * additive by ignoring them while surfacing a diagnostic warning.
+   */
+  unknownEntryPolicy?: 'error' | 'warn';
+}
+
+export type SelectorFeedSelectorOverrides = Record<string, Record<string, string>>;
+export type SelectorFeedVideoConstraints = Record<string, {
+  maxBytes?: number;
+  maxDurationS?: number;
+}>;
+
 export type SelectorFeedValidationResult =
   | {
     ok: true;
     feed: SelectorFeedV1;
+    selectors: SelectorFeedSelectorOverrides;
+    videoConstraints: SelectorFeedVideoConstraints;
     selectorCount: number;
+    warnings: string[];
   }
   | {
     ok: false;
+    kind: 'unsupported-schema' | 'invalid-feed';
     errors: string[];
   };
 
@@ -34,29 +52,40 @@ const selectorKeysByPlatform = new Map(
 );
 const videoConstraintKeys = new Set(['maxBytes', 'maxDurationS']);
 
-export function validateSelectorFeed(value: unknown): SelectorFeedValidationResult {
+export function validateSelectorFeed(
+  value: unknown,
+  options: SelectorFeedValidationOptions = {},
+): SelectorFeedValidationResult {
   const errors: string[] = [];
+  const warnings: string[] = [];
+  const unknownEntries = options.unknownEntryPolicy === 'warn' ? warnings : errors;
   if (!isRecord(value)) {
-    return { ok: false, errors: ['feed must be a JSON object'] };
+    return {
+      ok: false,
+      kind: 'invalid-feed',
+      errors: ['feed must be a JSON object'],
+    };
   }
 
-  validateMetadata(value._meta, errors);
+  const unsupportedSchema = validateMetadata(value._meta, errors);
+  const selectors: SelectorFeedSelectorOverrides = {};
+  const videoConstraints: SelectorFeedVideoConstraints = {};
   let selectorCount = 0;
 
   for (const [platform, platformValue] of Object.entries(value)) {
     if (platform === '_meta') continue;
     if (platform === '_videoConstraints') {
-      validateVideoConstraints(platformValue, errors);
+      validateVideoConstraints(platformValue, videoConstraints, errors, unknownEntries);
       continue;
     }
     if (platform.startsWith('_')) {
-      errors.push(`${platform}: unknown reserved namespace`);
+      unknownEntries.push(`${platform}: unknown reserved namespace`);
       continue;
     }
 
     const allowedKeys = selectorKeysByPlatform.get(platform);
     if (!allowedKeys) {
-      errors.push(`${platform}: unknown platform`);
+      unknownEntries.push(`${platform}: unknown platform`);
       continue;
     }
     if (!isRecord(platformValue)) {
@@ -65,32 +94,46 @@ export function validateSelectorFeed(value: unknown): SelectorFeedValidationResu
     }
     for (const [key, selector] of Object.entries(platformValue)) {
       if (!allowedKeys.has(key)) {
-        errors.push(`${platform}.${key}: unknown schema-v1 selector wire key`);
+        unknownEntries.push(`${platform}.${key}: unknown schema-v1 selector wire key`);
         continue;
       }
       if (typeof selector !== 'string' || selector.trim().length === 0) {
         errors.push(`${platform}.${key}: selector must be a non-empty string`);
         continue;
       }
+      (selectors[platform] ??= {})[key] = selector;
       selectorCount += 1;
     }
   }
 
   return errors.length > 0
-    ? { ok: false, errors }
-    : { ok: true, feed: value as SelectorFeedV1, selectorCount };
+    ? {
+      ok: false,
+      kind: unsupportedSchema ? 'unsupported-schema' : 'invalid-feed',
+      errors,
+    }
+    : {
+      ok: true,
+      feed: value as SelectorFeedV1,
+      selectors,
+      videoConstraints,
+      selectorCount,
+      warnings,
+    };
 }
 
-function validateMetadata(value: unknown, errors: string[]): void {
+function validateMetadata(value: unknown, errors: string[]): boolean {
   if (!isRecord(value)) {
     errors.push('_meta: required metadata object is missing');
-    return;
+    return false;
   }
+  let unsupportedSchema = false;
   if (value.schemaVersion !== SELECTOR_FEED_SCHEMA_VERSION) {
     errors.push(
       `_meta.schemaVersion: unsupported schema ${JSON.stringify(value.schemaVersion)}; ` +
       `expected ${SELECTOR_FEED_SCHEMA_VERSION}`,
     );
+    unsupportedSchema = Object.hasOwn(value, 'schemaVersion');
   }
   if (typeof value.description !== 'string' || value.description.trim().length === 0) {
     errors.push('_meta.description: required non-empty string is missing');
@@ -98,16 +141,22 @@ function validateMetadata(value: unknown, errors: string[]): void {
   if (!isHttpsUrl(value.homepage)) {
     errors.push('_meta.homepage: required HTTPS URL is missing');
   }
+  return unsupportedSchema;
 }
 
-function validateVideoConstraints(value: unknown, errors: string[]): void {
+function validateVideoConstraints(
+  value: unknown,
+  parsed: SelectorFeedVideoConstraints,
+  errors: string[],
+  unknownEntries: string[],
+): void {
   if (!isRecord(value)) {
     errors.push('_videoConstraints: must be an object');
     return;
   }
   for (const [platform, constraints] of Object.entries(value)) {
     if (!selectorKeysByPlatform.has(platform)) {
-      errors.push(`_videoConstraints.${platform}: unknown platform`);
+      unknownEntries.push(`_videoConstraints.${platform}: unknown platform`);
       continue;
     }
     if (!isRecord(constraints)) {
@@ -116,13 +165,17 @@ function validateVideoConstraints(value: unknown, errors: string[]): void {
     }
     for (const [key, constraint] of Object.entries(constraints)) {
       if (!videoConstraintKeys.has(key)) {
-        errors.push(`_videoConstraints.${platform}.${key}: unknown constraint`);
+        unknownEntries.push(`_videoConstraints.${platform}.${key}: unknown constraint`);
       } else if (
         typeof constraint !== 'number'
         || !Number.isFinite(constraint)
         || constraint <= 0
       ) {
         errors.push(`_videoConstraints.${platform}.${key}: must be a positive finite number`);
+      } else {
+        const platformConstraints = parsed[platform] ??= {};
+        if (key === 'maxBytes') platformConstraints.maxBytes = constraint;
+        if (key === 'maxDurationS') platformConstraints.maxDurationS = constraint;
       }
     }
   }

--- a/src/utils/selector-overrides.ts
+++ b/src/utils/selector-overrides.ts
@@ -11,7 +11,6 @@
  * ```
  */
 import type { PlatformId } from '../messages';
-import { t } from './i18n';
 
 export type SelectorOverrides = Partial<Record<PlatformId, Record<string, string>>>;
 
@@ -22,25 +21,30 @@ export type SelectorOverrides = Partial<Record<PlatformId, Record<string, string
  */
 export type VideoConstraintsOverrides = Partial<Record<PlatformId, { maxBytes?: number; maxDurationS?: number }>>;
 
-const STORAGE_KEY = 'selectorOverrides';
-const STORAGE_FETCHED_AT_KEY = 'selectorOverridesFetchedAt';
-const STORAGE_VIDEO_CONSTRAINTS_KEY = 'videoConstraintsOverrides';
+export const SELECTOR_OVERRIDE_STORAGE_KEYS = {
+  selectors: 'selectorOverrides',
+  fetchedAt: 'selectorOverridesFetchedAt',
+  videoConstraints: 'videoConstraintsOverrides',
+  diagnostics: 'selectorFeedDiagnostics',
+} as const;
 
 export async function getOverrides(): Promise<SelectorOverrides> {
-  const stored = await browser.storage.local.get(STORAGE_KEY);
-  return (stored[STORAGE_KEY] as SelectorOverrides | undefined) ?? {};
+  const stored = await browser.storage.local.get(SELECTOR_OVERRIDE_STORAGE_KEYS.selectors);
+  return (
+    stored[SELECTOR_OVERRIDE_STORAGE_KEYS.selectors] as SelectorOverrides | undefined
+  ) ?? {};
 }
 
 export async function setOverrides(overrides: SelectorOverrides): Promise<void> {
   await browser.storage.local.set({
-    [STORAGE_KEY]: overrides,
-    [STORAGE_FETCHED_AT_KEY]: Date.now(),
+    [SELECTOR_OVERRIDE_STORAGE_KEYS.selectors]: overrides,
+    [SELECTOR_OVERRIDE_STORAGE_KEYS.fetchedAt]: Date.now(),
   });
 }
 
 export async function getFetchedAt(): Promise<number | null> {
-  const stored = await browser.storage.local.get(STORAGE_FETCHED_AT_KEY);
-  const v = stored[STORAGE_FETCHED_AT_KEY];
+  const stored = await browser.storage.local.get(SELECTOR_OVERRIDE_STORAGE_KEYS.fetchedAt);
+  const v = stored[SELECTOR_OVERRIDE_STORAGE_KEYS.fetchedAt];
   return typeof v === 'number' ? v : null;
 }
 
@@ -63,62 +67,10 @@ export async function resolveSelectors<T extends Record<string, string>>(
   return merged;
 }
 
-/**
- * リモート URL から override JSON を取得して保存。
- * URL が無効・JSON が不正な場合は false を返して overrides を変更しない(安全側)。
- */
-export async function fetchOverridesFrom(url: string): Promise<{ ok: boolean; error?: string; count?: number }> {
-  if (!url || !/^https:\/\//.test(url)) {
-    return { ok: false, error: t('runtimeSelectorUrlHttpsRequired') };
-  }
-  try {
-    const res = await fetch(url, { cache: 'no-store' });
-    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
-    const data = (await res.json()) as unknown;
-    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-      return { ok: false, error: t('runtimeSelectorJsonObjectRequired') };
-    }
-    // 簡易バリデーション: 各 platform のオブジェクトの値はすべて string。
-    // `_` プレフィックスの key (`_meta`, `_videoConstraints`) は selector ではなく
-    // メタ情報として扱い、selector parser から除外する
-    const valid: SelectorOverrides = {};
-    let count = 0;
-    for (const [platform, val] of Object.entries(data as Record<string, unknown>)) {
-      if (platform.startsWith('_')) continue;
-      if (!val || typeof val !== 'object' || Array.isArray(val)) continue;
-      const inner: Record<string, string> = {};
-      for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
-        if (typeof v === 'string' && v.length > 0) {
-          inner[k] = v;
-          count++;
-        }
-      }
-      if (Object.keys(inner).length > 0) valid[platform as PlatformId] = inner;
-    }
-    await setOverrides(valid);
-
-    // P17: 動画 constraint override の取り込み
-    const vcRaw = (data as Record<string, unknown>)['_videoConstraints'];
-    const vc: VideoConstraintsOverrides = {};
-    if (vcRaw && typeof vcRaw === 'object' && !Array.isArray(vcRaw)) {
-      for (const [platform, val] of Object.entries(vcRaw as Record<string, unknown>)) {
-        if (!val || typeof val !== 'object' || Array.isArray(val)) continue;
-        const c: { maxBytes?: number; maxDurationS?: number } = {};
-        const v = val as Record<string, unknown>;
-        if (typeof v['maxBytes'] === 'number' && v['maxBytes']! > 0) c.maxBytes = v['maxBytes'] as number;
-        if (typeof v['maxDurationS'] === 'number' && v['maxDurationS']! > 0) c.maxDurationS = v['maxDurationS'] as number;
-        if (Object.keys(c).length > 0) vc[platform as PlatformId] = c;
-      }
-    }
-    await browser.storage.local.set({ [STORAGE_VIDEO_CONSTRAINTS_KEY]: vc });
-
-    return { ok: true, count };
-  } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : String(e) };
-  }
-}
-
 export async function getVideoConstraintsOverrides(): Promise<VideoConstraintsOverrides> {
-  const stored = await browser.storage.local.get(STORAGE_VIDEO_CONSTRAINTS_KEY);
-  return (stored[STORAGE_VIDEO_CONSTRAINTS_KEY] as VideoConstraintsOverrides | undefined) ?? {};
+  const stored = await browser.storage.local.get(
+    SELECTOR_OVERRIDE_STORAGE_KEYS.videoConstraints,
+  );
+  const overrides = stored[SELECTOR_OVERRIDE_STORAGE_KEYS.videoConstraints] as VideoConstraintsOverrides | undefined;
+  return overrides ?? {};
 }


### PR DESCRIPTION
Closes #19

Parent: #12

## Summary
- parse runtime feeds through the schema-v1 wire contract while keeping publish validation strict
- clear stale selector/video caches on fetch, JSON, schema, or known-value failure
- ignore additive unknown entries but persist sanitized non-silent diagnostics
- include the last feed outcome in manual diagnostics and keep Options state aligned with fallback
- keep feed parsing out of content-script bundles

## Local verification
- npm run test:stability -- 5 (PASS; 73 files / 564 tests per run)
- npm run verify:commit (PASS)
- npm run selectors:validate -- ..\tutti-site\selectors.json (PASS)

## Surface exact-artifact gate
- commit e0aac032e605133e3f6e0a2271d86fd701ea715f
- extension 0.5.49; SHA-256 960BC5802B036DBFDCBB4AC2ED571862A61CC1BAFD71A7F9384CE47D7820352A
- live schema-v1 fetch diagnostics: applied; selector/video caches empty
- preview cases text-only,text-image,text-video: PASS, 24/24 results across all 11 SNS, submitReached=false
- no post URLs expected; no real posts made

The broader full matrix exposed unrelated Threads emoji verification and grouped video-only timeout debt; tracked in #20.