### PR TITLE
refactor: separate PlatformId from message contracts

### DIFF
--- a/src/adapters/capabilities.test.ts
+++ b/src/adapters/capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { ContentKind } from './types';
 import { adapters, checkVideoConstraint } from './registry';
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { PlatformAdapter } from './types';
 import { blueskyAdapter } from './bluesky';
 import { deviantartAdapter } from './deviantart';

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 
 /**
  * プラットフォームが受け付けるコンテンツの種別。

--- a/src/background/adapter-resolver.ts
+++ b/src/background/adapter-resolver.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { getAdapter } from '../adapters/registry';
 import type { PlatformAdapter } from '../adapters/types';
 import { getSettings } from '../storage';

--- a/src/background/post-concurrency.ts
+++ b/src/background/post-concurrency.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { getAdapter } from '../adapters/registry';
 
 export const REAL_POST_CONCURRENCY = 1;

--- a/src/background/post-url-capture.ts
+++ b/src/background/post-url-capture.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { waitForTabComplete } from './tab-management';
 import {
   captureRenderedProfilePostUrl,

--- a/src/background/post-url-rendered-profile.ts
+++ b/src/background/post-url-rendered-profile.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { closeTabSafely, waitForTabComplete } from './tab-management';
 import { retryTransientTabAction } from './tab-action-retry';
 

--- a/src/background/user-action-notifier.ts
+++ b/src/background/user-action-notifier.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { log } from '../utils/logger';
 import { t } from '../utils/i18n';
 import { retryTransientTabAction } from './tab-action-retry';

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -3,7 +3,9 @@
  * すべてのメッセージはこの判別共用体のいずれかに該当する。
  */
 
-export type PlatformId = 'x' | 'bluesky' | 'threads' | 'mastodon' | 'misskey' | 'tumblr' | 'pixiv' | 'deviantart' | 'instagram' | 'tiktok' | 'youtube';
+import type { PlatformId } from './types/platform';
+
+export type { PlatformId } from './types/platform';
 
 export type UserActionCategory =
   | 'sign-in'

--- a/src/popup/compatibility.test.ts
+++ b/src/popup/compatibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import {
   buildSelectedCompatibilityErrors,
   buildVideoCompatibility,

--- a/src/popup/compatibility.ts
+++ b/src/popup/compatibility.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { checkVideoConstraint, getAdapter } from '../adapters/registry';
 import { splitTextForPlatform } from '../utils/platform-text';
 import type { ImagePreview, PlatformOption, VideoPreview } from './types';

--- a/src/popup/draft-key.ts
+++ b/src/popup/draft-key.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { ImagePreview, VideoPreview, Visibility } from './types';
 
 export interface DraftKeyInput {

--- a/src/popup/platforms.test.ts
+++ b/src/popup/platforms.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { adapters } from '../adapters/registry';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import {
   buildPopupPlatformConfig,
   DEFAULT_SELECTED_PLATFORMS,

--- a/src/popup/platforms.ts
+++ b/src/popup/platforms.ts
@@ -1,6 +1,6 @@
 import { adapters } from '../adapters/registry';
 import type { PlatformAdapter } from '../adapters/types';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { PlatformOption } from './types';
 
 export const MAX_IMAGES = 4;

--- a/src/popup/presets.test.ts
+++ b/src/popup/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { DEFAULT_SELECTED_PLATFORMS } from './platforms';
 import {
   applyPresetSelection,

--- a/src/popup/presets.ts
+++ b/src/popup/presets.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { SnsPreset } from './types';
 
 export function selectedPlatformIds(selected: Record<PlatformId, boolean>): PlatformId[] {

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,0 +1,13 @@
+/** Tutti が投稿・診断・履歴で識別する platform ID。 */
+export type PlatformId =
+  | 'x'
+  | 'bluesky'
+  | 'threads'
+  | 'mastodon'
+  | 'misskey'
+  | 'tumblr'
+  | 'pixiv'
+  | 'deviantart'
+  | 'instagram'
+  | 'tiktok'
+  | 'youtube';

--- a/src/utils/compose-url.ts
+++ b/src/utils/compose-url.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 
 export function isKnownComposeUrl(platform: PlatformId, rawUrl: string): boolean {
   let url: URL;

--- a/src/utils/effective-limits.ts
+++ b/src/utils/effective-limits.ts
@@ -10,7 +10,7 @@
  * (= post latency を増やさない、次回反映)。
  */
 
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import type { VideoConstraints } from '../adapters/types';
 import { getApiCredentials } from './api-credentials';
 import { getSettings } from '../storage';

--- a/src/utils/interaction-notify.ts
+++ b/src/utils/interaction-notify.ts
@@ -10,7 +10,7 @@
  */
 
 import { getInteractionSnapshots, getPostHistory, pruneInteractionSnapshots, setInteractionSnapshots, type InteractionSnapshot } from '../storage';
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { extractPollingTarget, isPollingSupported, pollBluesky, pollMastodon, pollMisskey, type InteractionCounts } from './interaction-poll';
 import { t } from './i18n';
 

--- a/src/utils/interaction-poll.ts
+++ b/src/utils/interaction-poll.ts
@@ -14,7 +14,7 @@
  * 足すだけで bg は変更不要 (registry pattern)。
  */
 
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 
 export interface InteractionCounts {
   likes: number;

--- a/src/utils/platform-text.ts
+++ b/src/utils/platform-text.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { splitText } from './split';
 
 const X_URL_RE = /https?:\/\/[^\s]+/giu;

--- a/src/utils/post-id.ts
+++ b/src/utils/post-id.ts
@@ -12,7 +12,7 @@
  *   extractPostId('x', 'https://x.com/user/status/1234567890')
  *   // → '1234567890'
  */
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 
 export function extractPostId(platform: PlatformId, url: string | undefined): string | null {
   if (!url) return null;

--- a/src/utils/post-verify.ts
+++ b/src/utils/post-verify.ts
@@ -9,7 +9,7 @@
  * 自動検知して popup に warning として通知する。
  */
 
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { t } from './i18n';
 import { hasUrlEvidence } from './text-urls';
 

--- a/src/utils/reply-compose.ts
+++ b/src/utils/reply-compose.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import {
   elementTextMatches,
   isElementDisabled,

--- a/src/utils/selector-overrides.ts
+++ b/src/utils/selector-overrides.ts
@@ -10,7 +10,7 @@
  * { x?: { fileInput?: string, ... }, mastodon?: { ... }, ... }
  * ```
  */
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 
 export type SelectorOverrides = Partial<Record<PlatformId, Record<string, string>>>;
 

--- a/src/utils/user-detect.ts
+++ b/src/utils/user-detect.ts
@@ -1,4 +1,4 @@
-import type { PlatformId } from '../messages';
+import type { PlatformId } from '../types/platform';
 import { sleep } from './dom';
 
 /**


### PR DESCRIPTION
## Summary
- move the canonical 11-platform PlatformId union into src/types/platform.ts
- import and compatibility-re-export it from messages.ts
- migrate adapter and PlatformId-only consumers off the message-contract module

## Verification
- npm run verify:commit (81 files, 633 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- adapter directory has no remaining messages import

Surface/CWS gate is not applicable: this is a type-only dependency refactor and does not change posting, media, URLs, selectors, wire shapes, or permissions. No upload or submission performed.

Closes #42