### PR TITLE
refactor: register continuation strategies

### DIFF
--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -43,7 +43,8 @@ vi.mock('./adapter-resolver', () => ({
   resolveAdapter: mocks.resolveAdapter,
 }));
 
-vi.mock('./platform-strategies', () => ({
+vi.mock('./platform-strategies', async (importOriginal) => ({
+  ...await importOriginal<typeof import('./platform-strategies')>(),
   tryApiPath: mocks.tryApiPath,
 }));
 

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -6,7 +6,6 @@ import {
   buildVerifyExpectationForChunk,
   buildFinalChunkResult,
   buildDomPostAttempts,
-  buildReplyOverrideUrl,
   getComposeUrlForMedia,
   isAmbiguousPostDispatchError,
   resolvePreSubmitLoadOptions,
@@ -39,27 +38,6 @@ describe('platform poster helpers', () => {
       relaxedComposeUrlReady: true,
     });
     expect(resolvePreSubmitLoadOptions(threadsAdapter)).toBeUndefined();
-  });
-
-  it('builds X reply intent URLs from previous post URLs', () => {
-    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/alice/status/123456')).toBe(
-      'https://x.com/intent/post?in_reply_to=123456',
-    );
-  });
-
-  it('does not build reply URLs without a continuation target or for unsupported platforms', () => {
-    expect(buildReplyOverrideUrl('x', 0, 'https://x.com/alice/status/123456')).toBeUndefined();
-    expect(buildReplyOverrideUrl('bluesky', 1, 'https://bsky.app/profile/alice/post/abc')).toBeUndefined();
-    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/home')).toBeUndefined();
-  });
-
-  it('opens Mastodon and Threads continuation chunks from the previous post URL', () => {
-    expect(buildReplyOverrideUrl('mastodon', 1, 'https://mastodon.social/@alice/1234567890')).toBe(
-      'https://mastodon.social/@alice/1234567890',
-    );
-    expect(buildReplyOverrideUrl('threads', 1, 'https://www.threads.com/@alice/post/ABC123')).toBe(
-      'https://www.threads.com/@alice/post/ABC123',
-    );
   });
 
   it('builds safe pre-submit fallback attempts for normal SNS posting', () => {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -18,7 +18,11 @@ import {
   openOrFocusTab,
   type OpenOrFocusTabOptions,
 } from './tab-management';
-import { tryApiPath } from './platform-strategies';
+import {
+  buildReplyOverrideUrl,
+  continuationNeedsReplyUrl,
+  tryApiPath,
+} from './platform-strategies';
 import { capturePostUrlFromTabWithRetry } from './post-url-capture';
 import {
   buildLoginRedirectErrorForUrl,
@@ -32,7 +36,6 @@ import { maybeResizeImagesForPlatform } from './media-preprocess';
 import { downgradeHardVerifyFailures, toPreviewResult } from './post-result-policy';
 import type { OpenedTabRegistry } from './opened-tab-registry';
 import { retryTransientTabAction } from './tab-action-retry';
-import { continuationNeedsReplyUrl } from '../utils/reply-compose';
 import type { VerifyExpectation } from '../utils/post-verify';
 import { extractHttpUrls } from '../utils/text-urls';
 
@@ -568,18 +571,6 @@ export function isAmbiguousPostDispatchError(err: unknown): boolean {
     message.includes('back/forward cache') ||
     message.includes('content script response timed out')
   );
-}
-
-export function buildReplyOverrideUrl(
-  platform: PlatformId,
-  chunkIndex: number,
-  prevPostUrl: string | undefined,
-): string | undefined {
-  if (chunkIndex === 0 || !prevPostUrl) return undefined;
-  if (platform === 'mastodon' || platform === 'threads') return prevPostUrl;
-  if (platform !== 'x') return undefined;
-  const match = prevPostUrl.match(/\/status\/(\d+)/);
-  return match?.[1] ? `https://x.com/intent/post?in_reply_to=${match[1]}` : undefined;
 }
 
 export function getComposeUrlForMedia(

--- a/src/background/platform-strategies.test.ts
+++ b/src/background/platform-strategies.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { adapters } from '../adapters/registry';
 import {
   backgroundPlatformStrategies,
+  buildReplyOverrideUrl,
+  continuationNeedsReplyUrl,
   extractPostId,
 } from './platform-strategies';
 
@@ -11,6 +13,29 @@ describe('background platform strategy registry', () => {
     for (const strategy of Object.values(backgroundPlatformStrategies)) {
       expect(strategy.parsePostId).toBeTypeOf('function');
     }
+  });
+
+  it('derives continuation support and URLs from strategy membership', () => {
+    expect(Object.entries(backgroundPlatformStrategies)
+      .filter(([, strategy]) => strategy.continuationUrl)
+      .map(([platform]) => platform)).toEqual(['x', 'threads', 'mastodon']);
+    expect(continuationNeedsReplyUrl('x')).toBe(true);
+    expect(continuationNeedsReplyUrl('mastodon')).toBe(true);
+    expect(continuationNeedsReplyUrl('threads')).toBe(true);
+    expect(continuationNeedsReplyUrl('bluesky')).toBe(false);
+
+    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/alice/status/123456')).toBe(
+      'https://x.com/intent/post?in_reply_to=123456',
+    );
+    expect(buildReplyOverrideUrl('mastodon', 1, 'https://mastodon.social/@alice/123')).toBe(
+      'https://mastodon.social/@alice/123',
+    );
+    expect(buildReplyOverrideUrl('threads', 1, 'https://www.threads.com/@alice/post/ABC')).toBe(
+      'https://www.threads.com/@alice/post/ABC',
+    );
+    expect(buildReplyOverrideUrl('x', 0, 'https://x.com/alice/status/123456')).toBeUndefined();
+    expect(buildReplyOverrideUrl('bluesky', 1, 'https://bsky.app/profile/alice/post/abc')).toBeUndefined();
+    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/home')).toBeUndefined();
   });
 });
 

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -14,6 +14,8 @@ export interface BackgroundPlatformStrategy {
   parsePostId: (url: URL) => string | null;
   /** credentials / borrowed session がある場合だけ使う API posting 手続き。 */
   apiPost?: ApiPostingStrategy;
+  /** 2 chunk 目以降を captured parent URL へ接続する compose URL 手続き。 */
+  continuationUrl?: (previousPostUrl: string) => string | undefined;
 }
 
 /**
@@ -23,6 +25,10 @@ export interface BackgroundPlatformStrategy {
 export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatformStrategy> = {
   x: {
     parsePostId: ({ pathname }) => pathname.match(/\/status(?:es)?\/(\d+)/)?.[1] ?? null,
+    continuationUrl: (previousPostUrl) => {
+      const statusId = previousPostUrl.match(/\/status\/(\d+)/)?.[1];
+      return statusId ? `https://x.com/intent/post?in_reply_to=${statusId}` : undefined;
+    },
   },
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
@@ -30,6 +36,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   },
   threads: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([A-Za-z0-9_-]+)/)?.[1] ?? null,
+    continuationUrl: (previousPostUrl) => previousPostUrl,
   },
   mastodon: {
     parsePostId: ({ pathname }) => (
@@ -38,6 +45,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? null
     ),
     apiPost: tryMastodonApiPost,
+    continuationUrl: (previousPostUrl) => previousPostUrl,
   },
   misskey: {
     parsePostId: ({ pathname }) => pathname.match(/\/notes\/([a-zA-Z0-9]+)/)?.[1] ?? null,
@@ -108,4 +116,17 @@ export async function tryApiPath(
   const strategy = getBackgroundPlatformStrategy(platform).apiPost;
   if (!strategy) return 'no-credentials';
   return await strategy({ text, images, cw, visibility, replyToUrl });
+}
+
+export function continuationNeedsReplyUrl(platform: PlatformId): boolean {
+  return getBackgroundPlatformStrategy(platform).continuationUrl !== undefined;
+}
+
+export function buildReplyOverrideUrl(
+  platform: PlatformId,
+  chunkIndex: number,
+  previousPostUrl: string | undefined,
+): string | undefined {
+  if (chunkIndex === 0 || !previousPostUrl) return undefined;
+  return getBackgroundPlatformStrategy(platform).continuationUrl?.(previousPostUrl);
 }

--- a/src/utils/reply-compose.test.ts
+++ b/src/utils/reply-compose.test.ts
@@ -2,7 +2,6 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-  continuationNeedsReplyUrl,
   findReplyButton,
   isPlatformPostDetailUrl,
   parseMastodonStatusIdFromUrl,
@@ -16,13 +15,6 @@ function markVisible(el: HTMLElement): void {
 }
 
 describe('reply compose helpers', () => {
-  it('requires a captured parent URL for continuation platforms', () => {
-    expect(continuationNeedsReplyUrl('x')).toBe(true);
-    expect(continuationNeedsReplyUrl('mastodon')).toBe(true);
-    expect(continuationNeedsReplyUrl('threads')).toBe(true);
-    expect(continuationNeedsReplyUrl('bluesky')).toBe(false);
-  });
-
   it('detects Mastodon and Threads post detail URLs', () => {
     expect(isPlatformPostDetailUrl('mastodon', 'https://mastodon.social/@alice/1234567890')).toBe(true);
     expect(isPlatformPostDetailUrl('mastodon', 'https://mastodon.social/share?text=hello')).toBe(false);

--- a/src/utils/reply-compose.ts
+++ b/src/utils/reply-compose.ts
@@ -10,10 +10,6 @@ import { clickElementInMainWorld } from './image';
 
 const REPLY_TEXTS = ['Reply', '返信', '返信する', 'Respond'];
 
-export function continuationNeedsReplyUrl(platform: PlatformId): boolean {
-  return platform === 'x' || platform === 'mastodon' || platform === 'threads';
-}
-
 export function isPlatformPostDetailUrl(platform: PlatformId, url: string): boolean {
   if (platform === 'mastodon') return parseMastodonStatusIdFromUrl(url) !== undefined;
   if (platform === 'threads') return /^https:\/\/(?:www\.)?threads\.(?:com|net)\/@[^/]+\/post\/[\w-]+(?:[/?#]|$)/.test(url);


### PR DESCRIPTION
## Summary
- register X, Mastodon, and Threads continuation URL procedures in the background strategy registry
- derive captured-parent requirements from strategy membership
- remove continuation platform branches from platform-poster
- keep content-side reply DOM helpers independent of the background registry

## Verification
- npm run verify:commit (81 files, 633 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- focused continuation, transport-boundary, and content reply tests PASS

Surface/CWS gate is not applicable: this relocates existing continuation URL selection without changing posting actions, media, URL capture, selectors, or release state. No upload or submission performed.

Closes #48