### PR TITLE
refactor: decode runtime messages at boundaries

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,7 +1,6 @@
 import { log } from '../src/utils/logger';
 import type {
   ImageAttachment,
-  Message,
   PlatformId,
   PostResultMessage,
 } from '../src/messages';
@@ -31,6 +30,7 @@ import { createPostingStateManager } from '../src/background/posting-state';
 import { createPlatformPoster } from '../src/background/platform-poster';
 import { maybeCompressVideoForBudget } from '../src/background/media-preprocess';
 import { createExtensionUpdateManager } from '../src/background/extension-update';
+import { decodeMessage } from '../src/utils/message-decoder';
 
 const logBuffer = createPersistentLogBuffer();
 const userActionNotifier = createUserActionNotifier();
@@ -159,7 +159,8 @@ export default defineBackground(() => {
   });
 
   browser.runtime.onMessage.addListener((rawMsg, sender, sendResponse) => {
-    const msg = rawMsg as Message;
+    const msg = decodeMessage(rawMsg);
+    if (!msg) return;
 
     if (msg.type === 'USER_ACTION_REQUIRED') {
       const tabId = sender.tab?.id;

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -22,9 +22,10 @@
  */
 
 import { FFmpeg } from '@ffmpeg/ffmpeg';
-import type { ConvertVideoMessage, Message } from '../../src/messages';
+import type { ConvertVideoMessage } from '../../src/messages';
 import { getBinary, putBinary } from '../../src/utils/binary-transfer';
 import { initLogLevelFromSettings, log } from '../../src/utils/logger';
+import { decodeMessage } from '../../src/utils/message-decoder';
 
 void initLogLevelFromSettings();
 
@@ -299,7 +300,8 @@ function even(value: number): number {
 }
 
 browser.runtime.onMessage.addListener((rawMsg, _sender, sendResponse) => {
-  const msg = rawMsg as Message;
+  const msg = decodeMessage(rawMsg);
+  if (!msg) return;
   if (msg.type !== 'CONVERT_VIDEO') return;
 
   void compressVideo(msg)

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import type {
-    Message,
     PlatformId,
     PostResultMessage,
   } from '../../src/messages';
   import { getAdapter } from '../../src/adapters/registry';
   import { initLogLevelFromSettings } from '../../src/utils/logger';
+  import { decodeMessage } from '../../src/utils/message-decoder';
   import {
     clearDraft,
     getDraft,
@@ -488,7 +488,8 @@
   // background からの進捗ストリームを受信
   $effect(() => {
     const listener = (rawMsg: unknown) => {
-      const msg = rawMsg as Message;
+      const msg = decodeMessage(rawMsg);
+      if (!msg) return;
       const next = applyProgressMessage(msg, currentPostingViewState());
       if (next) applyPostingViewState(next);
       if (msg.type === 'EXTENSION_UPDATE_AVAILABLE') {

--- a/entrypoints/verify-helper.content.ts
+++ b/entrypoints/verify-helper.content.ts
@@ -11,7 +11,7 @@
  * 別 file で 1 つにまとめる (per-SNS に分散させる手間を避ける)。
  */
 
-import type { Message } from '../src/messages';
+import { decodeMessage } from '../src/utils/message-decoder';
 
 export default defineContentScript({
   matches: [
@@ -88,7 +88,8 @@ export default defineContentScript({
     };
 
     browser.runtime.onMessage.addListener((rawMsg, _sender, sendResponse) => {
-      const msg = rawMsg as Message;
+      const msg = decodeMessage(rawMsg);
+      if (!msg) return;
       if (msg.type !== 'VERIFY_POST_DOM') return;
       const ogDescription =
         document.querySelector<HTMLMetaElement>('meta[property="og:description"]')?.content ??

--- a/src/fixtures/messages/post-request-additive.json
+++ b/src/fixtures/messages/post-request-additive.json
@@ -1,0 +1,21 @@
+{
+  "type": "POST_REQUEST",
+  "text": "additive contract",
+  "platforms": [
+    "x"
+  ],
+  "images": [
+    {
+      "name": "fixture.png",
+      "type": "image/png",
+      "data": "AA==",
+      "futureAttachmentField": {
+        "revision": 2
+      }
+    }
+  ],
+  "autoPost": false,
+  "futureRequestField": {
+    "traceId": "fixture-trace"
+  }
+}

--- a/src/utils/content-script-bootstrap.ts
+++ b/src/utils/content-script-bootstrap.ts
@@ -33,6 +33,7 @@ import { initLogLevelFromSettings, log } from './logger';
 import { buildDiagnosis } from './diagnose';
 import { detectAndReportUser } from './user-detect';
 import { t } from './i18n';
+import { decodeMessage } from './message-decoder';
 import {
   getPostSubmissionTrace,
   hasPostSubmissionStarted,
@@ -77,7 +78,8 @@ export function bootstrapContentScript<S extends Record<string, string>>(
   const { platform, selectors, detectUser, runPost, extraHandler } = opts;
 
   browser.runtime.onMessage.addListener((rawMsg, _sender, sendResponse) => {
-    const msg = rawMsg as Message;
+    const msg = decodeMessage(rawMsg);
+    if (!msg) return;
 
     // 当 SNS 固有の追加 handler (bluesky の GET_BLUESKY_SESSION 等)
     if (extraHandler) {

--- a/src/utils/message-decoder.test.ts
+++ b/src/utils/message-decoder.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import postRequestFixture from '../fixtures/messages/post-request-additive.json';
+import postResultFixture from '../fixtures/messages/post-result-additive.json';
+import postToPlatformFixture from '../fixtures/messages/post-to-platform-additive.json';
+import type { Message, PostResultMessage } from '../messages';
+import { decodeMessage } from './message-decoder';
+
+const postResult: PostResultMessage = {
+  type: 'POST_RESULT',
+  platform: 'x',
+  success: true,
+};
+
+const currentMessageSamples: Message[] = [
+  { type: 'POST_REQUEST', text: 'sample', platforms: ['x'] },
+  { type: 'POST_TO_PLATFORM', platform: 'x', text: 'sample' },
+  postResult,
+  { type: 'PLATFORM_PROGRESS', result: postResult },
+  { type: 'GET_EXTENSION_UPDATE_STATE' },
+  { type: 'APPLY_EXTENSION_UPDATE' },
+  { type: 'EXTENSION_UPDATE_AVAILABLE', state: { available: true, version: '1.0.0' } },
+  { type: 'CURRENT_USER', platform: 'x', username: null },
+  {
+    type: 'CONVERT_VIDEO',
+    inputRef: 'input',
+    mimeType: 'video/mp4',
+    durationS: 10,
+    targetBytes: 1_000,
+  },
+  { type: 'CONVERSION_PROGRESS', progress: 0.5, stage: 'transcode' },
+  { type: 'CONVERSION_COMPLETE', outputRef: 'output', outputBytes: 500 },
+  { type: 'CONVERSION_ERROR', error: 'sample' },
+  { type: 'DIAGNOSE_REQUEST', platforms: ['x'] },
+  { type: 'DIAGNOSE_PLATFORM', platform: 'x' },
+  {
+    type: 'DIAGNOSE_PLATFORM_RESULT',
+    platform: 'x',
+    url: 'https://x.com/',
+    selectors: [{
+      name: 'editor',
+      selector: '[contenteditable]',
+      matchCount: 1,
+      firstMatchPreview: null,
+    }],
+    detectedUser: null,
+    domSnapshot: null,
+  },
+  {
+    type: 'LOG_APPEND',
+    entry: { ts: 1, level: 'INFO', context: 'test', message: 'sample' },
+  },
+  { type: 'LOG_EXPORT_REQUEST' },
+  { type: 'GET_BG_STATE' },
+  { type: 'CLEAR_POSTING_STATE' },
+  { type: 'GET_BINARY_CHUNK', dataRef: 'data', offset: 0, length: 1 },
+  { type: 'GET_BLUESKY_SESSION' },
+  {
+    type: 'BLUESKY_SESSION_RESULT',
+    accessJwt: 'jwt',
+    did: 'did:plc:sample',
+    handle: 'sample.test',
+  },
+  { type: 'VERIFY_POST_DOM' },
+  {
+    type: 'VERIFY_POST_DOM_RESULT',
+    ogDescription: '',
+    ogImage: '',
+    bodyExcerpt: '',
+  },
+  { type: 'REFRESH_USER' },
+  { type: 'BROADCAST_REFRESH_USERS' },
+  { type: 'USER_ACTION_REQUIRED', platform: 'x', reason: 'captcha' },
+  { type: 'LOG_CLEAR' },
+];
+
+describe('runtime message decoder', () => {
+  it('accepts a compile-time checked sample of every current message type', () => {
+    for (const sample of currentMessageSamples) {
+      expect(decodeMessage(sample)).toBe(sample);
+    }
+  });
+
+  it.each([
+    ['POST_REQUEST', postRequestFixture],
+    ['POST_TO_PLATFORM', postToPlatformFixture],
+    ['POST_RESULT', postResultFixture],
+  ])('accepts additive fields on %s without copying or stripping them', (_type, fixture) => {
+    const decoded = decodeMessage(fixture);
+
+    expect(decoded).toBe(fixture);
+    expect(decoded).toMatchObject(fixture);
+  });
+
+  it('ignores unknown message types', () => {
+    expect(decodeMessage({
+      type: 'FUTURE_MESSAGE_TYPE',
+      futurePayload: { revision: 2 },
+    })).toBeUndefined();
+  });
+
+  it.each([
+    null,
+    [],
+    { type: 'POST_REQUEST', text: 'missing platforms' },
+    { type: 'POST_REQUEST', text: 'bad platform', platforms: ['future-network'] },
+    { type: 'POST_TO_PLATFORM', platform: 'x', text: 123 },
+    { type: 'POST_RESULT', platform: 'x', success: 'yes' },
+    {
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      flow: { submitReached: 'no' },
+    },
+  ])('rejects malformed known message %#', (value) => {
+    expect(decodeMessage(value)).toBeUndefined();
+  });
+
+  it('accepts all current tag-only messages', () => {
+    for (const type of [
+      'GET_EXTENSION_UPDATE_STATE',
+      'APPLY_EXTENSION_UPDATE',
+      'LOG_EXPORT_REQUEST',
+      'GET_BG_STATE',
+      'CLEAR_POSTING_STATE',
+      'GET_BLUESKY_SESSION',
+      'VERIFY_POST_DOM',
+      'REFRESH_USER',
+      'BROADCAST_REFRESH_USERS',
+      'LOG_CLEAR',
+    ]) {
+      expect(decodeMessage({ type, futureField: true })).toMatchObject({ type });
+    }
+  });
+});

--- a/src/utils/message-decoder.ts
+++ b/src/utils/message-decoder.ts
@@ -1,0 +1,232 @@
+import type { ImageAttachment, Message, PlatformId, PostResultMessage } from '../messages';
+
+type UnknownRecord = Record<string, unknown>;
+type Validator = (value: UnknownRecord) => boolean;
+
+const PLATFORM_IDS = new Set<PlatformId>([
+  'x',
+  'bluesky',
+  'threads',
+  'mastodon',
+  'misskey',
+  'tumblr',
+  'pixiv',
+  'deviantart',
+  'instagram',
+  'tiktok',
+  'youtube',
+]);
+
+const VISIBILITIES = new Set(['public', 'unlisted', 'private', 'direct']);
+const USER_ACTIONS = new Set([
+  'sign-in',
+  'check-account',
+  'complete-captcha',
+  'complete-confirmation',
+  'activate-tab',
+  'check-post-before-retry',
+  'fix-media',
+  'wait',
+  'report-ui-change',
+]);
+const LOG_LEVELS = new Set(['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG']);
+
+const MESSAGE_VALIDATORS = {
+  POST_REQUEST: (value) =>
+    isString(value.text) &&
+    isPlatformArray(value.platforms) &&
+    optional(value, 'images', isAttachmentArray) &&
+    optional(value, 'autoPost', isBoolean) &&
+    optional(value, 'cw', isString) &&
+    optional(value, 'visibility', (item) => isString(item) && VISIBILITIES.has(item)) &&
+    optional(value, 'trimVideoToSeconds', isFiniteNumber),
+  POST_TO_PLATFORM: (value) =>
+    isPlatformId(value.platform) &&
+    isString(value.text) &&
+    optional(value, 'textChunks', isStringArray) &&
+    optional(value, 'images', isAttachmentArray) &&
+    optional(value, 'dryRun', isBoolean) &&
+    optional(value, 'expectedUser', isString) &&
+    optional(value, 'cw', isString) &&
+    optional(value, 'visibility', (item) => isString(item) && VISIBILITIES.has(item)),
+  POST_RESULT: isPostResult,
+  PLATFORM_PROGRESS: (value) => isPostResult(value.result),
+  GET_EXTENSION_UPDATE_STATE: () => true,
+  APPLY_EXTENSION_UPDATE: () => true,
+  EXTENSION_UPDATE_AVAILABLE: (value) => isExtensionUpdateState(value.state),
+  CURRENT_USER: (value) =>
+    isPlatformId(value.platform) &&
+    (isString(value.username) || value.username === null),
+  CONVERT_VIDEO: (value) =>
+    isString(value.inputRef) &&
+    isString(value.mimeType) &&
+    isFiniteNumber(value.durationS) &&
+    isFiniteNumber(value.targetBytes) &&
+    optional(value, 'aspectMode', (item) => item === 'passthrough' || item === 'vertical9x16') &&
+    optional(value, 'trimToSeconds', isFiniteNumber),
+  CONVERSION_PROGRESS: (value) =>
+    isFiniteNumber(value.progress) &&
+    optional(value, 'stage', (item) => item === 'load' || item === 'transcode'),
+  CONVERSION_COMPLETE: (value) =>
+    isString(value.outputRef) &&
+    isFiniteNumber(value.outputBytes),
+  CONVERSION_ERROR: (value) => isString(value.error),
+  DIAGNOSE_REQUEST: (value) => optional(value, 'platforms', isPlatformArray),
+  DIAGNOSE_PLATFORM: (value) => isPlatformId(value.platform),
+  DIAGNOSE_PLATFORM_RESULT: (value) =>
+    isPlatformId(value.platform) &&
+    isString(value.url) &&
+    Array.isArray(value.selectors) &&
+    value.selectors.every(isSelectorAudit) &&
+    (isString(value.detectedUser) || value.detectedUser === null) &&
+    (isString(value.domSnapshot) || value.domSnapshot === null),
+  LOG_APPEND: (value) => isLogEntry(value.entry),
+  LOG_EXPORT_REQUEST: () => true,
+  GET_BG_STATE: () => true,
+  CLEAR_POSTING_STATE: () => true,
+  GET_BINARY_CHUNK: (value) =>
+    isString(value.dataRef) &&
+    isFiniteNumber(value.offset) &&
+    isFiniteNumber(value.length),
+  GET_BLUESKY_SESSION: () => true,
+  BLUESKY_SESSION_RESULT: (value) =>
+    isString(value.accessJwt) &&
+    isString(value.did) &&
+    isString(value.handle) &&
+    optional(value, 'pdsHost', isString),
+  VERIFY_POST_DOM: () => true,
+  VERIFY_POST_DOM_RESULT: (value) =>
+    isString(value.ogDescription) &&
+    isString(value.ogImage) &&
+    isString(value.bodyExcerpt) &&
+    optional(value, 'hasImage', isBoolean) &&
+    optional(value, 'hasVideo', isBoolean),
+  REFRESH_USER: () => true,
+  BROADCAST_REFRESH_USERS: () => true,
+  USER_ACTION_REQUIRED: (value) =>
+    isPlatformId(value.platform) &&
+    (value.reason === 'captcha' || value.reason === 'confirmation'),
+  LOG_CLEAR: () => true,
+} satisfies Record<Message['type'], Validator>;
+
+/**
+ * Decode an extension runtime message without imposing an exact-object wire
+ * contract. Known required fields are checked, while additive unknown fields
+ * remain on the original object for forward compatibility.
+ */
+export function decodeMessage(value: unknown): Message | undefined {
+  if (!isRecord(value) || !isString(value.type)) return undefined;
+  const validator = MESSAGE_VALIDATORS[value.type as Message['type']];
+  if (!validator || !validator(value)) return undefined;
+  return value as unknown as Message;
+}
+
+function isPostResult(value: unknown): value is PostResultMessage {
+  if (!isRecord(value) || value.type !== 'POST_RESULT') return false;
+  return isPlatformId(value.platform) &&
+    isBoolean(value.success) &&
+    optional(value, 'preview', isBoolean) &&
+    optional(value, 'confirmed', isBoolean) &&
+    optional(value, 'uncertain', isBoolean) &&
+    optional(value, 'userAction', (item) => isString(item) && USER_ACTIONS.has(item)) &&
+    optional(value, 'flow', isPostFlowTrace) &&
+    optional(value, 'error', isString) &&
+    optional(value, 'url', isString) &&
+    optional(value, 'verify', isPostVerifyResult);
+}
+
+function isPostFlowTrace(value: unknown): boolean {
+  if (!isRecord(value) || !isBoolean(value.submitReached)) return false;
+  return optional(value, 'mode', (item) => item === 'preview' || item === 'post') &&
+    optional(value, 'attempt', isString) &&
+    optional(value, 'lastCompletedStep', isString) &&
+    optional(value, 'failedStep', isString) &&
+    optional(value, 'submissionStartedAt', isFiniteNumber) &&
+    optional(value, 'tabUrlBefore', isString) &&
+    optional(value, 'tabUrlAfter', isString) &&
+    optional(value, 'urlCaptureTrace', isStringArray);
+}
+
+function isPostVerifyResult(value: unknown): boolean {
+  if (!isRecord(value) || !isBoolean(value.verified) || !Array.isArray(value.issues)) return false;
+  return value.issues.every((issue) =>
+    isRecord(issue) &&
+    isString(issue.kind) &&
+    isString(issue.message) &&
+    (issue.severity === 'warn' || issue.severity === 'error'),
+  );
+}
+
+function isExtensionUpdateState(value: unknown): boolean {
+  if (!isRecord(value) || !isBoolean(value.available)) return false;
+  return optional(value, 'version', isString) &&
+    optional(value, 'applying', isBoolean);
+}
+
+function isSelectorAudit(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return isString(value.name) &&
+    isString(value.selector) &&
+    isFiniteNumber(value.matchCount) &&
+    (isString(value.firstMatchPreview) || value.firstMatchPreview === null);
+}
+
+function isLogEntry(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return isFiniteNumber(value.ts) &&
+    isString(value.level) &&
+    LOG_LEVELS.has(value.level) &&
+    isString(value.context) &&
+    isString(value.message);
+}
+
+function isAttachmentArray(value: unknown): value is ImageAttachment[] {
+  return Array.isArray(value) && value.every(isAttachment);
+}
+
+function isAttachment(value: unknown): value is ImageAttachment {
+  if (!isRecord(value) || !isString(value.name) || !isString(value.type)) return false;
+  return optional(value, 'data', isString) &&
+    optional(value, 'dataRef', isString) &&
+    optional(value, 'bytes', isFiniteNumber) &&
+    optional(value, 'durationS', isFiniteNumber) &&
+    optional(value, 'videoCodec', isString) &&
+    optional(value, 'videoCodecParameters', isString) &&
+    optional(value, 'alt', isString);
+}
+
+function isPlatformArray(value: unknown): value is PlatformId[] {
+  return Array.isArray(value) && value.every(isPlatformId);
+}
+
+function isPlatformId(value: unknown): value is PlatformId {
+  return isString(value) && PLATFORM_IDS.has(value as PlatformId);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+function optional(
+  value: UnknownRecord,
+  key: string,
+  predicate: (item: unknown) => boolean,
+): boolean {
+  return value[key] === undefined || predicate(value[key]);
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}


### PR DESCRIPTION
## Summary

- add an exhaustive runtime decoder for every current Message type
- preserve additive unknown fields while rejecting unknown types and malformed required fields
- apply decoding at background, shared content, offscreen, verify-helper, and popup runtime listeners
- add compile-time/current-shape and additive fixture coverage

## Verification

- npm run verify:commit: PASS (77 files / 605 tests and production build)
- npm run test:stability -- 5: PASS 5/5
- Surface exact artifact: all returned full-matrix results safe; only existing #20 grouped harness flakes
- Surface isolation: Threads emoji 2/2 PASS; all 9 video platforms split into two groups, 18/18 PASS
- Evidence: https://github.com/komm64/tutti/issues/30#issuecomment-5085623919

Closes #30
Parent #12