### PR TITLE
refactor: finish platform poster strategies

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -28,40 +28,7 @@ const GUARDED_ORCHESTRATORS = [
 const PLATFORM_LITERAL_ALLOWLIST: Partial<Record<
   (typeof GUARDED_ORCHESTRATORS)[number],
   LiteralAllowance[]
->> = {
-  'src/background/platform-poster.ts': [
-    {
-      line: "const useInlineThread = adapter.id === 'bluesky' || (adapter.id === 'x' && !autoPost);",
-      reason: 'Inline multi-chunk compose is an existing background strategy procedure.',
-      owner: 'Issue #12 Phase 2 strategy migration',
-      removalPhase: 'Phase 2 before closure',
-    },
-    {
-      line: "const canUseApiWithReplyUrl = adapter.id === 'mastodon' && !!replyToUrl;",
-      reason: 'Mastodon API continuation capability still needs a strategy-owned predicate.',
-      owner: 'Issue #12 Phase 2 strategy migration',
-      removalPhase: 'Phase 2 before closure',
-    },
-    {
-      line: "if (adapter.id === 'tumblr' && hasVideo) return 'https://www.tumblr.com/new/video';",
-      reason: 'Tumblr media-specific compose URL still needs a strategy-owned resolver.',
-      owner: 'Issue #12 Phase 2 strategy migration',
-      removalPhase: 'Phase 2 before closure',
-    },
-    {
-      line: "adapter.id === 'x' && dryRun && !!textChunks && textChunks.length > 1;",
-      reason: 'X inline-thread preview focus still needs a strategy-owned predicate.',
-      owner: 'Issue #12 Phase 2 strategy migration',
-      removalPhase: 'Phase 2 before closure',
-    },
-    {
-      line: "const expectedUrls = platform === 'tumblr' ? extractHttpUrls(chunkText) : [];",
-      reason: 'Tumblr verification URL expectation still needs a strategy-owned builder.',
-      owner: 'Issue #12 Phase 2 strategy migration',
-      removalPhase: 'Phase 2 before closure',
-    },
-  ],
-};
+>> = {};
 
 const PLATFORM_COLLECTION_PATTERNS = [
   {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -17,11 +17,16 @@ import {
   type OpenOrFocusTabOptions,
 } from './tab-management';
 import {
+  buildExpectedUrlsForVerification,
   buildReplyOverrideUrl,
+  canUseApiWithReplyUrl,
   capturePostUrlFromTabWithRetry,
   continuationNeedsReplyUrl,
   isVerifySupported,
+  resolveComposeUrlForMedia,
   runVerify,
+  shouldForceInlineThreadPreviewForeground,
+  shouldUseInlineThread,
   tryApiPath,
 } from './platform-strategies';
 import {
@@ -37,7 +42,6 @@ import { downgradeHardVerifyFailures, toPreviewResult } from './post-result-poli
 import type { OpenedTabRegistry } from './opened-tab-registry';
 import { retryTransientTabAction } from './tab-action-retry';
 import type { VerifyExpectation } from '../utils/post-verify';
-import { extractHttpUrls } from '../utils/text-urls';
 
 const CHUNK_INTERVAL_MS = 2000;
 
@@ -99,9 +103,7 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
 
     const chunks = splitTextForPlatform(adapter.id, text, adapter.charLimit);
 
-    // X autoPost needs URL-confirmed reply chaining; preview keeps inline compose.
-    const useInlineThread = adapter.id === 'bluesky' || (adapter.id === 'x' && !autoPost);
-    if (useInlineThread && chunks.length > 1) {
+    if (shouldUseInlineThread(adapter.id, autoPost) && chunks.length > 1) {
       return await postSingleChunkInlineThread(adapter, chunks, images, autoPost);
     }
 
@@ -277,8 +279,12 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
       lastCompletedStep: 'preflight',
     };
 
-    const canUseApiWithReplyUrl = adapter.id === 'mastodon' && !!replyToUrl;
-    if (autoPost && (!overrideUrl || canUseApiWithReplyUrl) && !textChunks && !attempt.skipApi) {
+    if (
+      autoPost
+      && (!overrideUrl || canUseApiWithReplyUrl(adapter.id, replyToUrl))
+      && !textChunks
+      && !attempt.skipApi
+    ) {
       const apiResult = await tryApiPath(adapter.id, text, images, cw, visibility, replyToUrl);
       const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, baseFlow);
       if (apiOutcome) {
@@ -578,9 +584,7 @@ export function getComposeUrlForMedia(
   text: string,
   images?: readonly ImageAttachment[],
 ): string {
-  const hasVideo = images?.some((image) => image.type.startsWith('video/')) === true;
-  if (adapter.id === 'tumblr' && hasVideo) return 'https://www.tumblr.com/new/video';
-  return adapter.getComposeUrl(text);
+  return resolveComposeUrlForMedia(adapter.id, adapter.getComposeUrl(text), images);
 }
 
 export function resolvePreSubmitLoadOptions(
@@ -603,9 +607,9 @@ export function shouldOpenActive(
 ): boolean {
   if (forceForeground) return true;
   if (autoPost) return true;
-  const forceForegroundForXThreadPreview =
-    adapter.id === 'x' && dryRun && !!textChunks && textChunks.length > 1;
-  return adapter.requiresForegroundTab === true || forceForegroundForXThreadPreview;
+  const forceForegroundForThreadPreview =
+    shouldForceInlineThreadPreviewForeground(adapter.id, dryRun, textChunks);
+  return adapter.requiresForegroundTab === true || forceForegroundForThreadPreview;
 }
 
 export function buildDomPostAttempts(
@@ -718,7 +722,7 @@ export function buildVerifyExpectationForChunk(
 ): VerifyExpectation {
   const chunkText = chunks.length > 1 ? chunks[chunkIndex] ?? chunks[chunks.length - 1] ?? text : text;
   const mediaBelongsToThisChunk = chunks.length <= 1 || chunkIndex === 0;
-  const expectedUrls = platform === 'tumblr' ? extractHttpUrls(chunkText) : [];
+  const expectedUrls = buildExpectedUrlsForVerification(platform, chunkText);
   return {
     text: chunkText,
     hasImages: mediaBelongsToThisChunk && !!images?.some((image) => image.type.startsWith('image/')),

--- a/src/background/platform-strategies.test.ts
+++ b/src/background/platform-strategies.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { adapters } from '../adapters/registry';
 import {
   backgroundPlatformStrategies,
+  buildExpectedUrlsForVerification,
   buildReplyOverrideUrl,
+  canUseApiWithReplyUrl,
   continuationNeedsReplyUrl,
   extractPostId,
   isPostUrlCaptureSupported,
   isVerifySupported,
+  resolveComposeUrlForMedia,
+  shouldForceInlineThreadPreviewForeground,
+  shouldUseInlineThread,
 } from './platform-strategies';
 
 describe('background platform strategy registry', () => {
@@ -38,6 +43,33 @@ describe('background platform strategy registry', () => {
     expect(buildReplyOverrideUrl('x', 0, 'https://x.com/alice/status/123456')).toBeUndefined();
     expect(buildReplyOverrideUrl('bluesky', 1, 'https://bsky.app/profile/alice/post/abc')).toBeUndefined();
     expect(buildReplyOverrideUrl('x', 1, 'https://x.com/home')).toBeUndefined();
+  });
+
+  it('derives inline thread and API reply continuation policy from strategies', () => {
+    expect(shouldUseInlineThread('bluesky', true)).toBe(true);
+    expect(shouldUseInlineThread('x', false)).toBe(true);
+    expect(shouldUseInlineThread('x', true)).toBe(false);
+    expect(shouldUseInlineThread('threads', false)).toBe(false);
+
+    expect(canUseApiWithReplyUrl('mastodon', 'https://mastodon.social/@alice/123')).toBe(true);
+    expect(canUseApiWithReplyUrl('mastodon', undefined)).toBe(false);
+    expect(canUseApiWithReplyUrl('bluesky', 'https://bsky.app/profile/alice/post/abc')).toBe(false);
+  });
+
+  it('derives compose, preview foreground, and verify expectation policy from strategies', () => {
+    const video = [{ name: 'clip.mp4', type: 'video/mp4', data: 'AA==' }];
+    expect(resolveComposeUrlForMedia('tumblr', 'https://www.tumblr.com/new/text', video))
+      .toBe('https://www.tumblr.com/new/video');
+    expect(resolveComposeUrlForMedia('x', 'https://x.com/compose/post', video))
+      .toBe('https://x.com/compose/post');
+
+    expect(shouldForceInlineThreadPreviewForeground('x', true, ['first', 'second'])).toBe(true);
+    expect(shouldForceInlineThreadPreviewForeground('x', false, ['first', 'second'])).toBe(false);
+    expect(shouldForceInlineThreadPreviewForeground('bluesky', true, ['first', 'second'])).toBe(false);
+
+    expect(buildExpectedUrlsForVerification('tumblr', 'Try https://tutti.komm64.com/'))
+      .toEqual(['https://tutti.komm64.com/']);
+    expect(buildExpectedUrlsForVerification('x', 'Try https://tutti.komm64.com/')).toEqual([]);
   });
 
   it('registers verification for every current platform', () => {

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -31,6 +31,7 @@ import {
   capturePostUrlFromTabWithRetry as capturePostUrlWithGenericFlow,
   type CapturePostUrlOptions,
 } from './post-url-capture';
+import { extractHttpUrls } from '../utils/text-urls';
 
 export type PostUrlCaptureStrategy = (
   options: CapturePostUrlOptions,
@@ -41,8 +42,22 @@ export interface BackgroundPlatformStrategy {
   parsePostId: (url: URL) => string | null;
   /** credentials / borrowed session がある場合だけ使う API posting 手続き。 */
   apiPost?: ApiPostingStrategy;
+  /** API posting strategyがreply URLをthread continuationとして処理できる。 */
+  apiReplyContinuation?: true;
+  /** 複数chunkを1つのcompose surfaceへまとめるplatform固有policy。 */
+  inlineThread?: {
+    shouldUse: (autoPost: boolean) => boolean;
+    forceForegroundPreview?: true;
+  };
   /** 2 chunk 目以降を captured parent URL へ接続する compose URL 手続き。 */
   continuationUrl?: (previousPostUrl: string) => string | undefined;
+  /** media kindに応じてadapter既定値を置き換えるcompose URL手続き。 */
+  resolveComposeUrl?: (
+    defaultUrl: string,
+    attachments?: readonly ImageAttachment[],
+  ) => string;
+  /** verification時に本文から追加で期待するURLを構築する。 */
+  expectedUrls?: (text: string) => string[];
   /** 投稿後 URL と期待値を照合する verification 手続き。 */
   verifyPost?: VerificationStrategy;
   /** 投稿後に platform 固有の post URL を取得する手続き。 */
@@ -56,6 +71,10 @@ export interface BackgroundPlatformStrategy {
 export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatformStrategy> = {
   x: {
     parsePostId: ({ pathname }) => pathname.match(/\/status(?:es)?\/(\d+)/)?.[1] ?? null,
+    inlineThread: {
+      shouldUse: (autoPost) => !autoPost,
+      forceForegroundPreview: true,
+    },
     continuationUrl: (previousPostUrl) => {
       const statusId = previousPostUrl.match(/\/status\/(\d+)/)?.[1];
       return statusId ? `https://x.com/intent/post?in_reply_to=${statusId}` : undefined;
@@ -66,6 +85,9 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryBlueskyApiPost,
+    inlineThread: {
+      shouldUse: () => true,
+    },
     verifyPost: verifyBlueskyPost,
     capturePostUrl: capturePostUrlWithGenericFlow,
   },
@@ -82,6 +104,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? null
     ),
     apiPost: tryMastodonApiPost,
+    apiReplyContinuation: true,
     continuationUrl: (previousPostUrl) => previousPostUrl,
     verifyPost: verifyMastodonPost,
     capturePostUrl: capturePostUrlWithGenericFlow,
@@ -98,6 +121,12 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? pathname.match(/^\/[^/]+\/(\d+)(?:\/|$)/)?.[1]
       ?? null
     ),
+    resolveComposeUrl: (defaultUrl, attachments) => (
+      attachments?.some((attachment) => attachment.type.startsWith('video/'))
+        ? 'https://www.tumblr.com/new/video'
+        : defaultUrl
+    ),
+    expectedUrls: extractHttpUrls,
     verifyPost: verifyTumblrPost,
     capturePostUrl: capturePostUrlWithGenericFlow,
   },
@@ -175,6 +204,17 @@ export function continuationNeedsReplyUrl(platform: PlatformId): boolean {
   return getBackgroundPlatformStrategy(platform).continuationUrl !== undefined;
 }
 
+export function shouldUseInlineThread(platform: PlatformId, autoPost: boolean): boolean {
+  return getBackgroundPlatformStrategy(platform).inlineThread?.shouldUse(autoPost) === true;
+}
+
+export function canUseApiWithReplyUrl(
+  platform: PlatformId,
+  replyToUrl: string | undefined,
+): boolean {
+  return !!replyToUrl && getBackgroundPlatformStrategy(platform).apiReplyContinuation === true;
+}
+
 export function buildReplyOverrideUrl(
   platform: PlatformId,
   chunkIndex: number,
@@ -182,6 +222,34 @@ export function buildReplyOverrideUrl(
 ): string | undefined {
   if (chunkIndex === 0 || !previousPostUrl) return undefined;
   return getBackgroundPlatformStrategy(platform).continuationUrl?.(previousPostUrl);
+}
+
+export function resolveComposeUrlForMedia(
+  platform: PlatformId,
+  defaultUrl: string,
+  attachments?: readonly ImageAttachment[],
+): string {
+  return getBackgroundPlatformStrategy(platform).resolveComposeUrl?.(defaultUrl, attachments)
+    ?? defaultUrl;
+}
+
+export function shouldForceInlineThreadPreviewForeground(
+  platform: PlatformId,
+  dryRun: boolean,
+  textChunks?: readonly string[],
+): boolean {
+  const inlineThread = getBackgroundPlatformStrategy(platform).inlineThread;
+  return dryRun
+    && inlineThread?.forceForegroundPreview === true
+    && !!textChunks
+    && textChunks.length > 1;
+}
+
+export function buildExpectedUrlsForVerification(
+  platform: PlatformId,
+  text: string,
+): string[] {
+  return getBackgroundPlatformStrategy(platform).expectedUrls?.(text) ?? [];
 }
 
 export function isVerifySupported(platform: PlatformId): boolean {


### PR DESCRIPTION
## Summary
- move the remaining platform-specific posting decisions out of `platform-poster.ts` into the strategy registry
- cover inline threads, API reply continuation, compose URL resolution, foreground preview policy, and expected URL extraction with characterization tests
- reduce the direct-platform-literal architecture allowlist to empty

## Verification
- `npm run verify:commit`: PASS (84 files / 649 tests + build)
- Surface exact-artifact preview matrix: PASS (20 runs / 160 platform results; failures `[]`; unsafe `[]`)
- Extension version: `0.5.49`
- Artifact SHA-256: `4270245085D64BB38A976F88FE35DA9896FB989336F6E9B54A1426CA005BA2F3`
- No CWS upload/submission performed

Closes #60
Parent: #12 Phase 2 closure
