### PR TITLE
refactor: register API posting strategies

### DIFF
--- a/src/background/api-posting.test.ts
+++ b/src/background/api-posting.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { postViaApi as postBlueskyApi, postViaSession as postBlueskySessionApi } from '../api/bluesky';
 import { postViaApi as postMastodonApi } from '../api/mastodon';
 import { getApiCredentials } from '../utils/api-credentials';
-import { tryApiPath } from './api-posting';
+import { backgroundPlatformStrategies, tryApiPath } from './platform-strategies';
 
 vi.mock('../api/bluesky', () => ({
   postViaApi: vi.fn(async () => ({ success: true, postUrl: 'https://bsky.app/profile/alice/post/abc' })),
@@ -36,6 +36,17 @@ describe('tryApiPath', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('derives API support from strategy membership', () => {
+    expect(Object.entries(backgroundPlatformStrategies)
+      .filter(([, strategy]) => strategy.apiPost)
+      .map(([platform]) => platform)).toEqual(['bluesky', 'mastodon', 'misskey']);
+  });
+
+  it('returns no-credentials without credential lookup when no API strategy is registered', async () => {
+    expect(await tryApiPath('x', 'hello')).toBe('no-credentials');
+    expect(getCreds).not.toHaveBeenCalled();
   });
 
   it('uses the Bluesky API path for video attachments', async () => {

--- a/src/background/api-posting.ts
+++ b/src/background/api-posting.ts
@@ -1,4 +1,4 @@
-import type { ImageAttachment, PlatformId } from '../messages';
+import type { ImageAttachment } from '../messages';
 import type { BlueskySessionResult } from '../messages';
 import { postViaApi as postBlueskyApi, postViaSession as postBlueskySession } from '../api/bluesky';
 import type { Session as BlueskySession } from '../api/bluesky';
@@ -11,32 +11,44 @@ import { parseMastodonStatusIdFromUrl } from '../utils/reply-compose';
 
 export type ApiPostingVisibility = 'public' | 'unlisted' | 'private' | 'direct';
 
-/**
- * 設定された API credentials があれば API path で投稿。無ければ 'no-credentials'。
- * P15 で対応しているのは Bluesky / Mastodon / Misskey の 3 platforms。
- */
-export async function tryApiPath(
-  platform: PlatformId,
+export interface ApiPostingInput {
   text: string,
   images?: ImageAttachment[],
   cw?: string,
   visibility?: ApiPostingVisibility,
   replyToUrl?: string,
-): Promise<ApiPostResult | 'no-credentials'> {
+}
+
+export type ApiPostingStrategy = (
+  input: ApiPostingInput,
+) => Promise<ApiPostResult | 'no-credentials'>;
+
+export async function tryBlueskyApiPost({
+  text,
+  images,
+}: ApiPostingInput): Promise<ApiPostResult | 'no-credentials'> {
   const creds = await getApiCredentials();
-  if (platform === 'bluesky') {
-    if (creds.bluesky) {
-      return await postBlueskyApi(creds.bluesky, { text, images });
-    }
-    const session = await readBlueskySessionFromOpenTab();
-    if (session) {
-      const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
-      log.info(`bluesky via borrowed web session API start: media=${images?.length ?? 0} video=${hasVideo}`);
-      return await postBlueskySession(session, { text, images });
-    }
-    return 'no-credentials';
+  if (creds.bluesky) {
+    return await postBlueskyApi(creds.bluesky, { text, images });
   }
-  if (platform === 'mastodon' && creds.mastodon) {
+  const session = await readBlueskySessionFromOpenTab();
+  if (session) {
+    const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
+    log.info(`bluesky via borrowed web session API start: media=${images?.length ?? 0} video=${hasVideo}`);
+    return await postBlueskySession(session, { text, images });
+  }
+  return 'no-credentials';
+}
+
+export async function tryMastodonApiPost({
+  text,
+  images,
+  cw,
+  visibility,
+  replyToUrl,
+}: ApiPostingInput): Promise<ApiPostResult | 'no-credentials'> {
+  const creds = await getApiCredentials();
+  if (creds.mastodon) {
     return await postMastodonApi(creds.mastodon, {
       text,
       images,
@@ -45,7 +57,17 @@ export async function tryApiPath(
       replyToId: replyToUrl ? parseMastodonStatusIdFromUrl(replyToUrl) : undefined,
     });
   }
-  if (platform === 'misskey' && creds.misskey) {
+  return 'no-credentials';
+}
+
+export async function tryMisskeyApiPost({
+  text,
+  images,
+  cw,
+  visibility,
+}: ApiPostingInput): Promise<ApiPostResult | 'no-credentials'> {
+  const creds = await getApiCredentials();
+  if (creds.misskey) {
     return await postMisskeyApi(creds.misskey, { text, images, cw, visibility });
   }
   return 'no-credentials';

--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -43,7 +43,7 @@ vi.mock('./adapter-resolver', () => ({
   resolveAdapter: mocks.resolveAdapter,
 }));
 
-vi.mock('./api-posting', () => ({
+vi.mock('./platform-strategies', () => ({
   tryApiPath: mocks.tryApiPath,
 }));
 

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -18,7 +18,7 @@ import {
   openOrFocusTab,
   type OpenOrFocusTabOptions,
 } from './tab-management';
-import { tryApiPath } from './api-posting';
+import { tryApiPath } from './platform-strategies';
 import { capturePostUrlFromTabWithRetry } from './post-url-capture';
 import {
   buildLoginRedirectErrorForUrl,

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -1,8 +1,19 @@
+import type { ImageAttachment } from '../messages';
+import type { ApiPostResult } from '../api/types';
 import type { PlatformId } from '../types/platform';
+import {
+  tryBlueskyApiPost,
+  tryMastodonApiPost,
+  tryMisskeyApiPost,
+  type ApiPostingStrategy,
+  type ApiPostingVisibility,
+} from './api-posting';
 
 export interface BackgroundPlatformStrategy {
   /** 投稿 URL から platform 固有の安定 post ID を抽出する。 */
   parsePostId: (url: URL) => string | null;
+  /** credentials / borrowed session がある場合だけ使う API posting 手続き。 */
+  apiPost?: ApiPostingStrategy;
 }
 
 /**
@@ -15,6 +26,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   },
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
+    apiPost: tryBlueskyApiPost,
   },
   threads: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([A-Za-z0-9_-]+)/)?.[1] ?? null,
@@ -25,9 +37,11 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? pathname.match(/\/users\/\w+\/statuses\/(\d+)/)?.[1]
       ?? null
     ),
+    apiPost: tryMastodonApiPost,
   },
   misskey: {
     parsePostId: ({ pathname }) => pathname.match(/\/notes\/([a-zA-Z0-9]+)/)?.[1] ?? null,
+    apiPost: tryMisskeyApiPost,
   },
   tumblr: {
     parsePostId: ({ pathname }) => (
@@ -77,4 +91,21 @@ export function extractPostId(platform: PlatformId, rawUrl: string | undefined):
   } catch {
     return null;
   }
+}
+
+/**
+ * 設定された API credentials / session があれば登録済み API strategy で投稿する。
+ * strategy 未登録または credentials 不在なら、post action 前の DOM path 選択へ戻す。
+ */
+export async function tryApiPath(
+  platform: PlatformId,
+  text: string,
+  images?: ImageAttachment[],
+  cw?: string,
+  visibility?: ApiPostingVisibility,
+  replyToUrl?: string,
+): Promise<ApiPostResult | 'no-credentials'> {
+  const strategy = getBackgroundPlatformStrategy(platform).apiPost;
+  if (!strategy) return 'no-credentials';
+  return await strategy({ text, images, cw, visibility, replyToUrl });
 }


### PR DESCRIPTION
## Summary
- split Bluesky, Mastodon, and Misskey API paths into platform-bound strategy functions
- register API support through optional apiPost members in the background registry
- make generic tryApiPath dispatch solely through registry membership
- preserve credentials, borrowed Bluesky session, media, Mastodon reply, and no-credentials semantics

## Verification
- npm run verify:commit (81 files, 636 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- API membership and unsupported-platform no-credentials tests added
- existing no-transport-fallback boundary tests PASS

Surface/CWS gate is not applicable: this relocates dispatch without changing posting procedures, media, URLs, selectors, or release state. No upload or submission performed.

Closes #46