### PR TITLE
refactor: register URL capture entry strategies

### DIFF
--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -45,6 +45,7 @@ vi.mock('./adapter-resolver', () => ({
 
 vi.mock('./platform-strategies', async (importOriginal) => ({
   ...await importOriginal<typeof import('./platform-strategies')>(),
+  capturePostUrlFromTabWithRetry: mocks.capturePostUrlFromTabWithRetry,
   runVerify: mocks.runVerify,
   tryApiPath: mocks.tryApiPath,
 }));
@@ -62,10 +63,6 @@ vi.mock('./media-preprocess', () => ({
 
 vi.mock('./platform-media', () => ({
   prepareMediaForPlatform: mocks.prepareMediaForPlatform,
-}));
-
-vi.mock('./post-url-capture', () => ({
-  capturePostUrlFromTabWithRetry: mocks.capturePostUrlFromTabWithRetry,
 }));
 
 vi.mock('./tab-action-retry', () => ({

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -18,12 +18,12 @@ import {
 } from './tab-management';
 import {
   buildReplyOverrideUrl,
+  capturePostUrlFromTabWithRetry,
   continuationNeedsReplyUrl,
   isVerifySupported,
   runVerify,
   tryApiPath,
 } from './platform-strategies';
-import { capturePostUrlFromTabWithRetry } from './post-url-capture';
 import {
   buildLoginRedirectErrorForUrl,
   buildMissingReceiverLoginError,

--- a/src/background/platform-strategies.test.ts
+++ b/src/background/platform-strategies.test.ts
@@ -5,6 +5,7 @@ import {
   buildReplyOverrideUrl,
   continuationNeedsReplyUrl,
   extractPostId,
+  isPostUrlCaptureSupported,
   isVerifySupported,
 } from './platform-strategies';
 
@@ -43,6 +44,13 @@ describe('background platform strategy registry', () => {
     for (const [platform, strategy] of Object.entries(backgroundPlatformStrategies)) {
       expect(strategy.verifyPost).toBeTypeOf('function');
       expect(isVerifySupported(platform as keyof typeof backgroundPlatformStrategies)).toBe(true);
+    }
+  });
+
+  it('registers URL capture for every current platform', () => {
+    for (const [platform, strategy] of Object.entries(backgroundPlatformStrategies)) {
+      expect(strategy.capturePostUrl).toBeTypeOf('function');
+      expect(isPostUrlCaptureSupported(platform as keyof typeof backgroundPlatformStrategies)).toBe(true);
     }
   });
 });

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -27,6 +27,14 @@ import {
   verifyYouTubePost,
   type VerificationStrategy,
 } from './verify-dispatcher';
+import {
+  capturePostUrlFromTabWithRetry as capturePostUrlWithGenericFlow,
+  type CapturePostUrlOptions,
+} from './post-url-capture';
+
+export type PostUrlCaptureStrategy = (
+  options: CapturePostUrlOptions,
+) => Promise<string | undefined>;
 
 export interface BackgroundPlatformStrategy {
   /** 投稿 URL から platform 固有の安定 post ID を抽出する。 */
@@ -37,6 +45,8 @@ export interface BackgroundPlatformStrategy {
   continuationUrl?: (previousPostUrl: string) => string | undefined;
   /** 投稿後 URL と期待値を照合する verification 手続き。 */
   verifyPost?: VerificationStrategy;
+  /** 投稿後に platform 固有の post URL を取得する手続き。 */
+  capturePostUrl?: PostUrlCaptureStrategy;
 }
 
 /**
@@ -51,16 +61,19 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       return statusId ? `https://x.com/intent/post?in_reply_to=${statusId}` : undefined;
     },
     verifyPost: verifyXPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryBlueskyApiPost,
     verifyPost: verifyBlueskyPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   threads: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([A-Za-z0-9_-]+)/)?.[1] ?? null,
     continuationUrl: (previousPostUrl) => previousPostUrl,
     verifyPost: verifyThreadsPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   mastodon: {
     parsePostId: ({ pathname }) => (
@@ -71,11 +84,13 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
     apiPost: tryMastodonApiPost,
     continuationUrl: (previousPostUrl) => previousPostUrl,
     verifyPost: verifyMastodonPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   misskey: {
     parsePostId: ({ pathname }) => pathname.match(/\/notes\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryMisskeyApiPost,
     verifyPost: verifyMisskeyPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   tumblr: {
     parsePostId: ({ pathname }) => (
@@ -84,10 +99,12 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? null
     ),
     verifyPost: verifyTumblrPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   pixiv: {
     parsePostId: ({ pathname }) => pathname.match(/\/artworks\/(\d+)/)?.[1] ?? null,
     verifyPost: verifyPixivPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   deviantart: {
     parsePostId: ({ pathname }) => (
@@ -96,14 +113,17 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? null
     ),
     verifyPost: verifyDeviantArtPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   instagram: {
     parsePostId: ({ pathname }) => pathname.match(/\/(?:p|reel)\/([\w-]+)/)?.[1] ?? null,
     verifyPost: verifyInstagramPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   tiktok: {
     parsePostId: ({ pathname }) => pathname.match(/\/video\/(\d+)/)?.[1] ?? null,
     verifyPost: verifyTikTokPost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
   youtube: {
     parsePostId: (url) => {
@@ -117,6 +137,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       return null;
     },
     verifyPost: verifyYouTubePost,
+    capturePostUrl: capturePostUrlWithGenericFlow,
   },
 };
 
@@ -175,4 +196,16 @@ export async function runVerify(
   const strategy = getBackgroundPlatformStrategy(platform).verifyPost;
   if (!strategy) return verifyError(`${platform}: verification strategy unavailable`);
   return await strategy(postUrl, expected);
+}
+
+export function isPostUrlCaptureSupported(platform: PlatformId): boolean {
+  return getBackgroundPlatformStrategy(platform).capturePostUrl !== undefined;
+}
+
+export async function capturePostUrlFromTabWithRetry(
+  options: CapturePostUrlOptions,
+): Promise<string | undefined> {
+  const strategy = getBackgroundPlatformStrategy(options.platform).capturePostUrl;
+  if (!strategy) return undefined;
+  return await strategy(options);
 }

--- a/src/background/post-url-capture.ts
+++ b/src/background/post-url-capture.ts
@@ -30,23 +30,7 @@ export type PostUrlCaptureScriptArgs = [
   minCapturedAt: number | null,
 ];
 
-const CAPTURE_SUPPORTED_PLATFORMS = new Set<PlatformId>([
-  'mastodon',
-  'misskey',
-  'bluesky',
-  'threads',
-  'tumblr',
-  'x',
-  'pixiv',
-  'deviantart',
-  'instagram',
-  'tiktok',
-  'youtube',
-]);
-
 export function buildPostUrlCaptureRetryPlan(platform: PlatformId): CapturePostUrlRetryStep[] {
-  if (!CAPTURE_SUPPORTED_PLATFORMS.has(platform)) return [];
-
   const steps: CapturePostUrlRetryStep[] = [{ label: 'immediate', delayMs: 0 }];
   if (platform === 'youtube') {
     return [
@@ -171,8 +155,6 @@ export async function capturePostUrlFromTab(options: CapturePostUrlOptions): Pro
     onDebug,
     frameRetry = 0,
   } = options;
-  if (!CAPTURE_SUPPORTED_PLATFORMS.has(platform)) return undefined;
-
   const dbg = (message: string): void => {
     onDebug?.(`[capturePostUrl ${platform}] ${message}`);
   };


### PR DESCRIPTION
## Summary
- register URL capture entry procedures for all 11 background platform strategies
- derive capture support from optional registry membership
- remove CAPTURE_SUPPORTED_PLATFORMS and redundant guards
- route platform-poster through registry dispatch while leaving all internal capture procedures and retry plans unchanged

## Verification
- npm run verify:commit (82 files, 640 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- existing retry-plan/capture helper and transport-boundary tests PASS

Surface/CWS gate is not applicable for this merge: only support dispatch ownership changed and no release upload occurred. Any future CWS upload remains subject to the exact-artifact Surface gate.

Closes #52