### PR TITLE
refactor: identify post requests and intent

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -30,7 +30,7 @@ import { createPostingStateManager } from '../src/background/posting-state';
 import { createPlatformPoster } from '../src/background/platform-poster';
 import { maybeCompressVideoForBudget } from '../src/background/media-preprocess';
 import { createExtensionUpdateManager } from '../src/background/extension-update';
-import { decodeMessage } from '../src/utils/message-decoder';
+import { decodeMessageWithDiagnostics } from '../src/utils/message-decoder';
 
 const logBuffer = createPersistentLogBuffer();
 const userActionNotifier = createUserActionNotifier();
@@ -159,8 +159,21 @@ export default defineBackground(() => {
   });
 
   browser.runtime.onMessage.addListener((rawMsg, sender, sendResponse) => {
-    const msg = decodeMessage(rawMsg);
-    if (!msg) return;
+    const decoded = decodeMessageWithDiagnostics(rawMsg);
+    if (!decoded) return;
+    const { message: msg, diagnostics } = decoded;
+    if (msg.type === 'POST_REQUEST' &&
+        (diagnostics.requestIdDefaulted || diagnostics.intentDefaulted)) {
+      const detail = [
+        diagnostics.requestIdDefaulted ? 'requestId' : '',
+        diagnostics.intentDefaulted
+          ? `intent${diagnostics.receivedIntent ? `(${diagnostics.receivedIntent})` : ''}`
+          : '',
+      ].filter(Boolean).join(',');
+      logBuffer.appendBackground(
+        `POST_REQUEST contract defaulted ${detail}; requestId=${msg.requestId} intent=${msg.intent}`,
+      );
+    }
 
     if (msg.type === 'USER_ACTION_REQUIRED') {
       const tabId = sender.tab?.id;

--- a/entrypoints/history/History.svelte
+++ b/entrypoints/history/History.svelte
@@ -5,6 +5,7 @@
   import { formatRelTime } from '../../src/utils/formatters';
   import { getMedia } from '../../src/utils/history-media';
   import { t } from '../../src/utils/i18n';
+  import { createPostRequestId } from '../../src/utils/post-request-id';
 
   interface TimelineMedia {
     name: string;
@@ -131,6 +132,9 @@
       })));
       const req: PostRequestMessage = {
         type: 'POST_REQUEST',
+        requestId: createPostRequestId(),
+        intent: 'history-repost',
+        sourceHistoryEntryId: entry.id,
         text,
         platforms: targets,
         images: images.length > 0 ? images : undefined,

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -844,6 +844,7 @@
         cw,
         visibility,
         trimToS,
+        intent: isRetry ? 'retry' : 'new',
       });
       if (!response) {
         errorMessage = t('backgroundNoResponse');

--- a/scripts/drive-via-runtime.mjs
+++ b/scripts/drive-via-runtime.mjs
@@ -34,7 +34,14 @@ if (swTarget) {
 
   // Trigger POST_REQUEST via service worker (background's onMessage handler)
   const postResult = await worker.evaluate(() => new Promise((resolve) => {
-    chrome.runtime.sendMessage({ type: 'POST_REQUEST', text: 'Tutti SW direct test ' + Date.now(), platforms: ['tumblr'], images: [] }, (response) => {
+    chrome.runtime.sendMessage({
+      type: 'POST_REQUEST',
+      requestId: crypto.randomUUID(),
+      intent: 'new',
+      text: 'Tutti SW direct test ' + Date.now(),
+      platforms: ['tumblr'],
+      images: [],
+    }, (response) => {
       resolve({ response, lastError: chrome.runtime.lastError?.message });
     });
   }));

--- a/scripts/e2e/debug-history-trace.mjs
+++ b/scripts/e2e/debug-history-trace.mjs
@@ -35,7 +35,13 @@ console.log('storage cleared');
 const resp = await page.evaluate(async () => {
   return await new Promise((res) => {
     chrome.runtime.sendMessage(
-      { type: 'POST_REQUEST', text: 'TRACE_MARKER', platforms: [] },
+      {
+        type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
+        text: 'TRACE_MARKER',
+        platforms: [],
+      },
       (r) => res(r ?? { err: chrome.runtime.lastError?.message }),
     );
   });

--- a/scripts/e2e/debug-history-write.mjs
+++ b/scripts/e2e/debug-history-write.mjs
@@ -72,7 +72,14 @@ console.log('=== bg cleared ===', directCall);
 const resp = await page.evaluate(async () => {
   return await new Promise((res) => {
     chrome.runtime.sendMessage(
-      { type: 'POST_REQUEST', text: 'DEBUG_TEXT_MARKER', platforms: [], images: undefined },
+      {
+        type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
+        text: 'DEBUG_TEXT_MARKER',
+        platforms: [],
+        images: undefined,
+      },
       (r) => res(r ?? { err: chrome.runtime.lastError?.message }),
     );
   });

--- a/scripts/e2e/mock-browser-smoke.mjs
+++ b/scripts/e2e/mock-browser-smoke.mjs
@@ -160,6 +160,8 @@ async function runRuntimePreviewSmoke(page) {
   const response = await withTimeout(
     page.evaluate((text) => chrome.runtime.sendMessage({
       type: 'POST_REQUEST',
+      requestId: crypto.randomUUID(),
+      intent: 'new',
       text,
       platforms: ['x'],
       autoPost: false,

--- a/scripts/e2e/probe-x-thread-buttons.mjs
+++ b/scripts/e2e/probe-x-thread-buttons.mjs
@@ -33,6 +33,8 @@ await popup.evaluate(async () => {
 const text = 'あ'.repeat(141);
 const response = await popup.evaluate(async (body) => chrome.runtime.sendMessage({
   type: 'POST_REQUEST',
+  requestId: crypto.randomUUID(),
+  intent: 'new',
   text: body,
   platforms: ['x'],
   images: [],

--- a/scripts/e2e/surface-posting-matrix.mjs
+++ b/scripts/e2e/surface-posting-matrix.mjs
@@ -245,6 +245,8 @@ for (const caseName of requestedCases) {
     try {
       response = await withTimeout(sendPostRequest(popup, {
         type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
         text,
         platforms,
         images,

--- a/scripts/e2e/surface-url-capture-check.mjs
+++ b/scripts/e2e/surface-url-capture-check.mjs
@@ -142,6 +142,8 @@ const postResponse = await popup.evaluate(
     return await new Promise((resolveResponse) => {
       chrome.runtime.sendMessage({
         type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
         text: postText,
         platforms: targetPlatforms,
         images: [imagePayload],

--- a/scripts/e2e/test-multichunk-bugs.mjs
+++ b/scripts/e2e/test-multichunk-bugs.mjs
@@ -160,6 +160,8 @@ for (const sc of scenarios) {
   const startedAt = Date.now();
   const payload = {
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: sc.text,
     platforms: [sc.platform],
     images: sc.withImage ? [{

--- a/scripts/e2e/verify-history-v1.mjs
+++ b/scripts/e2e/verify-history-v1.mjs
@@ -184,6 +184,8 @@ const tinyPng = keepMedia
 const postResult = await extPage.evaluate(async ({ text, image }) => {
   return await chrome.runtime.sendMessage({
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text,
     platforms: ['bluesky'],
     images: image ? [image] : undefined,

--- a/scripts/e2e/verify-real-multipost.mjs
+++ b/scripts/e2e/verify-real-multipost.mjs
@@ -169,7 +169,14 @@ const t0 = Date.now();
 const postResp = await popup.evaluate(async ({ text, platforms, image }) => {
   return new Promise((resolve) => {
     chrome.runtime.sendMessage(
-      { type: 'POST_REQUEST', text, platforms, images: image ? [image] : [] },
+      {
+        type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
+        text,
+        platforms,
+        images: image ? [image] : [],
+      },
       (resp) => resolve(resp ?? { ok: false, error: chrome.runtime.lastError?.message ?? 'no response' }),
     );
   });

--- a/scripts/e2e/verify-v0495-bsky-resize.mjs
+++ b/scripts/e2e/verify-v0495-bsky-resize.mjs
@@ -92,6 +92,8 @@ console.log('\n=== Bluesky big image preview ===');
 const result = await popupPage.evaluate(async ({ base64 }) => {
   return await chrome.runtime.sendMessage({
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: 'big-image v0.4.95 verify',
     platforms: ['bluesky'],
     images: [{

--- a/scripts/e2e/verify-v0496-state-persist.mjs
+++ b/scripts/e2e/verify-v0496-state-persist.mjs
@@ -50,6 +50,8 @@ console.log('=== POST_REQUEST 送信 ===');
 const postResult = await popupPage.evaluate(async () => {
   return await chrome.runtime.sendMessage({
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: 'v0.4.96 state persist verify',
     platforms: ['bluesky'],
   });

--- a/scripts/e2e/verify-v0497-progress-notif.mjs
+++ b/scripts/e2e/verify-v0497-progress-notif.mjs
@@ -53,6 +53,8 @@ console.log('badge before post:', JSON.stringify(await getBadgeText()));
 const postPromise = popupPage.evaluate(async () => {
   return await chrome.runtime.sendMessage({
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: 'v0.4.97 progress + notif verify',
     platforms: ['bluesky'],
   });

--- a/scripts/e2e/verify-v0500-badge-stability.mjs
+++ b/scripts/e2e/verify-v0500-badge-stability.mjs
@@ -54,6 +54,8 @@ console.log('badge before:', JSON.stringify(await getBadge()));
 const postPromise = popupPage.evaluate(async () => {
   return await chrome.runtime.sendMessage({
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: 'badge stability verify',
     platforms: ['bluesky'],
   });

--- a/scripts/e2e/verify-v057.mjs
+++ b/scripts/e2e/verify-v057.mjs
@@ -61,7 +61,13 @@ const t0 = Date.now();
 const resp = await page.evaluate(async ({ text, platforms }) => {
   return new Promise((res) => {
     chrome.runtime.sendMessage(
-      { type: 'POST_REQUEST', text, platforms },
+      {
+        type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
+        text,
+        platforms,
+      },
       (r) => res(r ?? { err: chrome.runtime.lastError?.message }),
     );
   });

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -214,7 +214,14 @@ const image = png
 const postResp = await popup.evaluate(async ({ text, image }) => {
   return new Promise((resolve) => {
     chrome.runtime.sendMessage(
-      { type: 'POST_REQUEST', text, platforms: ['x'], images: image ? [image] : undefined },
+      {
+        type: 'POST_REQUEST',
+        requestId: crypto.randomUUID(),
+        intent: 'new',
+        text,
+        platforms: ['x'],
+        images: image ? [image] : undefined,
+      },
       (resp) => resolve(resp ?? { error: chrome.runtime.lastError?.message ?? 'no response' }),
     );
   });

--- a/scripts/real-post-direct.mjs
+++ b/scripts/real-post-direct.mjs
@@ -103,6 +103,8 @@ const dispatchResult = await popupCdp.evalJs(`(async () => {
   if (!s?.autoPost) return { err: 'autoPost still false' };
   const message = {
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: ${JSON.stringify(testText)},
     platforms: [${JSON.stringify(platform)}],
     images: [{ name: ${JSON.stringify(mediaName)}, type: ${JSON.stringify(mediaType)}, data: ${JSON.stringify(b64)}${isVideo ? ', durationS: 5' : ''} }],

--- a/scripts/real-post-pixiv-direct.mjs
+++ b/scripts/real-post-pixiv-direct.mjs
@@ -85,6 +85,8 @@ const dispatchResult = await popupCdp.evalJs(`(async () => {
   // ImageAttachment は base64 string
   const message = {
     type: 'POST_REQUEST',
+    requestId: crypto.randomUUID(),
+    intent: 'new',
     text: ${JSON.stringify(testText)},
     platforms: ['pixiv'],
     images: [{ name: 'realpost.png', type: 'image/png', data: ${JSON.stringify(b64)} }],

--- a/src/fixtures/messages/post-request-additive.json
+++ b/src/fixtures/messages/post-request-additive.json
@@ -1,5 +1,7 @@
 {
   "type": "POST_REQUEST",
+  "requestId": "fixture-request-id",
+  "intent": "new",
   "text": "additive contract",
   "platforms": [
     "x"

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -66,9 +66,17 @@ export interface ImageAttachment {
   alt?: string;
 }
 
+export type PostRequestIntent = 'new' | 'retry' | 'history-repost';
+
 /** popup → background: 全 SNS への投稿リクエスト */
 export interface PostRequestMessage {
   type: 'POST_REQUEST';
+  /** A unique identity for one user-triggered background submission attempt. */
+  requestId: string;
+  /** Why this request may create a post. Used by the background submission guard. */
+  intent: PostRequestIntent;
+  /** Required context for a History-originated repost. */
+  sourceHistoryEntryId?: string;
   text: string;
   platforms: PlatformId[];
   images?: ImageAttachment[];

--- a/src/popup/post-media.test.ts
+++ b/src/popup/post-media.test.ts
@@ -4,6 +4,8 @@ import { buildPostRequest } from './post-media';
 describe('buildPostRequest', () => {
   it('builds a text-only request without optional fields', async () => {
     await expect(buildPostRequest({
+      requestId: 'request-1',
+      intent: 'new',
       text: 'hello',
       platforms: ['x'],
       images: [],
@@ -15,6 +17,8 @@ describe('buildPostRequest', () => {
       trimToS: null,
     })).resolves.toEqual({
       type: 'POST_REQUEST',
+      requestId: 'request-1',
+      intent: 'new',
       text: 'hello',
       platforms: ['x'],
       images: undefined,
@@ -27,6 +31,8 @@ describe('buildPostRequest', () => {
 
   it('builds an image-only request with alt text', async () => {
     await expect(buildPostRequest({
+      requestId: 'request-2',
+      intent: 'new',
       text: '',
       platforms: ['x'],
       images: [{
@@ -52,6 +58,8 @@ describe('buildPostRequest', () => {
 
   it('builds a text and image request without leaking default options', async () => {
     await expect(buildPostRequest({
+      requestId: 'request-3',
+      intent: 'new',
       text: 'caption',
       platforms: ['threads'],
       images: [{
@@ -80,6 +88,8 @@ describe('buildPostRequest', () => {
 
   it('keeps video metadata and explicit posting options', async () => {
     await expect(buildPostRequest({
+      requestId: 'request-4',
+      intent: 'retry',
       text: '',
       platforms: ['youtube'],
       images: [],
@@ -97,6 +107,8 @@ describe('buildPostRequest', () => {
       trimToS: 10,
     })).resolves.toMatchObject({
       type: 'POST_REQUEST',
+      requestId: 'request-4',
+      intent: 'retry',
       platforms: ['youtube'],
       images: [{ name: 'clip.mp4', type: 'video/mp4', data: 'AA==', durationS: 12, bytes: 1 }],
       autoPost: true,

--- a/src/popup/post-media.ts
+++ b/src/popup/post-media.ts
@@ -1,4 +1,9 @@
-import type { ImageAttachment, PlatformId, PostRequestMessage } from '../messages';
+import type {
+  ImageAttachment,
+  PlatformId,
+  PostRequestIntent,
+  PostRequestMessage,
+} from '../messages';
 import { getAdapter } from '../adapters/registry';
 import { packAttachmentForTransfer } from '../utils/attachment';
 import { resizeImage } from '../utils/image-resize';
@@ -58,11 +63,15 @@ export async function buildPostRequest(input: {
   cw: string;
   visibility: Visibility;
   trimToS: number | null;
+  requestId: string;
+  intent: Extract<PostRequestIntent, 'new' | 'retry'>;
 }): Promise<PostRequestMessage> {
   const media = await preparePostMedia(input.platforms, input.images, input.video, input.imageAlts);
   const wireMedia = await Promise.all(media.map((m) => packAttachmentForTransfer(m)));
   return {
     type: 'POST_REQUEST',
+    requestId: input.requestId,
+    intent: input.intent,
     text: input.text,
     platforms: input.platforms,
     images: wireMedia.length > 0 ? wireMedia : undefined,

--- a/src/popup/post-submit.test.ts
+++ b/src/popup/post-submit.test.ts
@@ -23,12 +23,19 @@ describe('popup post submit policy', () => {
       cw: '',
       visibility: 'public',
       trimToS: null,
+      intent: 'new',
     }, async (message) => {
       sent.push(message);
       return { results: [{ type: 'POST_RESULT', platform: 'x', success: true, preview: true }] };
     });
 
-    expect(sent[0]).toMatchObject({ type: 'POST_REQUEST', text: 'hello', autoPost: false });
+    expect(sent[0]).toMatchObject({
+      type: 'POST_REQUEST',
+      requestId: expect.any(String),
+      intent: 'new',
+      text: 'hello',
+      autoPost: false,
+    });
     expect(response?.results?.[0]).toMatchObject({ platform: 'x', preview: true });
   });
 

--- a/src/popup/post-submit.ts
+++ b/src/popup/post-submit.ts
@@ -1,6 +1,7 @@
-import type { PlatformId, PostResultMessage } from '../messages';
+import type { PlatformId, PostRequestIntent, PostResultMessage } from '../messages';
 import type { ImagePreview, VideoPreview, Visibility } from './types';
 import { buildPostRequest } from './post-media';
+import { createPostRequestId } from '../utils/post-request-id';
 
 export interface PostSubmissionInput {
   text: string;
@@ -12,6 +13,7 @@ export interface PostSubmissionInput {
   cw: string;
   visibility: Visibility;
   trimToS: number | null;
+  intent: Extract<PostRequestIntent, 'new' | 'retry'>;
 }
 
 export interface PostSubmissionResponse {
@@ -25,7 +27,10 @@ export async function sendPostRequest(
   input: PostSubmissionInput,
   sendMessage: RuntimeSendMessage = (message) => browser.runtime.sendMessage(message),
 ): Promise<PostSubmissionResponse | undefined> {
-  const message = await buildPostRequest(input);
+  const message = await buildPostRequest({
+    ...input,
+    requestId: createPostRequestId(),
+  });
   return await sendMessage(message) as PostSubmissionResponse | undefined;
 }
 

--- a/src/utils/message-decoder.test.ts
+++ b/src/utils/message-decoder.test.ts
@@ -3,7 +3,7 @@ import postRequestFixture from '../fixtures/messages/post-request-additive.json'
 import postResultFixture from '../fixtures/messages/post-result-additive.json';
 import postToPlatformFixture from '../fixtures/messages/post-to-platform-additive.json';
 import type { Message, PostResultMessage } from '../messages';
-import { decodeMessage } from './message-decoder';
+import { decodeMessage, decodeMessageWithDiagnostics } from './message-decoder';
 
 const postResult: PostResultMessage = {
   type: 'POST_RESULT',
@@ -12,7 +12,13 @@ const postResult: PostResultMessage = {
 };
 
 const currentMessageSamples: Message[] = [
-  { type: 'POST_REQUEST', text: 'sample', platforms: ['x'] },
+  {
+    type: 'POST_REQUEST',
+    requestId: 'sample-request-id',
+    intent: 'new',
+    text: 'sample',
+    platforms: ['x'],
+  },
   { type: 'POST_TO_PLATFORM', platform: 'x', text: 'sample' },
   postResult,
   { type: 'PLATFORM_PROGRESS', result: postResult },
@@ -96,6 +102,51 @@ describe('runtime message decoder', () => {
       type: 'FUTURE_MESSAGE_TYPE',
       futurePayload: { revision: 2 },
     })).toBeUndefined();
+  });
+
+  it.each([
+    ['missing intent', undefined],
+    ['unknown intent', 'future-intent'],
+  ])('defaults %s conservatively for a potentially real post', (_label, intent) => {
+    const decoded = decodeMessageWithDiagnostics({
+      type: 'POST_REQUEST',
+      text: 'legacy real post',
+      platforms: ['x'],
+      autoPost: true,
+      intent,
+    });
+
+    expect(decoded?.message).toMatchObject({
+      type: 'POST_REQUEST',
+      intent: 'retry',
+    });
+    expect((decoded?.message as { requestId?: string }).requestId).toEqual(expect.any(String));
+    expect(decoded?.diagnostics).toMatchObject({
+      requestIdDefaulted: true,
+      intentDefaulted: true,
+    });
+  });
+
+  it('defaults a legacy preview intent to new without treating it as a real post', () => {
+    const decoded = decodeMessageWithDiagnostics({
+      type: 'POST_REQUEST',
+      text: 'legacy preview',
+      platforms: ['x'],
+      autoPost: false,
+    });
+
+    expect(decoded?.message).toMatchObject({
+      type: 'POST_REQUEST',
+      intent: 'new',
+    });
+    expect(decoded?.diagnostics.intentDefaulted).toBe(true);
+  });
+
+  it('preserves explicit request identity and intent without diagnostics', () => {
+    const decoded = decodeMessageWithDiagnostics(postRequestFixture);
+
+    expect(decoded?.message).toBe(postRequestFixture);
+    expect(decoded?.diagnostics).toEqual({});
   });
 
   it.each([

--- a/src/utils/message-decoder.ts
+++ b/src/utils/message-decoder.ts
@@ -1,4 +1,11 @@
-import type { ImageAttachment, Message, PlatformId, PostResultMessage } from '../messages';
+import type {
+  ImageAttachment,
+  Message,
+  PlatformId,
+  PostRequestIntent,
+  PostResultMessage,
+} from '../messages';
+import { createPostRequestId } from './post-request-id';
 
 type UnknownRecord = Record<string, unknown>;
 type Validator = (value: UnknownRecord) => boolean;
@@ -30,6 +37,7 @@ const USER_ACTIONS = new Set([
   'report-ui-change',
 ]);
 const LOG_LEVELS = new Set(['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG']);
+const POST_REQUEST_INTENTS = new Set<PostRequestIntent>(['new', 'retry', 'history-repost']);
 
 const MESSAGE_VALIDATORS = {
   POST_REQUEST: (value) =>
@@ -39,7 +47,8 @@ const MESSAGE_VALIDATORS = {
     optional(value, 'autoPost', isBoolean) &&
     optional(value, 'cw', isString) &&
     optional(value, 'visibility', (item) => isString(item) && VISIBILITIES.has(item)) &&
-    optional(value, 'trimVideoToSeconds', isFiniteNumber),
+    optional(value, 'trimVideoToSeconds', isFiniteNumber) &&
+    optional(value, 'sourceHistoryEntryId', isString),
   POST_TO_PLATFORM: (value) =>
     isPlatformId(value.platform) &&
     isString(value.text) &&
@@ -115,10 +124,46 @@ const MESSAGE_VALIDATORS = {
  * remain on the original object for forward compatibility.
  */
 export function decodeMessage(value: unknown): Message | undefined {
+  return decodeMessageWithDiagnostics(value)?.message;
+}
+
+export interface MessageDecodeDiagnostics {
+  requestIdDefaulted?: true;
+  intentDefaulted?: true;
+  receivedIntent?: string;
+}
+
+export interface DecodedMessage {
+  message: Message;
+  diagnostics: MessageDecodeDiagnostics;
+}
+
+export function decodeMessageWithDiagnostics(value: unknown): DecodedMessage | undefined {
   if (!isRecord(value) || !isString(value.type)) return undefined;
   const validator = MESSAGE_VALIDATORS[value.type as Message['type']];
   if (!validator || !validator(value)) return undefined;
-  return value as unknown as Message;
+  if (value.type !== 'POST_REQUEST') {
+    return { message: value as unknown as Message, diagnostics: {} };
+  }
+
+  const diagnostics: MessageDecodeDiagnostics = {};
+  const requestId = isString(value.requestId) && value.requestId.trim()
+    ? value.requestId
+    : createPostRequestId();
+  if (requestId !== value.requestId) diagnostics.requestIdDefaulted = true;
+
+  const intent = isPostRequestIntent(value.intent)
+    ? value.intent
+    : value.autoPost === false ? 'new' : 'retry';
+  if (intent !== value.intent) {
+    diagnostics.intentDefaulted = true;
+    if (isString(value.intent)) diagnostics.receivedIntent = value.intent;
+  }
+
+  const message = requestId === value.requestId && intent === value.intent
+    ? value
+    : { ...value, requestId, intent };
+  return { message: message as unknown as Message, diagnostics };
 }
 
 function isPostResult(value: unknown): value is PostResultMessage {
@@ -197,6 +242,10 @@ function isAttachment(value: unknown): value is ImageAttachment {
 
 function isPlatformArray(value: unknown): value is PlatformId[] {
   return Array.isArray(value) && value.every(isPlatformId);
+}
+
+function isPostRequestIntent(value: unknown): value is PostRequestIntent {
+  return isString(value) && POST_REQUEST_INTENTS.has(value as PostRequestIntent);
 }
 
 function isPlatformId(value: unknown): value is PlatformId {

--- a/src/utils/message-wire-contract.test.ts
+++ b/src/utils/message-wire-contract.test.ts
@@ -128,6 +128,7 @@ describe('additive message wire fixtures', () => {
       cw: '',
       visibility: 'public',
       trimToS: null,
+      intent: 'new',
     }, async (message) => {
       sent.push(message);
       return postResponseFixture;
@@ -135,6 +136,8 @@ describe('additive message wire fixtures', () => {
 
     expect(sent[0]).toMatchObject({
       type: 'POST_REQUEST',
+      requestId: expect.any(String),
+      intent: 'new',
       text: 'additive contract',
       autoPost: false,
     });

--- a/src/utils/post-request-id.ts
+++ b/src/utils/post-request-id.ts
@@ -1,0 +1,3 @@
+export function createPostRequestId(): string {
+  return crypto.randomUUID();
+}


### PR DESCRIPTION
## Summary
- require `requestId` and explicit `new | retry | history-repost` intent on `POST_REQUEST`
- update popup, History, Surface matrix, and supported direct callers
- conservatively decode missing/unknown real-post intent as `retry`, while preserving additive fields and recording defaults in diagnostics

## Verification
- `npm run verify:commit` (77 files / 609 tests, compile, production build)
- `npm run test:stability -- 5` (PASS 5/5)
- exact-artifact Surface preview gate; full matrix plus targeted isolation PASS for affected cases

Surface evidence: https://github.com/komm64/tutti/issues/32#issuecomment-5085796030
Known concurrent harness observation: https://github.com/komm64/tutti/issues/20#issuecomment-5085796609

Closes #32