### PR TITLE
refactor: register verification strategies

### DIFF
--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -45,6 +45,7 @@ vi.mock('./adapter-resolver', () => ({
 
 vi.mock('./platform-strategies', async (importOriginal) => ({
   ...await importOriginal<typeof import('./platform-strategies')>(),
+  runVerify: mocks.runVerify,
   tryApiPath: mocks.tryApiPath,
 }));
 
@@ -74,10 +75,6 @@ vi.mock('./tab-action-retry', () => ({
 vi.mock('./tab-management', () => ({
   closeTabSafely: mocks.closeTabSafely,
   openOrFocusTab: mocks.openOrFocusTab,
-}));
-
-vi.mock('./verify-dispatcher', () => ({
-  runVerify: mocks.runVerify,
 }));
 
 function adapter(id: PlatformAdapter['id'] = 'mastodon'): PlatformAdapter {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -9,10 +9,8 @@ import type { PlatformAdapter } from '../adapters/types';
 import type { ApiPostResult } from '../api/types';
 import { getLastSeenUsers, getSettings } from '../storage';
 import { splitTextForPlatform } from '../utils/platform-text';
-import { isVerifySupported } from '../utils/post-verify';
 import { log } from '../utils/logger';
 import { t } from '../utils/i18n';
-import { runVerify } from './verify-dispatcher';
 import {
   closeTabSafely,
   openOrFocusTab,
@@ -21,6 +19,8 @@ import {
 import {
   buildReplyOverrideUrl,
   continuationNeedsReplyUrl,
+  isVerifySupported,
+  runVerify,
   tryApiPath,
 } from './platform-strategies';
 import { capturePostUrlFromTabWithRetry } from './post-url-capture';

--- a/src/background/platform-strategies.test.ts
+++ b/src/background/platform-strategies.test.ts
@@ -5,6 +5,7 @@ import {
   buildReplyOverrideUrl,
   continuationNeedsReplyUrl,
   extractPostId,
+  isVerifySupported,
 } from './platform-strategies';
 
 describe('background platform strategy registry', () => {
@@ -36,6 +37,13 @@ describe('background platform strategy registry', () => {
     expect(buildReplyOverrideUrl('x', 0, 'https://x.com/alice/status/123456')).toBeUndefined();
     expect(buildReplyOverrideUrl('bluesky', 1, 'https://bsky.app/profile/alice/post/abc')).toBeUndefined();
     expect(buildReplyOverrideUrl('x', 1, 'https://x.com/home')).toBeUndefined();
+  });
+
+  it('registers verification for every current platform', () => {
+    for (const [platform, strategy] of Object.entries(backgroundPlatformStrategies)) {
+      expect(strategy.verifyPost).toBeTypeOf('function');
+      expect(isVerifySupported(platform as keyof typeof backgroundPlatformStrategies)).toBe(true);
+    }
   });
 });
 

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -2,12 +2,31 @@ import type { ImageAttachment } from '../messages';
 import type { ApiPostResult } from '../api/types';
 import type { PlatformId } from '../types/platform';
 import {
+  verifyError,
+  type VerifyExpectation,
+  type VerifyResult,
+} from '../utils/post-verify';
+import {
   tryBlueskyApiPost,
   tryMastodonApiPost,
   tryMisskeyApiPost,
   type ApiPostingStrategy,
   type ApiPostingVisibility,
 } from './api-posting';
+import {
+  verifyBlueskyPost,
+  verifyDeviantArtPost,
+  verifyInstagramPost,
+  verifyMastodonPost,
+  verifyMisskeyPost,
+  verifyPixivPost,
+  verifyThreadsPost,
+  verifyTikTokPost,
+  verifyTumblrPost,
+  verifyXPost,
+  verifyYouTubePost,
+  type VerificationStrategy,
+} from './verify-dispatcher';
 
 export interface BackgroundPlatformStrategy {
   /** 投稿 URL から platform 固有の安定 post ID を抽出する。 */
@@ -16,6 +35,8 @@ export interface BackgroundPlatformStrategy {
   apiPost?: ApiPostingStrategy;
   /** 2 chunk 目以降を captured parent URL へ接続する compose URL 手続き。 */
   continuationUrl?: (previousPostUrl: string) => string | undefined;
+  /** 投稿後 URL と期待値を照合する verification 手続き。 */
+  verifyPost?: VerificationStrategy;
 }
 
 /**
@@ -29,14 +50,17 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       const statusId = previousPostUrl.match(/\/status\/(\d+)/)?.[1];
       return statusId ? `https://x.com/intent/post?in_reply_to=${statusId}` : undefined;
     },
+    verifyPost: verifyXPost,
   },
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryBlueskyApiPost,
+    verifyPost: verifyBlueskyPost,
   },
   threads: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([A-Za-z0-9_-]+)/)?.[1] ?? null,
     continuationUrl: (previousPostUrl) => previousPostUrl,
+    verifyPost: verifyThreadsPost,
   },
   mastodon: {
     parsePostId: ({ pathname }) => (
@@ -46,10 +70,12 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
     ),
     apiPost: tryMastodonApiPost,
     continuationUrl: (previousPostUrl) => previousPostUrl,
+    verifyPost: verifyMastodonPost,
   },
   misskey: {
     parsePostId: ({ pathname }) => pathname.match(/\/notes\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryMisskeyApiPost,
+    verifyPost: verifyMisskeyPost,
   },
   tumblr: {
     parsePostId: ({ pathname }) => (
@@ -57,9 +83,11 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? pathname.match(/^\/[^/]+\/(\d+)(?:\/|$)/)?.[1]
       ?? null
     ),
+    verifyPost: verifyTumblrPost,
   },
   pixiv: {
     parsePostId: ({ pathname }) => pathname.match(/\/artworks\/(\d+)/)?.[1] ?? null,
+    verifyPost: verifyPixivPost,
   },
   deviantart: {
     parsePostId: ({ pathname }) => (
@@ -67,12 +95,15 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? pathname.match(/\/art\/(\d+)\/?$/)?.[1]
       ?? null
     ),
+    verifyPost: verifyDeviantArtPost,
   },
   instagram: {
     parsePostId: ({ pathname }) => pathname.match(/\/(?:p|reel)\/([\w-]+)/)?.[1] ?? null,
+    verifyPost: verifyInstagramPost,
   },
   tiktok: {
     parsePostId: ({ pathname }) => pathname.match(/\/video\/(\d+)/)?.[1] ?? null,
+    verifyPost: verifyTikTokPost,
   },
   youtube: {
     parsePostId: (url) => {
@@ -85,6 +116,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       }
       return null;
     },
+    verifyPost: verifyYouTubePost,
   },
 };
 
@@ -129,4 +161,18 @@ export function buildReplyOverrideUrl(
 ): string | undefined {
   if (chunkIndex === 0 || !previousPostUrl) return undefined;
   return getBackgroundPlatformStrategy(platform).continuationUrl?.(previousPostUrl);
+}
+
+export function isVerifySupported(platform: PlatformId): boolean {
+  return getBackgroundPlatformStrategy(platform).verifyPost !== undefined;
+}
+
+export async function runVerify(
+  platform: PlatformId,
+  postUrl: string,
+  expected: VerifyExpectation,
+): Promise<VerifyResult> {
+  const strategy = getBackgroundPlatformStrategy(platform).verifyPost;
+  if (!strategy) return verifyError(`${platform}: verification strategy unavailable`);
+  return await strategy(postUrl, expected);
 }

--- a/src/background/verify-dispatcher.test.ts
+++ b/src/background/verify-dispatcher.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyBlueskyPost } from '../api/bluesky-verify';
+import { verifyMastodonPost } from '../api/mastodon-verify';
+import { verifyMisskeyPost } from '../api/misskey-verify';
+import {
+  cleanGenericDescription,
+  cleanInstagramDescription,
+  cleanThreadsDescription,
+  cleanXDescription,
+  cleanYouTubeDescription,
+  judgeInstagramImage,
+  judgeXImage,
+  verifyViaOg,
+} from '../utils/post-verify-og';
+import type { VerifyExpectation, VerifyResult } from '../utils/post-verify';
+import type { PlatformId } from '../types/platform';
+import { runVerify } from './platform-strategies';
+
+const mocks = vi.hoisted(() => {
+  const ok = (): VerifyResult => ({ verified: true, issues: [] });
+  return {
+    verifyBluesky: vi.fn(async () => ok()),
+    verifyMastodon: vi.fn(async () => ok()),
+    verifyMisskey: vi.fn(async () => ok()),
+    verifyViaOg: vi.fn(async () => ok()),
+  };
+});
+
+vi.mock('../api/bluesky-verify', () => ({
+  verifyBlueskyPost: mocks.verifyBluesky,
+}));
+
+vi.mock('../api/mastodon-verify', () => ({
+  verifyMastodonPost: mocks.verifyMastodon,
+}));
+
+vi.mock('../api/misskey-verify', () => ({
+  verifyMisskeyPost: mocks.verifyMisskey,
+}));
+
+vi.mock('../utils/post-verify-og', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../utils/post-verify-og')>(),
+  verifyViaOg: mocks.verifyViaOg,
+}));
+
+const expected: VerifyExpectation = {
+  text: 'hello',
+  hasImages: false,
+};
+
+describe('verification strategy routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('routes federated platforms to their public API verifiers', async () => {
+    await runVerify('bluesky', 'https://example.test/bluesky', expected);
+    await runVerify('mastodon', 'https://example.test/mastodon', expected);
+    await runVerify('misskey', 'https://example.test/misskey', expected);
+
+    expect(vi.mocked(verifyBlueskyPost)).toHaveBeenCalledOnce();
+    expect(vi.mocked(verifyMastodonPost)).toHaveBeenCalledOnce();
+    expect(vi.mocked(verifyMisskeyPost)).toHaveBeenCalledOnce();
+    expect(vi.mocked(verifyViaOg)).not.toHaveBeenCalled();
+  });
+
+  it('preserves each OG platform cleaner and image judge', async () => {
+    const cases: Array<[
+      PlatformId,
+      typeof cleanGenericDescription,
+      typeof judgeXImage | undefined,
+    ]> = [
+      ['x', cleanXDescription, judgeXImage],
+      ['instagram', cleanInstagramDescription, judgeInstagramImage],
+      ['threads', cleanThreadsDescription, undefined],
+      ['tumblr', cleanGenericDescription, undefined],
+      ['pixiv', cleanGenericDescription, undefined],
+      ['deviantart', cleanGenericDescription, undefined],
+      ['tiktok', cleanGenericDescription, undefined],
+      ['youtube', cleanYouTubeDescription, undefined],
+    ];
+
+    for (const [platform, cleanDescription, judgeImage] of cases) {
+      await runVerify(platform, `https://example.test/${platform}`, expected);
+      expect(vi.mocked(verifyViaOg)).toHaveBeenLastCalledWith(
+        `https://example.test/${platform}`,
+        expected,
+        { cleanDescription, judgeImage },
+      );
+    }
+
+    expect(vi.mocked(verifyViaOg)).toHaveBeenCalledTimes(cases.length);
+  });
+
+  it.each([
+    ['x', { ...expected }, true],
+    ['tiktok', { ...expected }, true],
+    ['threads', { ...expected, hasImages: true }, false],
+  ] as const)('preserves forced DOM fallback policy for %s', async (platform, expectation, withWarning) => {
+    vi.useFakeTimers();
+    vi.mocked(verifyViaOg).mockResolvedValueOnce({
+      verified: true,
+      issues: withWarning
+        ? [{ kind: 'caption-missing', message: 'warning', severity: 'warn' }]
+        : [],
+    });
+    const create = vi.fn(async () => ({ id: 42 }));
+    const sendMessage = vi.fn(async () => ({
+      type: 'VERIFY_POST_DOM_RESULT',
+      ogDescription: 'hello',
+      bodyExcerpt: 'hello',
+      ogImage: '',
+      hasImage: true,
+    }));
+    const remove = vi.fn(async () => undefined);
+    vi.stubGlobal('browser', { tabs: { create, sendMessage, remove } });
+
+    const pending = runVerify(platform, `https://example.test/${platform}`, expectation);
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toMatchObject({ verified: true });
+    expect(create).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledWith(42);
+  });
+});

--- a/src/background/verify-dispatcher.ts
+++ b/src/background/verify-dispatcher.ts
@@ -12,9 +12,9 @@
  */
 
 import type { PlatformId, VerifyPostDomResult } from '../messages';
-import { verifyBlueskyPost } from '../api/bluesky-verify';
-import { verifyMastodonPost } from '../api/mastodon-verify';
-import { verifyMisskeyPost } from '../api/misskey-verify';
+import { verifyBlueskyPost as verifyBlueskyViaApi } from '../api/bluesky-verify';
+import { verifyMastodonPost as verifyMastodonViaApi } from '../api/mastodon-verify';
+import { verifyMisskeyPost as verifyMisskeyViaApi } from '../api/misskey-verify';
 import {
   verifyViaOg,
   cleanInstagramDescription,
@@ -30,39 +30,116 @@ import { extractHttpUrls } from '../utils/text-urls';
 import { log } from '../utils/logger';
 import { retryTransientTabAction } from './tab-action-retry';
 
-export async function runVerify(
+export type VerificationStrategy = (
+  postUrl: string,
+  expected: VerifyExpectation,
+) => Promise<VerifyResult>;
+
+interface OgVerificationPolicy {
+  cleanDescription: (description: string) => string;
+  judgeImage?: (ogImage: string) => boolean;
+  forceDomFallback?: (initial: VerifyResult, expected: VerifyExpectation) => boolean;
+  resolveDomHasImages?: (
+    response: VerifyPostDomResult,
+    expected: VerifyExpectation,
+    ogImage: string,
+  ) => boolean;
+  acceptDomResult?: (result: VerifyResult) => boolean;
+}
+
+export const verifyBlueskyPost: VerificationStrategy = verifyBlueskyViaApi;
+export const verifyMastodonPost: VerificationStrategy = verifyMastodonViaApi;
+export const verifyMisskeyPost: VerificationStrategy = verifyMisskeyViaApi;
+
+export const verifyXPost: VerificationStrategy = (postUrl, expected) => verifyOgPost(
+  'x',
+  postUrl,
+  expected,
+  {
+    cleanDescription: cleanXDescription,
+    judgeImage: judgeXImage,
+    forceDomFallback: (initial) => initial.issues.length > 0,
+    acceptDomResult: (result) => result.issues.length === 0,
+  },
+);
+
+export const verifyInstagramPost: VerificationStrategy = (postUrl, expected) => verifyOgPost(
+  'instagram',
+  postUrl,
+  expected,
+  {
+    cleanDescription: cleanInstagramDescription,
+    judgeImage: judgeInstagramImage,
+  },
+);
+
+export const verifyThreadsPost: VerificationStrategy = (postUrl, expected) => verifyOgPost(
+  'threads',
+  postUrl,
+  expected,
+  {
+    cleanDescription: cleanThreadsDescription,
+    forceDomFallback: (_initial, expectation) => expectation.hasImages,
+    resolveDomHasImages: (response, expectation, ogImage) => (
+      expectation.hasImages && typeof response.hasImage === 'boolean'
+        ? response.hasImage
+        : !!ogImage
+    ),
+  },
+);
+
+export const verifyTumblrPost: VerificationStrategy = createGenericOgStrategy('tumblr');
+export const verifyPixivPost: VerificationStrategy = createGenericOgStrategy('pixiv');
+export const verifyDeviantArtPost: VerificationStrategy = createGenericOgStrategy('deviantart');
+
+export const verifyTikTokPost: VerificationStrategy = (postUrl, expected) => verifyOgPost(
+  'tiktok',
+  postUrl,
+  expected,
+  {
+    cleanDescription: cleanGenericDescription,
+    forceDomFallback: (initial) => initial.issues.length > 0,
+  },
+);
+
+export const verifyYouTubePost: VerificationStrategy = (postUrl, expected) => verifyOgPost(
+  'youtube',
+  postUrl,
+  expected,
+  { cleanDescription: cleanYouTubeDescription },
+);
+
+function createGenericOgStrategy(platform: PlatformId): VerificationStrategy {
+  return (postUrl, expected) => verifyOgPost(
+    platform,
+    postUrl,
+    expected,
+    { cleanDescription: cleanGenericDescription },
+  );
+}
+
+async function verifyOgPost(
   platform: PlatformId,
   postUrl: string,
   expected: VerifyExpectation,
+  policy: OgVerificationPolicy,
 ): Promise<VerifyResult> {
-  if (platform === 'bluesky') return verifyBlueskyPost(postUrl, expected);
-  if (platform === 'mastodon') return verifyMastodonPost(postUrl, expected);
-  if (platform === 'misskey') return verifyMisskeyPost(postUrl, expected);
-
   // og:meta tag verify (8 SNS 共通) — まず server-side fetch で試す
-  const cleaner =
-    platform === 'instagram' ? cleanInstagramDescription :
-    platform === 'threads' ? cleanThreadsDescription :
-    platform === 'x' ? cleanXDescription :
-    platform === 'youtube' ? cleanYouTubeDescription :
-    cleanGenericDescription;
-  const judgeImg =
-    platform === 'instagram' ? judgeInstagramImage :
-    platform === 'x' ? judgeXImage :
-    undefined;
-  const r1 = await verifyViaOg(postUrl, expected, { cleanDescription: cleaner, judgeImage: judgeImg });
+  const r1 = await verifyViaOg(postUrl, expected, {
+    cleanDescription: policy.cleanDescription,
+    judgeImage: policy.judgeImage,
+  });
   const needsDomFallback =
     !r1.verified ||
     r1.issues.some((issue) => issue.severity === 'error') ||
-    ((platform === 'x' || platform === 'tiktok') && r1.issues.length > 0) ||
-    (platform === 'threads' && expected.hasImages);
+    policy.forceDomFallback?.(r1, expected) === true;
   if (!needsDomFallback) return r1;
 
   // server-side fetch が失敗、 または public HTML が本文を省略した場合は DOM fallback。
   // X は未ログイン HTML を HTTP 200 で返すため、 verified=true でも caption-missing
   // になることがある。
   log.info(`${platform}: og fetch 不十分、 DOM verify に fallback`);
-  return await verifyViaDomTab(platform, postUrl, expected, cleaner, judgeImg);
+  return await verifyViaDomTab(platform, postUrl, expected, policy);
 }
 
 /**
@@ -73,8 +150,7 @@ async function verifyViaDomTab(
   platform: PlatformId,
   postUrl: string,
   expected: VerifyExpectation,
-  cleaner: (s: string) => string,
-  judgeImg: ((og: string) => boolean) | undefined,
+  policy: OgVerificationPolicy,
 ): Promise<VerifyResult> {
   let verifyTab: Browser.tabs.Tab | undefined;
   try {
@@ -98,10 +174,10 @@ async function verifyViaDomTab(
         const img = resp.ogImage ?? '';
         // public OG が一部だけ残る SNS がある。DOM fallback では body も結合し、
         // hydration 後の実本文を比較対象に含める。
-        const text = [cleaner(desc), resp.bodyExcerpt ?? ''].filter(Boolean).join('\n');
-        const hasImages = platform === 'threads' && expected.hasImages && typeof resp.hasImage === 'boolean'
-          ? resp.hasImage
-          : judgeImg ? judgeImg(img) : !!img;
+        const text = [policy.cleanDescription(desc), resp.bodyExcerpt ?? ''].filter(Boolean).join('\n');
+        const hasImages = policy.resolveDomHasImages
+          ? policy.resolveDomHasImages(resp, expected, img)
+          : policy.judgeImage ? policy.judgeImage(img) : !!img;
         const hasVideo = expected.hasVideo ? resp.hasVideo === true : undefined;
         latestResult = buildVerifyResult(expected, {
           text,
@@ -110,7 +186,7 @@ async function verifyViaDomTab(
           links: expected.expectedUrls?.length ? extractHttpUrls(text) : undefined,
         });
         const hasHardIssue = latestResult.issues.some((issue) => issue.severity === 'error');
-        if (!hasHardIssue && (platform !== 'x' || latestResult.issues.length === 0)) {
+        if (!hasHardIssue && (policy.acceptDomResult?.(latestResult) ?? true)) {
           return latestResult;
         }
       } catch { /* content script not ready yet */ }

--- a/src/utils/post-verify.ts
+++ b/src/utils/post-verify.ts
@@ -9,7 +9,6 @@
  * 自動検知して popup に warning として通知する。
  */
 
-import type { PlatformId } from '../types/platform';
 import { t } from './i18n';
 import { hasUrlEvidence } from './text-urls';
 
@@ -157,12 +156,4 @@ export function verifyError(reason: string): VerifyResult {
     verified: false,
     issues: [{ kind: 'verify-error', message: reason, severity: 'warn' }],
   };
-}
-
-/** verify 実装 registry を判定 (v0.4.76 で 11 SNS 全対応) */
-export function isVerifySupported(platform: PlatformId): boolean {
-  return [
-    'bluesky', 'mastodon', 'misskey',  // public API
-    'x', 'instagram', 'threads', 'tumblr', 'pixiv', 'deviantart', 'tiktok', 'youtube',  // og:meta
-  ].includes(platform);
 }


### PR DESCRIPTION
## Summary
- register one verifyPost procedure for every background platform strategy
- split public-API and platform-bound OG verification procedures without changing policies
- derive verification support and dispatch from registry membership
- remove the duplicated support array and platform-poster dispatcher dependency
- add API/OG routing plus X/TikTok/Threads DOM-fallback characterization

## Verification
- npm run verify:commit (82 files, 639 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- all 11 verify strategy entries asserted

Surface/CWS gate is not applicable for this merge: verification dispatch is behavior-preserving and no release upload is performed. Any future CWS artifact remains subject to the exact-artifact Surface gate.

Closes #50