### PR TITLE
test: freeze post capture payload fixtures

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -28,6 +28,7 @@ import {
   extractMastodonPostRecord,
   extractThreadsPostRecord,
   extractTumblrPostRecord,
+  extractXPostId,
   isInstagramConfigureUrl,
   prepareInstagramConfigureBody,
 } from '../src/utils/post-capture-record';
@@ -499,17 +500,7 @@ export default defineContentScript({
       if (!/^(?:x|twitter)\.com$/.test(location.host) || window.__tuttiXPostCaptureInstalled) return;
       window.__tuttiXPostCaptureInstalled = true;
       const captureRestId = (body: unknown): void => {
-        const findRestId = (value: unknown, depth = 0): string | undefined => {
-          if (!value || typeof value !== 'object' || depth > 12) return undefined;
-          const obj = value as Record<string, unknown>;
-          if (typeof obj.rest_id === 'string' && /^\d+$/.test(obj.rest_id)) return obj.rest_id;
-          for (const child of Object.values(obj)) {
-            const found = findRestId(child, depth + 1);
-            if (found) return found;
-          }
-          return undefined;
-        };
-        const id = findRestId(body);
+        const id = extractXPostId(body);
         if (!id) return;
         const captured = { id, capturedAt: Date.now() };
         window.__tuttiXLatestPostId = captured;

--- a/src/fixtures/post-capture/instagram-configure.json
+++ b/src/fixtures/post-capture/instagram-configure.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://www.instagram.com/api/v1/media/configure/",
+    "body": "upload_id=fixture-upload&caption=fixture%20caption"
+  },
+  "response": {
+    "media": {
+      "code": "DAbC_def12",
+      "product_type": "feed"
+    },
+    "status": "ok"
+  },
+  "expected": {
+    "url": "https://www.instagram.com/p/DAbC_def12/",
+    "code": "DAbC_def12"
+  }
+}

--- a/src/fixtures/post-capture/mastodon-status.json
+++ b/src/fixtures/post-capture/mastodon-status.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://mastodon.social/api/v1/statuses"
+  },
+  "response": {
+    "id": "116731234567890123",
+    "uri": "https://mastodon.social/users/fixture/statuses/116731234567890123",
+    "url": "https://mastodon.social/@fixture/116731234567890123"
+  },
+  "expected": {
+    "url": "https://mastodon.social/users/fixture/statuses/116731234567890123",
+    "id": "116731234567890123"
+  }
+}

--- a/src/fixtures/post-capture/threads-create.json
+++ b/src/fixtures/post-capture/threads-create.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://www.threads.com/api/graphql",
+    "body": "doc_id=fixture&variables=%7B%22text%22%3A%22fixture%22%7D&operation=create_post"
+  },
+  "response": {
+    "data": {
+      "create_post": {
+        "post": {
+          "code": "DZaBc_12345",
+          "user": {
+            "username": "fixture"
+          }
+        }
+      }
+    }
+  },
+  "expected": {
+    "url": "https://www.threads.com/@fixture/post/DZaBc_12345",
+    "code": "DZaBc_12345",
+    "username": "fixture"
+  }
+}

--- a/src/fixtures/post-capture/tumblr-create.json
+++ b/src/fixtures/post-capture/tumblr-create.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://www.tumblr.com/api/v2/blog/fixture.tumblr.com/posts"
+  },
+  "response": {
+    "meta": {
+      "status": 201
+    },
+    "response": {
+      "id_string": "789012345678",
+      "blog": {
+        "name": "fixture"
+      }
+    }
+  },
+  "expected": {
+    "url": "https://www.tumblr.com/fixture/789012345678",
+    "id": "789012345678",
+    "blogName": "fixture"
+  }
+}

--- a/src/fixtures/post-capture/x-create-tweet.json
+++ b/src/fixtures/post-capture/x-create-tweet.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://x.com/i/api/graphql/fixture/CreateTweet"
+  },
+  "response": {
+    "data": {
+      "create_tweet": {
+        "tweet_results": {
+          "result": {
+            "__typename": "Tweet",
+            "rest_id": "1900123456789012345"
+          }
+        }
+      }
+    }
+  },
+  "expected": {
+    "id": "1900123456789012345"
+  }
+}

--- a/src/utils/post-capture-record.test.ts
+++ b/src/utils/post-capture-record.test.ts
@@ -1,10 +1,16 @@
 import { Window } from 'happy-dom';
 import { describe, expect, it } from 'vitest';
+import instagramConfigureFixture from '../fixtures/post-capture/instagram-configure.json';
+import mastodonStatusFixture from '../fixtures/post-capture/mastodon-status.json';
+import threadsCreateFixture from '../fixtures/post-capture/threads-create.json';
+import tumblrCreateFixture from '../fixtures/post-capture/tumblr-create.json';
+import xCreateTweetFixture from '../fixtures/post-capture/x-create-tweet.json';
 import {
   extractInstagramPostRecord,
   extractMastodonPostRecord,
   extractThreadsPostRecord,
   extractTumblrPostRecord,
+  extractXPostId,
   findLatestTumblrPostUrlInDocument,
   findTumblrPostUrlInDocument,
   hashCaptureText,
@@ -13,6 +19,50 @@ import {
 } from './post-capture-record';
 
 describe('post capture records', () => {
+  it.each(['fetch', 'xhr'])('extracts the Instagram %s configure response fixture', () => {
+    const record = extractInstagramPostRecord(instagramConfigureFixture.response, 'hash', 100);
+
+    expect(record).toMatchObject({
+      ...instagramConfigureFixture.expected,
+      capturedAt: 100,
+      textHash: 'hash',
+    });
+  });
+
+  it.each(['fetch', 'xhr'])('extracts the Mastodon %s status response fixture', () => {
+    const record = extractMastodonPostRecord(mastodonStatusFixture.response, 'hash', 100);
+
+    expect(record).toMatchObject({
+      ...mastodonStatusFixture.expected,
+      capturedAt: 100,
+      textHash: 'hash',
+    });
+  });
+
+  it.each(['fetch', 'xhr'])('extracts the Tumblr %s create response fixture', () => {
+    const record = extractTumblrPostRecord(tumblrCreateFixture.response, undefined, 'hash', 100);
+
+    expect(record).toMatchObject({
+      ...tumblrCreateFixture.expected,
+      capturedAt: 100,
+      textHash: 'hash',
+    });
+  });
+
+  it.each(['fetch', 'xhr'])('extracts the Threads %s create response fixture', () => {
+    const record = extractThreadsPostRecord(threadsCreateFixture.response, undefined, 'hash', 100);
+
+    expect(record).toMatchObject({
+      ...threadsCreateFixture.expected,
+      capturedAt: 100,
+      textHash: 'hash',
+    });
+  });
+
+  it.each(['fetch', 'xhr'])('extracts the X %s CreateTweet response fixture', () => {
+    expect(extractXPostId(xCreateTweetFixture.response)).toBe(xCreateTweetFixture.expected.id);
+  });
+
   it('injects a missing Instagram caption into form configure bodies', () => {
     const prepared = prepareInstagramConfigureBody(
       'upload_id=1&caption=&children_metadata=%5B%5D',

--- a/src/utils/post-capture-record.ts
+++ b/src/utils/post-capture-record.ts
@@ -221,6 +221,19 @@ export function extractThreadsPostRecord(
   return { url, code, username: username ?? (fallbackUsername ? cleanThreadsUsername(fallbackUsername) : undefined), capturedAt: now, textHash };
 }
 
+export function extractXPostId(payload: unknown, depth = 0): string | undefined {
+  if (!payload || typeof payload !== 'object' || depth > 12) return undefined;
+  const object = payload as Record<string, unknown>;
+  if (typeof object.rest_id === 'string' && /^\d+$/.test(object.rest_id)) {
+    return object.rest_id;
+  }
+  for (const child of Object.values(object)) {
+    const found = extractXPostId(child, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 export function readFreshCapturedPost(
   raw: string | null,
   expectedText: string,


### PR DESCRIPTION
## Summary

- add sanitized fetch/XHR payload fixtures for Instagram, Mastodon, Tumblr, Threads, and X
- exercise the existing shared extractors with both fetch and XHR characterization cases
- move X rest_id traversal from the page hook into the tested pure capture utility without changing behavior

## Verification

- npm run verify:commit
- Surface exact artifact: 10 cases / 20 runs / 160 results PASS across all 11 SNS
- Evidence: https://github.com/komm64/tutti/issues/28#issuecomment-5085436757

Closes #28
Parent #12