### PR TITLE
fix: keep posting transport fixed after dispatch

### DIFF
--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlatformAdapter } from '../adapters/types';
+import type { PostResultMessage } from '../messages';
+import { createPlatformPoster } from './platform-poster';
+
+const mocks = vi.hoisted(() => ({
+  buildLoginRedirectErrorForUrl: vi.fn(() => null),
+  buildMissingReceiverLoginError: vi.fn(async () => null),
+  capturePostUrlFromTabWithRetry: vi.fn(async () => undefined),
+  closeTabSafely: vi.fn(async () => undefined),
+  getLastSeenUsers: vi.fn(async () => ({})),
+  getSettings: vi.fn(async () => ({ autoOpenPostUrl: 'never' })),
+  isMissingReceiverError: vi.fn(() => false),
+  maybeResizeImagesForPlatform: vi.fn(async (_adapter, images) => images),
+  openOrFocusTab: vi.fn(async () => ({
+    tab: { id: 42, url: 'https://social.example/compose' },
+    wasCreated: true,
+  })),
+  prepareMediaForPlatform: vi.fn(async (_adapter, _platform, images) => ({
+    ok: true,
+    images,
+  })),
+  resolveAdapter: vi.fn(),
+  retryTransientTabAction: vi.fn(async (_label, action) => await action()),
+  runVerify: vi.fn(),
+  sendPostMessageWhenReady: vi.fn(),
+  tryApiPath: vi.fn(),
+}));
+
+vi.mock('../storage', () => ({
+  getLastSeenUsers: mocks.getLastSeenUsers,
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock('../utils/logger', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('./adapter-resolver', () => ({
+  resolveAdapter: mocks.resolveAdapter,
+}));
+
+vi.mock('./api-posting', () => ({
+  tryApiPath: mocks.tryApiPath,
+}));
+
+vi.mock('./content-dispatch', () => ({
+  buildLoginRedirectErrorForUrl: mocks.buildLoginRedirectErrorForUrl,
+  buildMissingReceiverLoginError: mocks.buildMissingReceiverLoginError,
+  isMissingReceiverError: mocks.isMissingReceiverError,
+  sendPostMessageWhenReady: mocks.sendPostMessageWhenReady,
+}));
+
+vi.mock('./media-preprocess', () => ({
+  maybeResizeImagesForPlatform: mocks.maybeResizeImagesForPlatform,
+}));
+
+vi.mock('./platform-media', () => ({
+  prepareMediaForPlatform: mocks.prepareMediaForPlatform,
+}));
+
+vi.mock('./post-url-capture', () => ({
+  capturePostUrlFromTabWithRetry: mocks.capturePostUrlFromTabWithRetry,
+}));
+
+vi.mock('./tab-action-retry', () => ({
+  retryTransientTabAction: mocks.retryTransientTabAction,
+}));
+
+vi.mock('./tab-management', () => ({
+  closeTabSafely: mocks.closeTabSafely,
+  openOrFocusTab: mocks.openOrFocusTab,
+}));
+
+vi.mock('./verify-dispatcher', () => ({
+  runVerify: mocks.runVerify,
+}));
+
+function adapter(id: PlatformAdapter['id'] = 'mastodon'): PlatformAdapter {
+  return {
+    id,
+    name: id,
+    charLimit: 500,
+    matchUrl: (url) => url.startsWith('https://social.example/'),
+    getComposeUrl: () => 'https://social.example/compose',
+    prefillsViaUrl: false,
+    imageConstraints: {
+      maxBytesPerImage: 10 * 1024 * 1024,
+      maxImages: 4,
+    },
+    kinds: ['text', 'image'],
+  };
+}
+
+function createPoster() {
+  return createPlatformPoster({
+    openedTabs: {
+      record: vi.fn(),
+      forget: vi.fn(),
+    },
+  });
+}
+
+describe('platform poster transport boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveAdapter.mockResolvedValue(adapter());
+    vi.stubGlobal('browser', {
+      tabs: {
+        create: vi.fn(async () => ({ id: 99 })),
+        get: vi.fn(async () => ({ id: 42, url: 'https://social.example/compose' })),
+      },
+    });
+  });
+
+  it('does not open a DOM compose path after a selected API transport fails', async () => {
+    mocks.tryApiPath.mockResolvedValue({
+      success: false,
+      error: 'statuses 403: forbidden',
+    });
+
+    const result = await createPoster().postToPlatform('mastodon', 'hello', undefined, undefined, undefined, true);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'statuses 403: forbidden',
+      flow: {
+        attempt: 'api',
+        failedStep: 'api-post',
+      },
+    });
+    expect(mocks.tryApiPath).toHaveBeenCalledOnce();
+    expect(mocks.openOrFocusTab).not.toHaveBeenCalled();
+    expect(mocks.sendPostMessageWhenReady).not.toHaveBeenCalled();
+  });
+
+  it('stops after one real-post dispatch when the content response times out', async () => {
+    mocks.tryApiPath.mockResolvedValue('no-credentials');
+    mocks.sendPostMessageWhenReady.mockRejectedValue(
+      new Error('mastodon content script response timed out after 240000ms'),
+    );
+
+    const result = await createPoster().postToPlatform('mastodon', 'hello', undefined, undefined, undefined, true);
+
+    expect(result).toMatchObject({
+      success: false,
+      uncertain: true,
+      userAction: 'check-post-before-retry',
+      flow: {
+        submitReached: true,
+        failedStep: 'capture-url',
+      },
+    });
+    expect(mocks.openOrFocusTab).toHaveBeenCalledOnce();
+    expect(mocks.sendPostMessageWhenReady).toHaveBeenCalledOnce();
+    expect(mocks.capturePostUrlFromTabWithRetry).toHaveBeenCalledOnce();
+  });
+
+  it('stops after one real-post attempt when content reports submitReached', async () => {
+    mocks.tryApiPath.mockResolvedValue('no-credentials');
+    mocks.sendPostMessageWhenReady.mockResolvedValue({
+      type: 'POST_RESULT',
+      platform: 'mastodon',
+      success: false,
+      flow: {
+        mode: 'post',
+        submitReached: true,
+        failedStep: 'post-submit-check',
+      },
+      error: 'post completion could not be confirmed',
+    } satisfies PostResultMessage);
+
+    const result = await createPoster().postToPlatform('mastodon', 'hello', undefined, undefined, undefined, true);
+
+    expect(result).toMatchObject({
+      success: false,
+      uncertain: true,
+      userAction: 'check-post-before-retry',
+      flow: {
+        submitReached: true,
+        failedStep: 'post-submit-check',
+      },
+    });
+    expect(mocks.openOrFocusTab).toHaveBeenCalledOnce();
+    expect(mocks.sendPostMessageWhenReady).toHaveBeenCalledOnce();
+  });
+});

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -6,6 +6,9 @@ import {
   buildDomPostAttempts,
   buildReplyOverrideUrl,
   getComposeUrlForMedia,
+  isAmbiguousPostDispatchError,
+  resolveApiPostOutcome,
+  shouldRetryPostAttempt,
   shouldOpenActive,
   shouldReuseExistingTabForAttempt,
 } from './platform-poster';
@@ -194,5 +197,92 @@ describe('platform poster helpers', () => {
       undefined,
       0,
     ).expectedUrls).toBeUndefined();
+  });
+});
+
+describe('posting transport safety policy', () => {
+  it('falls through to DOM only when the selected API path has no credentials', () => {
+    expect(resolveApiPostOutcome('bluesky', 'no-credentials')).toBeNull();
+  });
+
+  it('keeps definitive API failures on the selected API transport', () => {
+    expect(resolveApiPostOutcome('mastodon', {
+      success: false,
+      error: 'statuses 403: forbidden',
+    })).toMatchObject({
+      type: 'POST_RESULT',
+      platform: 'mastodon',
+      success: false,
+      error: 'statuses 403: forbidden',
+      flow: {
+        attempt: 'api',
+        submitReached: false,
+        failedStep: 'api-post',
+      },
+    });
+  });
+
+  it('maps ambiguous or URL-less API outcomes to uncertain without another transport', () => {
+    expect(resolveApiPostOutcome('bluesky', {
+      success: false,
+      uncertain: true,
+      error: 'network interrupted',
+    })).toMatchObject({
+      success: false,
+      uncertain: true,
+      userAction: 'check-post-before-retry',
+      flow: {
+        attempt: 'api',
+        submitReached: true,
+        failedStep: 'capture-url',
+      },
+    });
+    expect(resolveApiPostOutcome('misskey', {
+      success: true,
+    })).toMatchObject({
+      success: false,
+      uncertain: true,
+      flow: {
+        attempt: 'api',
+        submitReached: true,
+      },
+    });
+  });
+
+  it('confirms API success only when a post URL is present', () => {
+    expect(resolveApiPostOutcome('bluesky', {
+      success: true,
+      postUrl: 'https://bsky.app/profile/alice.test/post/abc',
+    })).toMatchObject({
+      success: true,
+      confirmed: true,
+      url: 'https://bsky.app/profile/alice.test/post/abc',
+      flow: {
+        attempt: 'api',
+        submitReached: true,
+        lastCompletedStep: 'api-create-post',
+      },
+    });
+  });
+
+  it('stops real-post retries after submit but keeps preview and pre-submit retries', () => {
+    expect(shouldRetryPostAttempt(true, { submitReached: true })).toBe(false);
+    expect(shouldRetryPostAttempt(true, { submitReached: false })).toBe(true);
+    expect(shouldRetryPostAttempt(true)).toBe(true);
+    expect(shouldRetryPostAttempt(false, { submitReached: true })).toBe(true);
+  });
+
+  it('classifies channel-close and timeout failures as ambiguous after dispatch', () => {
+    for (const message of [
+      'A listener indicated an asynchronous response but the message channel closed',
+      'The message port closed before a response was received.',
+      'page entered the back/forward cache',
+      'youtube content script response timed out after 240000ms',
+    ]) {
+      expect(isAmbiguousPostDispatchError(new Error(message)), message).toBe(true);
+    }
+    expect(isAmbiguousPostDispatchError(
+      new Error('Could not establish connection. Receiving end does not exist.'),
+    )).toBe(false);
   });
 });

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -6,6 +6,7 @@ import type {
   PostToPlatformMessage,
 } from '../messages';
 import type { PlatformAdapter } from '../adapters/types';
+import type { ApiPostResult } from '../api/types';
 import { getLastSeenUsers, getSettings } from '../storage';
 import { splitTextForPlatform } from '../utils/platform-text';
 import { isVerifySupported } from '../utils/post-verify';
@@ -216,6 +217,28 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
         );
       } catch (err) {
         lastError = err;
+        const flow = err instanceof PostFlowError ? err.flow : undefined;
+        if (!shouldRetryPostAttempt(autoPost, flow)) {
+          const message = err instanceof Error ? err.message : String(err);
+          log.warn(
+            `${adapter.id}: post action may have started during "${attempt.label}"; ` +
+            'stopping automatic retries',
+          );
+          return {
+            type: 'POST_RESULT',
+            platform: adapter.id,
+            success: false,
+            uncertain: true,
+            userAction: 'check-post-before-retry',
+            flow: {
+              mode: 'post',
+              ...flow,
+              submitReached: true,
+              failedStep: flow?.failedStep ?? 'post-dispatch',
+            },
+            error: message,
+          };
+        }
         if (i >= attempts.length - 1) throw err;
         const next = attempts[i + 1]!;
         log.warn(
@@ -251,40 +274,22 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
     const canUseApiWithReplyUrl = adapter.id === 'mastodon' && !!replyToUrl;
     if (autoPost && (!overrideUrl || canUseApiWithReplyUrl) && !textChunks && !attempt.skipApi) {
       const apiResult = await tryApiPath(adapter.id, text, images, cw, visibility, replyToUrl);
-      if (apiResult === 'no-credentials') {
-        // Fall through to DOM path.
-      } else if (apiResult.success) {
-        if (!apiResult.postUrl) {
-          log.warn(`${adapter.id} via API: create response succeeded but no post URL was returned`);
-          return unconfirmedPostResult(adapter.id, {
-            ...baseFlow,
-            submitReached: true,
-            lastCompletedStep: 'api-create-post',
-            failedStep: 'capture-url',
-          });
+      const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, baseFlow);
+      if (apiOutcome) {
+        if (apiOutcome.success) {
+          log.info(`${adapter.id} via API ✓ ${apiOutcome.url ?? ''}`);
+        } else if (apiOutcome.uncertain) {
+          const detail = apiResult === 'no-credentials'
+            ? t('runtimeUnknownError')
+            : apiResult.error ?? t('runtimeUnknownError');
+          log.warn(`${adapter.id} via API: post result uncertain - ${detail}`);
+        } else {
+          log.warn(
+            `${adapter.id} via API failed; keeping this request on the selected API transport: ` +
+            `${apiOutcome.error ?? t('runtimeUnknownError')}`,
+          );
         }
-        log.info(`${adapter.id} via API ✓ ${apiResult.postUrl ?? ''}`);
-        return withFlow({
-          type: 'POST_RESULT',
-          platform: adapter.id,
-          success: true,
-          confirmed: true,
-          url: apiResult.postUrl,
-        }, {
-          ...baseFlow,
-          submitReached: true,
-          lastCompletedStep: 'api-create-post',
-        });
-      } else if (apiResult.uncertain) {
-        log.warn(`${adapter.id} via API: post result uncertain - ${apiResult.error ?? t('runtimeUnknownError')}`);
-        return unconfirmedPostResult(adapter.id, {
-          ...baseFlow,
-          submitReached: true,
-          lastCompletedStep: 'api-create-post',
-          failedStep: 'capture-url',
-        });
-      } else {
-        log.warn(`${adapter.id} via API failed before a confirmed post; falling back to DOM path: ${apiResult.error ?? t('runtimeUnknownError')}`);
+        return apiOutcome;
       }
     }
 
@@ -372,7 +377,15 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
             };
           }
         }
-        const recovered = await recoverFromMaybeLandedChannelClose(err, adapter.id, tab.id, text, expectedUser, dryRun, dispatchStartedAt);
+        const recovered = await recoverFromAmbiguousDispatchFailure(
+          err,
+          adapter.id,
+          tab.id,
+          text,
+          expectedUser,
+          dryRun,
+          dispatchStartedAt,
+        );
         if (recovered) return withFlow(recovered, { ...baseFlow, tabUrlBefore });
         throw err;
       }
@@ -413,7 +426,7 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
     await closeTabSafely(tabId);
   }
 
-  async function recoverFromMaybeLandedChannelClose(
+  async function recoverFromAmbiguousDispatchFailure(
     err: unknown,
     platform: PlatformId,
     tabId: number,
@@ -422,14 +435,10 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
     dryRun: boolean,
     minCapturedAt?: number,
   ): Promise<PostResultMessage | null> {
-    const msg = err instanceof Error ? err.message : String(err);
-    const maybeLanded =
-      msg.includes('asynchronous response') ||
-      msg.includes('message channel closed') ||
-      msg.includes('back/forward cache');
-    if (dryRun || !maybeLanded) return null;
+    if (dryRun || !isAmbiguousPostDispatchError(err)) return null;
 
-    log.warn(`${platform}: post 後に channel closed - ${msg.slice(0, 80)}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`${platform}: post dispatch result is ambiguous - ${msg.slice(0, 80)}`);
     const captured = await captureUrl(platform, tabId, text, expectedUser, minCapturedAt);
     return captured.url
       ? withFlow({ type: 'POST_RESULT', platform, success: true, confirmed: true, url: captured.url }, {
@@ -497,6 +506,67 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
   }
 
   return { postToPlatform };
+}
+
+export function resolveApiPostOutcome(
+  platform: PlatformId,
+  apiResult: ApiPostResult | 'no-credentials',
+  baseFlow: Partial<PostFlowTrace> = {},
+): PostResultMessage | null {
+  if (apiResult === 'no-credentials') return null;
+  const flow = {
+    ...baseFlow,
+    attempt: 'api',
+  };
+  if (apiResult.success && apiResult.postUrl) {
+    return withFlow({
+      type: 'POST_RESULT',
+      platform,
+      success: true,
+      confirmed: true,
+      url: apiResult.postUrl,
+    }, {
+      ...flow,
+      submitReached: true,
+      lastCompletedStep: 'api-create-post',
+    });
+  }
+  if (apiResult.success || apiResult.uncertain) {
+    return unconfirmedPostResult(platform, {
+      ...flow,
+      submitReached: true,
+      lastCompletedStep: 'api-create-post',
+      failedStep: 'capture-url',
+    });
+  }
+  return withFlow({
+    type: 'POST_RESULT',
+    platform,
+    success: false,
+    error: apiResult.error ?? t('runtimeUnknownError'),
+  }, {
+    ...flow,
+    submitReached: false,
+    failedStep: 'api-post',
+  });
+}
+
+export function shouldRetryPostAttempt(
+  autoPost: boolean,
+  flow?: Pick<PostFlowTrace, 'submitReached'>,
+): boolean {
+  return !autoPost || flow?.submitReached !== true;
+}
+
+export function isAmbiguousPostDispatchError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes('asynchronous response') ||
+    message.includes('message channel closed') ||
+    message.includes('message port closed') ||
+    message.includes('back/forward cache') ||
+    message.includes('content script response timed out')
+  );
 }
 
 export function buildReplyOverrideUrl(


### PR DESCRIPTION
## Summary

- keep a request on the selected API transport after any non-`no-credentials` API outcome
- map definitive API failure, uncertain outcome, URL-less success, and URL-confirmed success through one policy
- treat message channel close/port close/bfcache/response timeout as ambiguous after real dispatch
- stop real-post retries when a content flow reports `submitReached=true`
- preserve preview and confirmed pre-submit retry behavior

## Local verification

- `npm run test:stability -- 5`: PASS 5/5 (76 files / 582 tests each)
- `npm run verify:commit`: PASS
- integration tests prove:
  - API failure opens no DOM compose path
  - real response timeout performs one URL capture and stops uncertain
  - `submitReached=true` stops after one attempt

## Surface exact-artifact gate

- commit: `ef47e8b04f8297efbc3c4ebe06925743f8f96165`
- extension: v0.5.49, `heffmapbljoonmjghklgjhmfnldaeome`
- staged path: `C:\Users\komm64\Projects\tutti-surface-current\chrome-mv3`
- zip SHA-256: `BCBD439BB58A1D746380597E050785A2AF32C558CDD8E7B4D9912D46F916D8DA` (local/Surface matched)

Full preview repeat 2 completed with 142 returned results across all 11 SNS. Every returned result was successful preview with `submitReached=false` and no URL. The only failures were the already-tracked #20 Threads emoji first-reader mismatch and grouped video-only timeouts.

Affected targeted rerun:

```powershell
node scripts/e2e/surface-posting-matrix.mjs --mode preview --cases text-only,text-image,text-video --repeat 1 --case-timeout-ms 180000 --summary-json .tmp/surface-fixed-transport-issue26-targeted.json
```

PASS: 3 iterations / 24 results / all 11 SNS covered / failures 0 / all `success=true`, `preview=true`, `submitReached=false` / URLs 0.

Detailed evidence: https://github.com/komm64/tutti/issues/26#issuecomment-5085104912

No CWS upload or submission was performed. Surface scheduled task and CDP tunnel were cleaned up.

Closes #26