### PR TITLE
refactor: derive popup platform metadata from adapters

### DIFF
--- a/src/adapters/bluesky.ts
+++ b/src/adapters/bluesky.ts
@@ -4,6 +4,8 @@ export const blueskyAdapter: PlatformAdapter = {
   id: 'bluesky',
   name: 'Bluesky',
   charLimit: 300,
+  popupOrder: 2,
+  defaultSelected: true,
   matchUrl: (url) => /^https:\/\/bsky\.app\//.test(url),
   // /intent/compose?text= で compose dialog が開いて text が入る
   getComposeUrl: (text) =>

--- a/src/adapters/deviantart.ts
+++ b/src/adapters/deviantart.ts
@@ -19,6 +19,8 @@ export const deviantartAdapter: PlatformAdapter = {
   name: 'DeviantArt',
   // DA description は generous (5000 程度の感覚)。実用上限としてセット
   charLimit: 5000,
+  popupOrder: 8,
+  defaultSelected: false,
   matchUrl: (url) => /^https:\/\/(www\.)?deviantart\.com\//.test(url),
   getComposeUrl: () => 'https://www.deviantart.com/studio?new=1',
   getLoginUrl: () => 'https://www.deviantart.com/',

--- a/src/adapters/instagram.ts
+++ b/src/adapters/instagram.ts
@@ -24,6 +24,8 @@ export const instagramAdapter: PlatformAdapter = {
   name: 'Instagram',
   // caption 上限 2200 (probe で "0/2,200" と表示されてた)
   charLimit: 2200,
+  popupOrder: 9,
+  defaultSelected: false,
   matchUrl: (url) => /^https:\/\/(www\.)?instagram\.com\//.test(url),
   // home から Create ボタンを click する flow なので、compose URL は home に
   getComposeUrl: () => 'https://www.instagram.com/',

--- a/src/adapters/mastodon.ts
+++ b/src/adapters/mastodon.ts
@@ -11,6 +11,8 @@ export const mastodonAdapter: PlatformAdapter = {
   id: 'mastodon',
   name: 'Mastodon',
   charLimit: 500,
+  popupOrder: 5,
+  defaultSelected: true,
   matchUrl: (url) => url.startsWith(`${MASTODON_DEFAULT_INSTANCE}/`),
   // /share?text= で compose modal が開く(多くの Mastodon インスタンスで共通)
   getComposeUrl: (text) =>

--- a/src/adapters/misskey.ts
+++ b/src/adapters/misskey.ts
@@ -12,6 +12,8 @@ export const misskeyAdapter: PlatformAdapter = {
   id: 'misskey',
   name: 'Misskey',
   charLimit: 3000, // misskey.io は 3000 文字、インスタンス依存
+  popupOrder: 6,
+  defaultSelected: true,
   matchUrl: (url) => url.startsWith(`${MISSKEY_DEFAULT_INSTANCE}/`),
   // Misskey の Web Intent: /share?text=...
   getComposeUrl: (text) =>

--- a/src/adapters/pixiv.ts
+++ b/src/adapters/pixiv.ts
@@ -26,6 +26,8 @@ export const pixivAdapter: PlatformAdapter = {
   name: 'Pixiv',
   // caption 実用上限。Pixiv 側は無制限だが、超過警告を出すボーダーとして
   charLimit: 1000,
+  popupOrder: 7,
+  defaultSelected: false,
   matchUrl: (url) => /^https:\/\/(www\.)?pixiv\.net\//.test(url),
   getComposeUrl: () => 'https://www.pixiv.net/illustration/create',
   getLoginUrl: () => 'https://www.pixiv.net/',

--- a/src/adapters/threads.ts
+++ b/src/adapters/threads.ts
@@ -9,6 +9,8 @@ export const threadsAdapter: PlatformAdapter = {
   id: 'threads',
   name: 'Threads',
   charLimit: 500,
+  popupOrder: 3,
+  defaultSelected: true,
   // 2025 以降 threads.com に段階移行中。両ドメインを許容
   matchUrl: (url) => /^https:\/\/www\.threads\.(?:net|com)\//.test(url),
   // 新ドメイン threads.com の空 composer を使う(threads.net は redirect 想定)。

--- a/src/adapters/tiktok.ts
+++ b/src/adapters/tiktok.ts
@@ -21,6 +21,8 @@ export const tiktokAdapter: PlatformAdapter = {
   name: 'TikTok',
   // caption 上限 2200 (2024 から 4000 に増えた説もあるが確証なし、安全側で 2200)
   charLimit: 2200,
+  popupOrder: 10,
+  defaultSelected: false,
   matchUrl: (url) => /^https:\/\/(www\.)?tiktok\.com\//.test(url),
   getComposeUrl: () => 'https://www.tiktok.com/tiktokstudio/upload',
   getLoginUrl: () => 'https://www.tiktok.com/',

--- a/src/adapters/tumblr.ts
+++ b/src/adapters/tumblr.ts
@@ -9,6 +9,8 @@ export const tumblrAdapter: PlatformAdapter = {
   id: 'tumblr',
   name: 'Tumblr',
   charLimit: 4096,
+  popupOrder: 4,
+  defaultSelected: true,
   matchUrl: (url) => /^https:\/\/(www\.)?tumblr\.com\//.test(url),
   // /new/text で compose を開く。本文は DOM injection で入れる
   getComposeUrl: () => 'https://www.tumblr.com/new/text',

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -40,6 +40,10 @@ export interface PlatformAdapter {
   name: string;
   /** 文字数上限(超過時は分割対象) */
   charLimit: number;
+  /** popup 上の表示順。値は一意で、registryから昇順に導出する */
+  popupOrder: number;
+  /** 初回起動時のpopup選択状態 */
+  defaultSelected: boolean;
   /** 投稿ページとして扱う URL パターン(content script の matches と整合させる) */
   matchUrl: (url: string) => boolean;
   /** 投稿用に開くべき URL を返す。URL pre-fill する SNS では text を URL に乗せる */

--- a/src/adapters/x.ts
+++ b/src/adapters/x.ts
@@ -4,6 +4,8 @@ export const xAdapter: PlatformAdapter = {
   id: 'x',
   name: 'X',
   charLimit: 280,
+  popupOrder: 1,
+  defaultSelected: true,
   matchUrl: (url) => /^https:\/\/(x|twitter)\.com\//.test(url),
   /**
    * X は `/compose/post` の modal compose を使う。ホームの inline compose は

--- a/src/adapters/youtube.ts
+++ b/src/adapters/youtube.ts
@@ -26,6 +26,8 @@ export const youtubeAdapter: PlatformAdapter = {
   name: 'YouTube',
   // description 上限 5000
   charLimit: 5000,
+  popupOrder: 11,
+  defaultSelected: false,
   // studio.youtube.com / m.youtube.com / www.youtube.com
   matchUrl: (url) => /^https:\/\/((www|m|studio)\.)?youtube\.com\//.test(url),
   getComposeUrl: () => 'https://studio.youtube.com/',

--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -84,6 +84,8 @@ function adapter(id: PlatformAdapter['id'] = 'mastodon'): PlatformAdapter {
     id,
     name: id,
     charLimit: 500,
+    popupOrder: 1,
+    defaultSelected: true,
     matchUrl: (url) => url.startsWith('https://social.example/'),
     getComposeUrl: () => 'https://social.example/compose',
     prefillsViaUrl: false,

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -18,6 +18,8 @@ function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
     id: 'threads',
     name: 'Threads',
     charLimit: 500,
+    popupOrder: 1,
+    defaultSelected: true,
     matchUrl: (url) => url.startsWith('https://www.threads.com/'),
     getComposeUrl: (text) => `https://www.threads.com/intent/post?text=${encodeURIComponent(text)}`,
     prefillsViaUrl: true,

--- a/src/popup/platforms.test.ts
+++ b/src/popup/platforms.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_SELECTED_PLATFORMS, POPUP_PLATFORMS, resolveTuttiContext } from './platforms';
+import { adapters } from '../adapters/registry';
+import type { PlatformId } from '../messages';
+import {
+  buildPopupPlatformConfig,
+  DEFAULT_SELECTED_PLATFORMS,
+  POPUP_PLATFORMS,
+  resolveTuttiContext,
+} from './platforms';
 
 describe('resolveTuttiContext', () => {
   it('detects sidepanel, floating, and popup contexts', () => {
@@ -10,7 +17,69 @@ describe('resolveTuttiContext', () => {
 });
 
 describe('popup platform defaults', () => {
+  const expectedOrder: PlatformId[] = [
+    'x',
+    'bluesky',
+    'threads',
+    'tumblr',
+    'mastodon',
+    'misskey',
+    'pixiv',
+    'deviantart',
+    'instagram',
+    'tiktok',
+    'youtube',
+  ];
+
   it('has a selected flag for every platform', () => {
     expect(Object.keys(DEFAULT_SELECTED_PLATFORMS).sort()).toEqual(POPUP_PLATFORMS.map((p) => p.id).sort());
+  });
+
+  it('derives the current display order and defaults from adapter metadata', () => {
+    expect(POPUP_PLATFORMS.map(({ id }) => id)).toEqual(expectedOrder);
+    expect(DEFAULT_SELECTED_PLATFORMS).toEqual({
+      x: true,
+      bluesky: true,
+      threads: true,
+      mastodon: true,
+      misskey: true,
+      tumblr: true,
+      pixiv: false,
+      deviantart: false,
+      instagram: false,
+      tiktok: false,
+      youtube: false,
+    });
+  });
+
+  it('uses adapter names and character limits without popup-local copies', () => {
+    for (const option of POPUP_PLATFORMS) {
+      expect(option).toMatchObject({
+        name: adapters[option.id]?.name,
+        limit: adapters[option.id]?.charLimit,
+        available: true,
+      });
+    }
+  });
+
+  it('has complete and unique popup order metadata', () => {
+    const registeredAdapters = Object.values(adapters).filter((adapter) => adapter !== undefined);
+    const orders = registeredAdapters.map(({ popupOrder }) => popupOrder);
+
+    expect(registeredAdapters).toHaveLength(expectedOrder.length);
+    expect(new Set(orders).size).toBe(orders.length);
+    expect(orders.every(Number.isFinite)).toBe(true);
+  });
+
+  it('keeps missing registry entries visible but unavailable and unselected', () => {
+    const config = buildPopupPlatformConfig({ ...adapters, youtube: undefined });
+
+    expect(config.platforms.at(-1)).toEqual({
+      id: 'youtube',
+      name: 'youtube',
+      limit: 0,
+      available: false,
+    });
+    expect(config.defaultSelected.youtube).toBe(false);
   });
 });

--- a/src/popup/platforms.ts
+++ b/src/popup/platforms.ts
@@ -1,40 +1,57 @@
+import { adapters } from '../adapters/registry';
+import type { PlatformAdapter } from '../adapters/types';
 import type { PlatformId } from '../messages';
 import type { PlatformOption } from './types';
 
 export const MAX_IMAGES = 4;
 
-/**
- * 表示順は X → Bluesky → Threads → Tumblr → Mastodon → Misskey → Pixiv → DeviantArt の固定。
- * Bluesky は MAU 順なら 4 位だが、Tutti として推したい SNS なので X の隣 (2 位) に置く。
- * その他は概ね MAU 順。Pixiv / DeviantArt は image-only クリエイター向けなので末尾。
- */
-export const POPUP_PLATFORMS: PlatformOption[] = [
-  { id: 'x', name: 'X', limit: 280, available: true },
-  { id: 'bluesky', name: 'Bluesky', limit: 300, available: true },
-  { id: 'threads', name: 'Threads', limit: 500, available: true },
-  { id: 'tumblr', name: 'Tumblr', limit: 4096, available: true },
-  { id: 'mastodon', name: 'Mastodon', limit: 500, available: true },
-  { id: 'misskey', name: 'Misskey', limit: 3000, available: true },
-  { id: 'pixiv', name: 'Pixiv', limit: 1000, available: true },
-  { id: 'deviantart', name: 'DeviantArt', limit: 5000, available: true },
-  { id: 'instagram', name: 'Instagram', limit: 2200, available: true },
-  { id: 'tiktok', name: 'TikTok', limit: 2200, available: true },
-  { id: 'youtube', name: 'YouTube', limit: 5000, available: true },
-];
+type PopupPlatformMetadata = Pick<
+  PlatformAdapter,
+  'name' | 'charLimit' | 'popupOrder' | 'defaultSelected'
+>;
+type PopupPlatformRegistry = Readonly<Record<PlatformId, PopupPlatformMetadata | undefined>>;
 
-export const DEFAULT_SELECTED_PLATFORMS: Record<PlatformId, boolean> = {
-  x: true,
-  bluesky: true,
-  threads: true,
-  mastodon: true,
-  misskey: true,
-  tumblr: true,
-  pixiv: false,
-  deviantart: false,
-  instagram: false,
-  tiktok: false,
-  youtube: false,
-};
+/**
+ * 表示順は X → Bluesky → Threads → Tumblr → Mastodon → Misskey → Pixiv → DeviantArt
+ * → Instagram → TikTok → YouTube。
+ * Bluesky は MAU 順なら 4 位だが、Tutti として推したい SNS なので X の隣 (2 位) に置く。
+ * その他は概ね MAU 順。順序・表示名・文字数上限・初期選択は adapter descriptor を SoT とする。
+ */
+export function buildPopupPlatformConfig(registry: PopupPlatformRegistry): {
+  platforms: PlatformOption[];
+  defaultSelected: Record<PlatformId, boolean>;
+} {
+  const ids = Object.keys(registry) as PlatformId[];
+  const sourceOrder = new Map(ids.map((id, index) => [id, index]));
+  const platforms = ids
+    .map((id): PlatformOption => {
+      const adapter = registry[id];
+      return {
+        id,
+        name: adapter?.name ?? id,
+        limit: adapter?.charLimit ?? 0,
+        available: adapter !== undefined,
+      };
+    })
+    .sort((left, right) => {
+      const leftOrder = registry[left.id]?.popupOrder ?? Number.MAX_SAFE_INTEGER;
+      const rightOrder = registry[right.id]?.popupOrder ?? Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder
+        || (sourceOrder.get(left.id) ?? 0) - (sourceOrder.get(right.id) ?? 0);
+    });
+
+  const defaultSelected = Object.fromEntries(
+    ids.map((id) => [id, registry[id]?.defaultSelected === true]),
+  ) as Record<PlatformId, boolean>;
+
+  return { platforms, defaultSelected };
+}
+
+const popupPlatformConfig = buildPopupPlatformConfig(adapters);
+
+export const POPUP_PLATFORMS: PlatformOption[] = popupPlatformConfig.platforms;
+export const DEFAULT_SELECTED_PLATFORMS: Record<PlatformId, boolean> =
+  popupPlatformConfig.defaultSelected;
 
 export function resolveTuttiContext(
   pathname: string = location.pathname,


### PR DESCRIPTION
## Summary
- move popup order and default selection into required adapter metadata
- derive popup display name, character limit, availability, order, and defaults from the adapter registry
- preserve current UI behavior and cover missing adapters plus metadata completeness

## Verification
- npm run verify:commit (81 files, 632 tests, build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)

Surface/CWS gate is not applicable: this is a behavior-preserving metadata refactor and does not change posting, media, URL, selectors, or platform-specific behavior.

Closes #38