### PR TITLE
refactor: consolidate platform data collections

### DIFF
--- a/src/adapters/instagram.ts
+++ b/src/adapters/instagram.ts
@@ -26,6 +26,7 @@ export const instagramAdapter: PlatformAdapter = {
   charLimit: 2200,
   popupOrder: 9,
   defaultSelected: false,
+  preferredVideoAspect: '9:16',
   matchUrl: (url) => /^https:\/\/(www\.)?instagram\.com\//.test(url),
   // home から Create ボタンを click する flow なので、compose URL は home に
   getComposeUrl: () => 'https://www.instagram.com/',

--- a/src/adapters/tiktok.ts
+++ b/src/adapters/tiktok.ts
@@ -23,6 +23,7 @@ export const tiktokAdapter: PlatformAdapter = {
   charLimit: 2200,
   popupOrder: 10,
   defaultSelected: false,
+  preferredVideoAspect: '9:16',
   matchUrl: (url) => /^https:\/\/(www\.)?tiktok\.com\//.test(url),
   getComposeUrl: () => 'https://www.tiktok.com/tiktokstudio/upload',
   getLoginUrl: () => 'https://www.tiktok.com/',

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -59,6 +59,8 @@ export interface PlatformAdapter {
   previewLane?: 'foreground';
   /** 投稿操作前の compose page load timeout に対する宣言policy */
   preSubmitLoad?: PreSubmitLoadPolicy;
+  /** 動画投稿で優先する表示aspect。未指定なら原寸を維持する */
+  preferredVideoAspect?: '9:16';
   /** 投稿ページとして扱う URL パターン(content script の matches と整合させる) */
   matchUrl: (url: string) => boolean;
   /** 投稿用に開くべき URL を返す。URL pre-fill する SNS では text を URL に乗せる */

--- a/src/adapters/youtube.ts
+++ b/src/adapters/youtube.ts
@@ -28,6 +28,7 @@ export const youtubeAdapter: PlatformAdapter = {
   charLimit: 5000,
   popupOrder: 11,
   defaultSelected: false,
+  preferredVideoAspect: '9:16',
   // studio.youtube.com / m.youtube.com / www.youtube.com
   matchUrl: (url) => /^https:\/\/((www|m|studio)\.)?youtube\.com\//.test(url),
   getComposeUrl: () => 'https://studio.youtube.com/',

--- a/src/background/media-preprocess.test.ts
+++ b/src/background/media-preprocess.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { adapters } from '../adapters/registry';
 import {
+  needsVerticalLetterboxForPlatforms,
   needsVideoCodecTranscodeForPlatforms,
   resolveSafeVideoTargetBytes,
   shouldNormalizeVideoForSafePosting,
@@ -32,6 +34,16 @@ describe('video preprocessing budget', () => {
   it('transcodes when trimming or vertical letterboxing is requested', () => {
     expect(shouldTranscodeVideoForBudget(1, Infinity, false, true)).toBe(true);
     expect(shouldTranscodeVideoForBudget(1, Infinity, true, false)).toBe(true);
+  });
+
+  it('derives vertical letterboxing from adapter aspect policy', () => {
+    expect(Object.entries(adapters)
+      .filter(([, adapter]) => adapter?.preferredVideoAspect === '9:16')
+      .map(([platform]) => platform)).toEqual(['instagram', 'tiktok', 'youtube']);
+    expect(needsVerticalLetterboxForPlatforms(['instagram'])).toBe(true);
+    expect(needsVerticalLetterboxForPlatforms(['tiktok'])).toBe(true);
+    expect(needsVerticalLetterboxForPlatforms(['youtube'])).toBe(true);
+    expect(needsVerticalLetterboxForPlatforms(['x', 'bluesky', 'tumblr'])).toBe(false);
   });
 
   it('transcodes HEVC videos for Bluesky even when size is within budget', () => {

--- a/src/background/media-preprocess.ts
+++ b/src/background/media-preprocess.ts
@@ -45,6 +45,12 @@ export function shouldNormalizeVideoForSafePosting(video: ImageAttachment): bool
   return video.type.startsWith('video/');
 }
 
+export function needsVerticalLetterboxForPlatforms(
+  platforms: readonly PlatformId[],
+): boolean {
+  return platforms.some((platform) => getAdapter(platform)?.preferredVideoAspect === '9:16');
+}
+
 export function needsVideoCodecTranscodeForPlatforms(
   platforms: readonly PlatformId[],
   video: ImageAttachment,
@@ -117,9 +123,8 @@ export async function maybeCompressVideoForBudget(
   // (TikTok / YouTube Shorts / IG Reels) が含まれる場合は **size が範囲内でも
   // 9:16 letterbox のため再エンコードする**。
   const { autoLetterboxVerticalVideo } = await getSettings();
-  const verticalSns: PlatformId[] = ['tiktok', 'youtube', 'instagram'];
   const needsVerticalLetterbox =
-    autoLetterboxVerticalVideo && platforms.some((p) => verticalSns.includes(p));
+    autoLetterboxVerticalVideo && needsVerticalLetterboxForPlatforms(platforms);
 
   // v0.4.90: trim opt-in
   const needsTrim = !!(trimToSeconds && trimToSeconds > 0 && (video.durationS ?? 0) > trimToSeconds);

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,13 +1,16 @@
-/** Tutti が投稿・診断・履歴で識別する platform ID。 */
-export type PlatformId =
-  | 'x'
-  | 'bluesky'
-  | 'threads'
-  | 'mastodon'
-  | 'misskey'
-  | 'tumblr'
-  | 'pixiv'
-  | 'deviantart'
-  | 'instagram'
-  | 'tiktok'
-  | 'youtube';
+/** Tutti が投稿・診断・履歴で識別する platform ID の canonical tuple。 */
+export const PLATFORM_IDS = [
+  'x',
+  'bluesky',
+  'threads',
+  'mastodon',
+  'misskey',
+  'tumblr',
+  'pixiv',
+  'deviantart',
+  'instagram',
+  'tiktok',
+  'youtube',
+] as const;
+
+export type PlatformId = (typeof PLATFORM_IDS)[number];

--- a/src/utils/message-decoder.test.ts
+++ b/src/utils/message-decoder.test.ts
@@ -3,7 +3,24 @@ import postRequestFixture from '../fixtures/messages/post-request-additive.json'
 import postResultFixture from '../fixtures/messages/post-result-additive.json';
 import postToPlatformFixture from '../fixtures/messages/post-to-platform-additive.json';
 import type { Message, PostResultMessage } from '../messages';
+import { PLATFORM_IDS } from '../types/platform';
 import { decodeMessage, decodeMessageWithDiagnostics } from './message-decoder';
+
+it('keeps the canonical runtime platform ID vocabulary stable', () => {
+  expect(PLATFORM_IDS).toEqual([
+    'x',
+    'bluesky',
+    'threads',
+    'mastodon',
+    'misskey',
+    'tumblr',
+    'pixiv',
+    'deviantart',
+    'instagram',
+    'tiktok',
+    'youtube',
+  ]);
+});
 
 const postResult: PostResultMessage = {
   type: 'POST_RESULT',

--- a/src/utils/message-decoder.ts
+++ b/src/utils/message-decoder.ts
@@ -1,28 +1,16 @@
 import type {
   ImageAttachment,
   Message,
-  PlatformId,
   PostRequestIntent,
   PostResultMessage,
 } from '../messages';
+import { PLATFORM_IDS, type PlatformId } from '../types/platform';
 import { createPostRequestId } from './post-request-id';
 
 type UnknownRecord = Record<string, unknown>;
 type Validator = (value: UnknownRecord) => boolean;
 
-const PLATFORM_IDS = new Set<PlatformId>([
-  'x',
-  'bluesky',
-  'threads',
-  'mastodon',
-  'misskey',
-  'tumblr',
-  'pixiv',
-  'deviantart',
-  'instagram',
-  'tiktok',
-  'youtube',
-]);
+const PLATFORM_ID_SET = new Set<string>(PLATFORM_IDS);
 
 const VISIBILITIES = new Set(['public', 'unlisted', 'private', 'direct']);
 const USER_ACTIONS = new Set([
@@ -272,7 +260,7 @@ function isPostRequestIntent(value: unknown): value is PostRequestIntent {
 }
 
 function isPlatformId(value: unknown): value is PlatformId {
-  return isString(value) && PLATFORM_IDS.has(value as PlatformId);
+  return isString(value) && PLATFORM_ID_SET.has(value);
 }
 
 function isStringArray(value: unknown): value is string[] {


### PR DESCRIPTION
## Summary
- define one canonical runtime PLATFORM_IDS tuple and derive PlatformId from it
- derive message-decoder membership from that tuple
- move Instagram/TikTok/YouTube vertical aspect preference into adapter metadata
- derive media letterbox policy from adapters instead of a local platform array

## Verification
- npm run verify:commit (82 files, 642 tests, production build PASS)
- npm run e2e:smoke:no-build (runtime, popup, Mastodon simple flow, Instagram wizard PASS)
- canonical 11-ID vocabulary and exact three vertical adapters asserted

Surface/CWS gate is not applicable: this preserves validator and video policy behavior without changing media algorithms, posting, URLs, selectors, or release state. No upload or submission performed.

Closes #54