### PR TITLE
test: freeze storage migration fixtures

### DIFF
--- a/src/fixtures/storage/current-history.json
+++ b/src/fixtures/storage/current-history.json
@@ -1,0 +1,33 @@
+{
+  "postHistory": [
+    {
+      "version": 1,
+      "id": "current-additive-fields",
+      "textPreview": "current post",
+      "text": "current post with full text",
+      "bodyHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "platforms": ["mastodon"],
+      "results": {
+        "mastodon": {
+          "success": false,
+          "confirmed": false,
+          "uncertain": true,
+          "userAction": "check-post-before-retry",
+          "flow": {
+            "mode": "post",
+            "attempt": "default",
+            "submitReached": true,
+            "failedStep": "capture-url"
+          },
+          "futureResultField": {
+            "revision": 2
+          }
+        }
+      },
+      "hasMedia": true,
+      "mediaRefs": ["current-additive-fields-0"],
+      "timestamp": 1700000001000,
+      "futureEntryField": "preserve-me"
+    }
+  ]
+}

--- a/src/fixtures/storage/custom-settings.json
+++ b/src/fixtures/storage/custom-settings.json
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "autoPost": true,
+    "selectorOverrideUrl": "https://selectors.example/custom.json",
+    "uiLanguage": "ja"
+  }
+}

--- a/src/fixtures/storage/legacy-history.json
+++ b/src/fixtures/storage/legacy-history.json
@@ -1,0 +1,15 @@
+{
+  "postHistory": [
+    {
+      "id": "legacy-boolean-results",
+      "textPreview": "legacy post",
+      "platforms": ["x", "bluesky"],
+      "results": {
+        "x": true,
+        "bluesky": false
+      },
+      "hasMedia": false,
+      "timestamp": 1700000000000
+    }
+  ]
+}

--- a/src/fixtures/storage/legacy-last-seen-users.json
+++ b/src/fixtures/storage/legacy-last-seen-users.json
@@ -1,0 +1,8 @@
+{
+  "lastSeenUsers": {
+    "x": "Account",
+    "bluesky": "alice.test",
+    "youtube": " チャンネル ",
+    "mastodon": "@alice@social.example"
+  }
+}

--- a/src/fixtures/storage/legacy-pages-settings.json
+++ b/src/fixtures/storage/legacy-pages-settings.json
@@ -1,0 +1,5 @@
+{
+  "settings": {
+    "selectorOverrideUrl": "https://tutti-site.pages.dev/selectors.json#legacy"
+  }
+}

--- a/src/fixtures/storage/legacy-settings.json
+++ b/src/fixtures/storage/legacy-settings.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "dryRun": false,
+    "mastodonInstance": "https://social.example",
+    "selectorOverrideUrl": "https://komm64.github.io/tutti/selectors.json?legacy=1",
+    "logLevel": "DEBUG",
+    "autoOpenPostUrl": "never",
+    "uiLanguage": "ja-JP"
+  }
+}

--- a/src/storage-migrations.test.ts
+++ b/src/storage-migrations.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import customSettingsFixture from './fixtures/storage/custom-settings.json';
+import currentHistoryFixture from './fixtures/storage/current-history.json';
+import legacyHistoryFixture from './fixtures/storage/legacy-history.json';
+import legacyLastSeenUsersFixture from './fixtures/storage/legacy-last-seen-users.json';
+import legacyPagesSettingsFixture from './fixtures/storage/legacy-pages-settings.json';
+import legacySettingsFixture from './fixtures/storage/legacy-settings.json';
+import {
+  getLastSeenUsers,
+  getPostHistory,
+  getSettings,
+} from './storage';
+
+const CURRENT_SELECTOR_FEED_URL = 'https://tutti.komm64.com/selectors.json';
+
+function stubStorage(options: {
+  sync?: Record<string, unknown>;
+  local?: Record<string, unknown>;
+}): {
+  localSet: ReturnType<typeof vi.fn>;
+} {
+  const localSet = vi.fn(async () => undefined);
+  vi.stubGlobal('browser', {
+    storage: {
+      sync: {
+        get: vi.fn(async () => options.sync ?? {}),
+      },
+      local: {
+        get: vi.fn(async () => options.local ?? {}),
+        set: localSet,
+      },
+    },
+  });
+  return { localSet };
+}
+
+describe('storage migration fixtures', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the safe auto-post default and migrates the legacy selector endpoint', async () => {
+    stubStorage({ sync: legacySettingsFixture });
+
+    const settings = await getSettings();
+
+    expect(settings).toMatchObject({
+      autoPost: false,
+      mastodonInstance: 'https://social.example',
+      selectorOverrideUrl: CURRENT_SELECTOR_FEED_URL,
+      logLevel: 'DEBUG',
+      autoOpenPostUrl: 'never',
+      uiLanguage: 'auto',
+    });
+    expect(settings).not.toHaveProperty('dryRun');
+  });
+
+  it('preserves explicit current settings and custom selector endpoints', async () => {
+    stubStorage({ sync: customSettingsFixture });
+
+    await expect(getSettings()).resolves.toMatchObject({
+      autoPost: true,
+      selectorOverrideUrl: 'https://selectors.example/custom.json',
+      uiLanguage: 'ja',
+    });
+  });
+
+  it('also migrates the retired Cloudflare Pages selector endpoint', async () => {
+    stubStorage({ sync: legacyPagesSettingsFixture });
+
+    await expect(getSettings()).resolves.toMatchObject({
+      selectorOverrideUrl: CURRENT_SELECTOR_FEED_URL,
+    });
+  });
+
+  it('converts legacy boolean history results through the public reader', async () => {
+    stubStorage({ local: legacyHistoryFixture });
+
+    await expect(getPostHistory()).resolves.toEqual([
+      {
+        ...legacyHistoryFixture.postHistory[0],
+        results: {
+          x: { success: true },
+          bluesky: { success: false },
+        },
+      },
+    ]);
+  });
+
+  it('preserves current history payloads and unknown additive fields', async () => {
+    stubStorage({ local: currentHistoryFixture });
+
+    await expect(getPostHistory()).resolves.toEqual(currentHistoryFixture.postHistory);
+  });
+
+  it('filters reserved usernames and lazily writes the cleaned payload', async () => {
+    const { localSet } = stubStorage({ local: legacyLastSeenUsersFixture });
+
+    await expect(getLastSeenUsers()).resolves.toEqual({
+      bluesky: 'alice.test',
+      mastodon: '@alice@social.example',
+    });
+    expect(localSet).toHaveBeenCalledOnce();
+    expect(localSet).toHaveBeenCalledWith({
+      lastSeenUsers: {
+        bluesky: 'alice.test',
+        mastodon: '@alice@social.example',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add storage snapshots for legacy settings, history, and detected usernames
- exercise migrations through the public storage readers
- freeze safe `dryRun` handling, retired selector URL migration, additive history fields, and lazy username cleanup

## Verification

- `npm run verify:commit`
  - scripts catalog: PASS (271 files)
  - TypeScript: PASS
  - Vitest: PASS (74 files / 570 tests)
  - Chrome MV3 build: PASS
- artifact comparison against merged `main`: 78 files before/after, 0 SHA-256 content differences

Tests and JSON fixtures only; no extension runtime change. Surface/CWS gate is not applicable.

Closes #22