### PR TITLE
refactor: move posting policies into adapters

### DIFF
--- a/src/adapters/mastodon.ts
+++ b/src/adapters/mastodon.ts
@@ -13,6 +13,10 @@ export const mastodonAdapter: PlatformAdapter = {
   charLimit: 500,
   popupOrder: 5,
   defaultSelected: true,
+  preSubmitLoad: {
+    retryCount: 1,
+    urlReady: 'same-origin-path',
+  },
   matchUrl: (url) => url.startsWith(`${MASTODON_DEFAULT_INSTANCE}/`),
   // /share?text= で compose modal が開く(多くの Mastodon インスタンスで共通)
   getComposeUrl: (text) =>

--- a/src/adapters/tumblr.ts
+++ b/src/adapters/tumblr.ts
@@ -11,6 +11,7 @@ export const tumblrAdapter: PlatformAdapter = {
   charLimit: 4096,
   popupOrder: 4,
   defaultSelected: true,
+  previewLane: 'foreground',
   matchUrl: (url) => /^https:\/\/(www\.)?tumblr\.com\//.test(url),
   // /new/text で compose を開く。本文は DOM injection で入れる
   getComposeUrl: () => 'https://www.tumblr.com/new/text',

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -35,6 +35,13 @@ export interface ImageConstraints {
   maxImages: number;
 }
 
+export interface PreSubmitLoadPolicy {
+  /** 初回 timeout 後に行う追加 navigation / reload の回数 */
+  retryCount: number;
+  /** compose URL の query が遷移先で消費される場合の ready 判定 */
+  urlReady: 'exact-prefix' | 'same-origin-path';
+}
+
 export interface PlatformAdapter {
   id: PlatformId;
   name: string;
@@ -44,6 +51,14 @@ export interface PlatformAdapter {
   popupOrder: number;
   /** 初回起動時のpopup選択状態 */
   defaultSelected: boolean;
+  /**
+   * 通常は background preview lane。X / Tumblr のようにユーザー操作対象を
+   * foreground で見せる必要がある例外だけ指定する。
+   * requiresForegroundTab は別の強い要件として常に foreground を優先する。
+   */
+  previewLane?: 'foreground';
+  /** 投稿操作前の compose page load timeout に対する宣言policy */
+  preSubmitLoad?: PreSubmitLoadPolicy;
   /** 投稿ページとして扱う URL パターン(content script の matches と整合させる) */
   matchUrl: (url: string) => boolean;
   /** 投稿用に開くべき URL を返す。URL pre-fill する SNS では text を URL に乗せる */

--- a/src/adapters/x.ts
+++ b/src/adapters/x.ts
@@ -6,6 +6,7 @@ export const xAdapter: PlatformAdapter = {
   charLimit: 280,
   popupOrder: 1,
   defaultSelected: true,
+  previewLane: 'foreground',
   matchUrl: (url) => /^https:\/\/(x|twitter)\.com\//.test(url),
   /**
    * X は `/compose/post` の modal compose を使う。ホームの inline compose は

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { mastodonAdapter } from '../adapters/mastodon';
+import { threadsAdapter } from '../adapters/threads';
 import type { PlatformAdapter } from '../adapters/types';
 import {
   buildVerifyExpectationForChunk,
@@ -7,6 +9,7 @@ import {
   buildReplyOverrideUrl,
   getComposeUrlForMedia,
   isAmbiguousPostDispatchError,
+  resolvePreSubmitLoadOptions,
   resolveApiPostOutcome,
   shouldRetryPostAttempt,
   shouldOpenActive,
@@ -30,6 +33,14 @@ function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
 }
 
 describe('platform poster helpers', () => {
+  it('derives pre-submit load behavior from adapter policy', () => {
+    expect(resolvePreSubmitLoadOptions(mastodonAdapter)).toEqual({
+      loadRetries: 1,
+      relaxedComposeUrlReady: true,
+    });
+    expect(resolvePreSubmitLoadOptions(threadsAdapter)).toBeUndefined();
+  });
+
   it('builds X reply intent URLs from previous post URLs', () => {
     expect(buildReplyOverrideUrl('x', 1, 'https://x.com/alice/status/123456')).toBe(
       'https://x.com/intent/post?in_reply_to=123456',

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -13,7 +13,11 @@ import { isVerifySupported } from '../utils/post-verify';
 import { log } from '../utils/logger';
 import { t } from '../utils/i18n';
 import { runVerify } from './verify-dispatcher';
-import { closeTabSafely, openOrFocusTab } from './tab-management';
+import {
+  closeTabSafely,
+  openOrFocusTab,
+  type OpenOrFocusTabOptions,
+} from './tab-management';
 import { tryApiPath } from './api-posting';
 import { capturePostUrlFromTabWithRetry } from './post-url-capture';
 import {
@@ -33,7 +37,6 @@ import type { VerifyExpectation } from '../utils/post-verify';
 import { extractHttpUrls } from '../utils/text-urls';
 
 const CHUNK_INTERVAL_MS = 2000;
-const PRE_SUBMIT_LOAD_RETRY_PLATFORMS = new Set<PlatformId>(['mastodon']);
 
 type Visibility = 'public' | 'unlisted' | 'private' | 'direct';
 
@@ -298,9 +301,7 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
     const active = forceForeground || attempt.forceActive === true ||
       shouldOpenActive(adapter, dryRun, textChunks, autoPost);
     const reuseExistingTab = shouldReuseExistingTabForAttempt(adapter, autoPost, attempt, forceForeground);
-    const openOptions = PRE_SUBMIT_LOAD_RETRY_PLATFORMS.has(adapter.id)
-      ? { loadRetries: 1, relaxedComposeUrlReady: true }
-      : undefined;
+    const openOptions = resolvePreSubmitLoadOptions(adapter);
     const { tab, wasCreated } = await openOrFocusTab(
       overrideUrl ?? getComposeUrlForMedia(adapter, text, images),
       adapter.matchUrl,
@@ -589,6 +590,17 @@ export function getComposeUrlForMedia(
   const hasVideo = images?.some((image) => image.type.startsWith('video/')) === true;
   if (adapter.id === 'tumblr' && hasVideo) return 'https://www.tumblr.com/new/video';
   return adapter.getComposeUrl(text);
+}
+
+export function resolvePreSubmitLoadOptions(
+  adapter: Pick<PlatformAdapter, 'preSubmitLoad'>,
+): OpenOrFocusTabOptions | undefined {
+  const policy = adapter.preSubmitLoad;
+  if (!policy) return undefined;
+  return {
+    loadRetries: policy.retryCount,
+    relaxedComposeUrlReady: policy.urlReady === 'same-origin-path',
+  };
 }
 
 export function shouldOpenActive(

--- a/src/background/post-concurrency.ts
+++ b/src/background/post-concurrency.ts
@@ -6,8 +6,6 @@ export const PREVIEW_BACKGROUND_CONCURRENCY = 3;
 export const PREVIEW_VIDEO_BACKGROUND_CONCURRENCY = 1;
 export const PREVIEW_FOREGROUND_CONCURRENCY = 1;
 
-const INTERACTIVE_PREVIEW_PLATFORMS = new Set<PlatformId>(['x', 'tumblr']);
-
 export type PostExecutionLaneId = 'serial' | 'foreground' | 'background';
 
 export interface PostExecutionLane {
@@ -84,8 +82,9 @@ export function needsForegroundPreview(
   platform: PlatformId,
   options: PostExecutionPlanOptions = {},
 ): boolean {
-  return (!options.hasVideo && INTERACTIVE_PREVIEW_PLATFORMS.has(platform)) ||
-    getAdapter(platform)?.requiresForegroundTab === true;
+  const adapter = getAdapter(platform);
+  return (!options.hasVideo && adapter?.previewLane === 'foreground') ||
+    adapter?.requiresForegroundTab === true;
 }
 
 export function resolvePostConcurrency(


### PR DESCRIPTION
## Summary
- replace the X/Tumblr interactive-preview Set with declarative adapter lane overrides
- replace the Mastodon pre-submit retry Set with a typed adapter load policy
- keep scheduling and tab-loading algorithms generic and preserve existing behavior

## Verification
- npm run verify:commit (81 files, 633 tests, build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- removed both legacy platform-keyed Sets

Surface/CWS gate is not applicable: this relocates existing policy values without changing posting, media, compose URLs, selectors, or platform-specific flow behavior. No upload or submission performed.

Closes #40