### PR TITLE
test: align platform matrix with adapters

### DIFF
--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -1,15 +1,17 @@
 # Platform support matrix
 
-The **single source of truth** for the 11 networks Tutti supports.
-Treat this as the authoritative current state so that README / CWS listing /
-adapter code stay consistent.
+This document is the **single source of truth for real-post verification
+state** across the 11 networks Tutti supports. Executable content-kind and
+media constraints use `src/adapters/<id>.ts` as their source of truth; tests
+keep the corresponding tables below aligned with those adapters.
 
-Look here (not at each `src/adapters/<id>.ts`) to know "what works, and
-what hasn't been verified with a real post yet".
+Look here to know what the adapters support and what has not yet been verified
+with a real post.
 
-> Update rule: when adding an adapter / changing a constraint / moving
-> verification state, **update this file first**. README / CWS listing
-> etc. reference this.
+> Update rule: change executable support or constraints in the adapter first
+> and update the reflected table in the same change. Update real-post
+> verification state in this document first. README / CWS listing etc.
+> reference this.
 
 ## Legend
 
@@ -27,7 +29,7 @@ what hasn't been verified with a real post yet".
 | network | text | image | shortVideo | longVideo | path | multi-step | fg tab | API |
 |---|:---:|:---:|:---:|:---:|---|:---:|:---:|:---:|
 | X | ✅ | ✅ | ✅ | ✅ | DOM | — | — | — |
-| Bluesky | ✅ | ✅ | ✅ | — | DOM + API | — | — | ✅ |
+| Bluesky | ✅ | ✅ | ✅ | ✅ | DOM + API | — | — | ✅ |
 | Threads | ✅ | ✅ | ✅ | ✅ | DOM | — | — | — |
 | Mastodon | ✅ | ✅ | ✅ | ✅ | DOM + API | — | — | ✅ |
 | Misskey | ✅ | ✅ | ✅ | ✅ | DOM + API | — | — | ✅ |
@@ -38,21 +40,21 @@ what hasn't been verified with a real post yet".
 | Instagram | — | ⚠️ | ⚠️ | — | DOM | ✅ | ✅ | — |
 | DeviantArt | — | ⚠️ | — | — | DOM | ✅ | ✅ | — |
 
-## Posting constraints (extracted from adapter code, as of 2026-05-13)
+## Posting constraints (extracted from adapter code, as of 2026-07-27)
 
 | network | charLimit | maxImages | maxBytesPerImage | maxBytes (video) | maxDurationS |
 |---|---:|---:|---:|---:|---:|
-| X | 280 | 4 | 5 MB | 512 MB | unlimited |
-| Bluesky | 300 | 4 | 1 MB | 80 MiB | 60 |
-| Threads | 500 | 10 | 8 MB | 1 GB | unlimited |
-| Mastodon (mastodon.social) | 500 | 4 | 8 MB | 40 MB | unlimited |
-| Misskey (misskey.io) | 3000 | 16 | 100 MB | 100 MB | unlimited |
-| Tumblr | 4096 | 10 | 10 MB | 100 MB | unlimited |
-| Pixiv | 1000 (caption) | 200 | 30 MB | — | — |
-| TikTok | 2200 (caption) | — | — | 287 MB | 180 |
-| YouTube (Shorts) | 5000 (description) | — | — | 2 GB | 60 |
-| Instagram | 2200 (caption) | 10 | 30 MB | 100 MB | 60 |
-| DeviantArt | 5000 | 1 | 30 MB | — | — |
+| X | 280 | 4 | 5 MiB | 512 MiB | 140 |
+| Bluesky | 300 | 4 | 2,000,000 bytes | 80 MiB | 180 |
+| Threads | 500 | 10 | 8 MiB | 1 GiB | 300 |
+| Mastodon (mastodon.social) | 500 | 4 | 8 MiB | 40 MiB | unlimited |
+| Misskey (misskey.io) | 3000 | 16 | 100 MiB | 100 MiB | unlimited |
+| Tumblr | 4096 | 10 | 10 MiB | 100 MiB | unlimited |
+| Pixiv | 1000 (caption) | 200 | 32 MiB | — | — |
+| TikTok | 2200 (caption) | — | — | 287 MiB | 180 |
+| YouTube (Shorts) | 5000 (description) | — | — | 2 GiB | 60 |
+| Instagram | 2200 (caption) | 10 | 30 MiB | 100 MiB | 60 |
+| DeviantArt | 5000 | 1 | 30 MiB | — | — |
 
 - "unlimited" means **the client does not check duration**. The SNS may
   still reject server-side (the SNS UI error is surfaced to the popup).

--- a/src/adapters/capabilities.test.ts
+++ b/src/adapters/capabilities.test.ts
@@ -1,53 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import type { PlatformId } from '../types/platform';
-import type { ContentKind } from './types';
 import { adapters, checkVideoConstraint } from './registry';
+import type { PlatformAdapter } from './types';
 
-const EXPECTED_KINDS: Record<PlatformId, ContentKind[]> = {
-  x: ['text', 'image', 'shortVideo', 'longVideo'],
-  bluesky: ['text', 'image', 'shortVideo', 'longVideo'],
-  threads: ['text', 'image', 'shortVideo', 'longVideo'],
-  mastodon: ['text', 'image', 'shortVideo', 'longVideo'],
-  misskey: ['text', 'image', 'shortVideo', 'longVideo'],
-  tumblr: ['text', 'image', 'shortVideo', 'longVideo'],
-  pixiv: ['image'],
-  deviantart: ['image'],
-  instagram: ['image', 'shortVideo'],
-  tiktok: ['shortVideo'],
-  youtube: ['shortVideo'],
-};
+const REGISTERED_ADAPTERS = Object.values(adapters)
+  .filter((adapter): adapter is PlatformAdapter => adapter !== undefined);
 
-const SHORT_VIDEO_PLATFORMS = Object.entries(EXPECTED_KINDS)
-  .filter(([, kinds]) => kinds.includes('shortVideo'))
-  .map(([platform]) => platform as PlatformId);
+const VIDEO_ADAPTERS = REGISTERED_ADAPTERS
+  .filter((adapter) => adapter.kinds.includes('shortVideo') || adapter.kinds.includes('longVideo'));
 
-const IMAGE_ONLY_PLATFORMS = Object.entries(EXPECTED_KINDS)
-  .filter(([, kinds]) => !kinds.includes('shortVideo') && !kinds.includes('longVideo'))
-  .map(([platform]) => platform as PlatformId);
+const IMAGE_ONLY_ADAPTERS = REGISTERED_ADAPTERS
+  .filter((adapter) => !adapter.kinds.includes('shortVideo') && !adapter.kinds.includes('longVideo'));
 
 describe('adapter capability matrix', () => {
-  it('keeps public content-kind support stable', () => {
-    for (const [platform, expectedKinds] of Object.entries(EXPECTED_KINDS) as Array<[PlatformId, ContentKind[]]>) {
-      expect(adapters[platform]?.kinds, platform).toEqual(expectedKinds);
+  it('declares at least one unique content kind for every adapter', () => {
+    for (const adapter of REGISTERED_ADAPTERS) {
+      expect(adapter.kinds.length, adapter.id).toBeGreaterThan(0);
+      expect(new Set(adapter.kinds).size, adapter.id).toBe(adapter.kinds.length);
     }
   });
 
   it('keeps video constraints present only for video-capable platforms', () => {
-    for (const [platform, expectedKinds] of Object.entries(EXPECTED_KINDS) as Array<[PlatformId, ContentKind[]]>) {
-      const supportsVideo = expectedKinds.includes('shortVideo') || expectedKinds.includes('longVideo');
-      expect(!!adapters[platform]?.videoConstraints, platform).toBe(supportsVideo);
+    for (const adapter of REGISTERED_ADAPTERS) {
+      const supportsVideo = adapter.kinds.includes('shortVideo') || adapter.kinds.includes('longVideo');
+      expect(!!adapter.videoConstraints, adapter.id).toBe(supportsVideo);
     }
   });
 
   it('accepts a normal 30s video on every video-capable platform', () => {
-    for (const platform of SHORT_VIDEO_PLATFORMS) {
-      expect(checkVideoConstraint(platform, 30, 10 * 1024 * 1024), platform).toBeNull();
+    for (const adapter of VIDEO_ADAPTERS) {
+      expect(checkVideoConstraint(adapter.id, 30, 10 * 1024 * 1024), adapter.id).toBeNull();
     }
   });
 
   it('rejects video on image-only platforms', () => {
-    for (const platform of IMAGE_ONLY_PLATFORMS) {
-      expect(checkVideoConstraint(platform, 30, 10 * 1024 * 1024), platform).toContain('未対応');
+    for (const adapter of IMAGE_ONLY_ADAPTERS) {
+      expect(checkVideoConstraint(adapter.id, 30, 10 * 1024 * 1024), adapter.id).toContain('未対応');
     }
   });
 });

--- a/src/adapters/platform-matrix.test.ts
+++ b/src/adapters/platform-matrix.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { adapters } from './registry';
+import type { ContentKind, PlatformAdapter } from './types';
+
+const PLATFORM_MATRIX = readFileSync(
+  new URL('../../docs/platform-matrix.md', import.meta.url),
+  'utf8',
+);
+
+const REGISTERED_ADAPTERS = Object.values(adapters)
+  .filter((adapter): adapter is PlatformAdapter => adapter !== undefined);
+
+const KIND_COLUMNS: Array<[ContentKind, number]> = [
+  ['text', 1],
+  ['image', 2],
+  ['shortVideo', 3],
+  ['longVideo', 4],
+];
+
+function parseTable(heading: string): string[][] {
+  const headingStart = PLATFORM_MATRIX.indexOf(`## ${heading}`);
+  if (headingStart < 0) throw new Error(`Missing platform matrix section: ${heading}`);
+
+  const section = PLATFORM_MATRIX.slice(headingStart).split(/\n## /, 1)[0] ?? '';
+  return section
+    .split(/\r?\n/)
+    .filter((line) => /^\|.+\|$/.test(line))
+    .map((line) => line.slice(1, -1).split('|').map((cell) => cell.trim()))
+    .filter((cells) => cells[0] !== 'network' && !/^[-:]+$/.test(cells[0] ?? ''));
+}
+
+function adapterForDocName(docName: string): PlatformAdapter {
+  const adapterName = docName.replace(/\s+\([^)]*\)$/, '');
+  const matches = REGISTERED_ADAPTERS.filter((adapter) => adapter.name === adapterName);
+  if (matches.length !== 1) {
+    throw new Error(`Expected one adapter for docs row "${docName}", found ${matches.length}`);
+  }
+  return matches[0] as PlatformAdapter;
+}
+
+function expectCompletePlatformRows(rows: string[][]): void {
+  const docIds = rows.map((row) => adapterForDocName(getCell(row, 0)).id).sort();
+  const adapterIds = REGISTERED_ADAPTERS.map((adapter) => adapter.id).sort();
+  expect(docIds).toEqual(adapterIds);
+}
+
+function getCell(row: string[], index: number): string {
+  const cell = row[index];
+  if (cell === undefined) throw new Error(`Missing column ${index} in docs row: ${row.join(' | ')}`);
+  return cell;
+}
+
+function parseInteger(cell: string): number {
+  const match = cell.match(/^([\d,]+)/);
+  if (!match) throw new Error(`Expected integer value, got "${cell}"`);
+  return Number((match[1] as string).replaceAll(',', ''));
+}
+
+function parseBytes(cell: string): number {
+  const match = cell.match(/^([\d,]+)\s+(bytes|MiB|GiB)$/);
+  if (!match) throw new Error(`Expected exact byte value, got "${cell}"`);
+
+  const value = Number((match[1] as string).replaceAll(',', ''));
+  const unit = match[2];
+  if (unit === 'MiB') return value * 1024 * 1024;
+  if (unit === 'GiB') return value * 1024 * 1024 * 1024;
+  return value;
+}
+
+function parseDuration(cell: string): number {
+  return cell === 'unlimited' ? 0 : parseInteger(cell);
+}
+
+describe('docs platform matrix', () => {
+  it('reflects adapter content-kind support for every registered platform', () => {
+    const rows = parseTable('Overall matrix');
+    expectCompletePlatformRows(rows);
+
+    for (const row of rows) {
+      const adapter = adapterForDocName(getCell(row, 0));
+      const documentedKinds = KIND_COLUMNS
+        .filter(([, column]) => getCell(row, column) !== '—')
+        .map(([kind]) => kind);
+      expect(documentedKinds, adapter.id).toEqual(adapter.kinds);
+    }
+  });
+
+  it('reflects adapter posting constraints for every registered platform', () => {
+    const rows = parseTable('Posting constraints');
+    expectCompletePlatformRows(rows);
+
+    for (const row of rows) {
+      const adapter = adapterForDocName(getCell(row, 0));
+      const charLimit = getCell(row, 1);
+      const maxImages = getCell(row, 2);
+      const maxBytesPerImage = getCell(row, 3);
+      const maxVideoBytes = getCell(row, 4);
+      const maxDuration = getCell(row, 5);
+
+      expect(parseInteger(charLimit), `${adapter.id} charLimit`).toBe(adapter.charLimit);
+
+      if (adapter.kinds.includes('image')) {
+        expect(parseInteger(maxImages), `${adapter.id} maxImages`).toBe(adapter.imageConstraints.maxImages);
+        expect(parseBytes(maxBytesPerImage), `${adapter.id} maxBytesPerImage`)
+          .toBe(adapter.imageConstraints.maxBytesPerImage);
+      } else {
+        expect(maxImages, `${adapter.id} maxImages`).toBe('—');
+        expect(maxBytesPerImage, `${adapter.id} maxBytesPerImage`).toBe('—');
+      }
+
+      if (adapter.videoConstraints) {
+        expect(parseBytes(maxVideoBytes), `${adapter.id} video maxBytes`)
+          .toBe(adapter.videoConstraints.maxBytes);
+        expect(parseDuration(maxDuration), `${adapter.id} video maxDurationS`)
+          .toBe(adapter.videoConstraints.maxDurationS);
+      } else {
+        expect(maxVideoBytes, `${adapter.id} video maxBytes`).toBe('—');
+        expect(maxDuration, `${adapter.id} video maxDurationS`).toBe('—');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- define docs/adapter source-of-truth boundaries explicitly
- compare all documented content kinds and posting constraints with registered adapters
- remove duplicated platform-keyed capability fixture in favor of registry-derived invariants
- synchronize stale Bluesky, X, Threads, and media byte-limit rows with executable values

## Verification

- `npm run verify:commit` (84 files / 647 tests, compile and production build PASS)
- Surface gate not required: docs and tests only; extension runtime output is unchanged

Closes #58
Parent: #12 Phase 2