### PR TITLE
refactor: introduce typed background message handlers

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,8 +1,4 @@
 import { log } from '../src/utils/logger';
-import type {
-  PostRequestMessage,
-  PostResultMessage,
-} from '../src/messages';
 import { getSettings, setLastSeenUser } from '../src/storage';
 import { sweepExpired } from '../src/utils/history-media';
 import {
@@ -14,11 +10,8 @@ import {
   runPollCycle as runInteractionPollCycle,
 } from '../src/utils/interaction-notify';
 import { fetchOverridesFrom } from '../src/utils/selector-feed-runtime';
-import { notifyResults, clearBadge, updateProgressBadge } from '../src/background/post-status-ui';
-import { runPostScheduler } from '../src/background/post-scheduler';
+import { clearBadge, updateProgressBadge } from '../src/background/post-status-ui';
 import { buildDiagnosticsReport } from '../src/background/diagnostics';
-import { recordHistoryEntry, releasePostAttachments } from '../src/background/history-recorder';
-import { normalizePostEvidence, shouldRunPostCompletionSideEffects } from '../src/background/post-result-policy';
 import { applyDisplayModeBehavior, installFloatingWindowCleanup, openFloatingTutti, resolveAutoDisplayMode } from '../src/background/display-mode';
 import { createPersistentLogBuffer } from '../src/background/log-buffer';
 import { createUserActionNotifier } from '../src/background/user-action-notifier';
@@ -27,11 +20,10 @@ import { handleBinaryChunkRequest } from '../src/background/binary-chunk-handler
 import { createOpenedTabRegistry } from '../src/background/opened-tab-registry';
 import { createPostingStateManager } from '../src/background/posting-state';
 import { createPlatformPoster } from '../src/background/platform-poster';
-import { maybeCompressVideoForBudget } from '../src/background/media-preprocess';
 import { createExtensionUpdateManager } from '../src/background/extension-update';
-import { createSubmissionGuard, type SubmissionGuardReservation } from '../src/background/submission-guard';
-import { executeGuardedSubmission } from '../src/background/submission-execution';
-import { decodeMessageWithDiagnostics } from '../src/utils/message-decoder';
+import { createSubmissionGuard } from '../src/background/submission-guard';
+import { createPostRequestHandler } from '../src/background/post-request-handler';
+import { createBackgroundMessageRouter } from '../src/background/message-router';
 
 const logBuffer = createPersistentLogBuffer();
 const userActionNotifier = createUserActionNotifier();
@@ -43,6 +35,14 @@ const platformPoster = createPlatformPoster({
   openedTabs: openedTabRegistry,
   appendBackgroundLog: (message) => logBuffer.appendBackground(message),
 });
+const handlePostRequest = createPostRequestHandler({
+  submissionGuard,
+  openedTabs: openedTabRegistry,
+  postingState,
+  platformPoster,
+  appendBackgroundLog: (message) => logBuffer.appendBackground(message),
+  sendRuntimeMessage: (message) => browser.runtime.sendMessage(message),
+});
 const extensionUpdateManager = createExtensionUpdateManager({
   runtime: browser.runtime,
   storage: browser.storage.local,
@@ -52,6 +52,18 @@ const extensionUpdateManager = createExtensionUpdateManager({
       .sendMessage({ type: 'EXTENSION_UPDATE_AVAILABLE', state })
       .catch(() => { /* popup が閉じていれば届かないので無視 */ });
   },
+});
+const handleRuntimeMessage = createBackgroundMessageRouter({
+  logBuffer,
+  userActionNotifier,
+  userRefreshBroadcaster,
+  postingState,
+  extensionUpdateManager,
+  setLastSeenUser: (message) => setLastSeenUser(message.platform, message.username),
+  clearBadge,
+  handleBinaryChunkRequest,
+  buildDiagnosticsReport: (platforms) => buildDiagnosticsReport({ platforms }),
+  handlePostRequest,
 });
 
 export default defineBackground(() => {
@@ -160,248 +172,5 @@ export default defineBackground(() => {
     }
   });
 
-  browser.runtime.onMessage.addListener((rawMsg, sender, sendResponse) => {
-    const decoded = decodeMessageWithDiagnostics(rawMsg);
-    if (!decoded) return;
-    const { message: msg, diagnostics } = decoded;
-    if (msg.type === 'POST_REQUEST' &&
-        (diagnostics.requestIdDefaulted || diagnostics.intentDefaulted)) {
-      const detail = [
-        diagnostics.requestIdDefaulted ? 'requestId' : '',
-        diagnostics.intentDefaulted
-          ? `intent${diagnostics.receivedIntent ? `(${diagnostics.receivedIntent})` : ''}`
-          : '',
-      ].filter(Boolean).join(',');
-      logBuffer.appendBackground(
-        `POST_REQUEST contract defaulted ${detail}; requestId=${msg.requestId} intent=${msg.intent}`,
-      );
-    }
-
-    if (msg.type === 'USER_ACTION_REQUIRED') {
-      const tabId = sender.tab?.id;
-      if (typeof tabId === 'number') {
-        void userActionNotifier.notify(msg.platform, msg.reason, tabId);
-      }
-      return;
-    }
-
-    if (msg.type === 'CURRENT_USER') {
-      void setLastSeenUser(msg.platform, msg.username);
-      return; // fire-and-forget
-    }
-
-    if (msg.type === 'BROADCAST_REFRESH_USERS') {
-      // v0.4.83: popup mount 時に全 SNS tab に REFRESH_USER を送って
-      // active user を再検出させる。 multi-account 切替後の stale を防ぐ。
-      // v0.4.85: 5 秒 throttle。 popup を高速で何度も開閉した場合に
-      // 無駄な detection 連発を防ぐ。 5s 以内なら lastSeenUsers の cache を
-      // そのまま使う方が安全 (account は数秒単位で変わらない)。
-      userRefreshBroadcaster.broadcast();
-      return; // fire-and-forget、 結果は CURRENT_USER 経由で storage に
-    }
-
-    // P19: 進捗 UI を popup 閉じ→再開でも復活させるため、background で進捗状態を覚える
-    if (msg.type === 'CONVERSION_PROGRESS') {
-      postingState.setCompression({ progress: msg.progress, stage: msg.stage ?? 'transcode' });
-      return; // popup 側でも listen してるので fire-and-forget
-    }
-    if (msg.type === 'CONVERSION_COMPLETE' || msg.type === 'CONVERSION_ERROR') {
-      postingState.setCompression(null);
-      return; // 同上
-    }
-    if (msg.type === 'CLEAR_POSTING_STATE') {
-      // popup から明示的に「結果を消す / 新規投稿に備える」 ためのクリア。
-      // v0.4.96: postingStateInMemory を完了後も保持するようにした (popup の
-      // 再 open で 「結果が消える」 事故防止) ことに対するペアの API。
-      postingState.clearPostingState();
-      clearBadge();
-      sendResponse({ ok: true });
-      return false;
-    }
-
-    if (msg.type === 'GET_BG_STATE') {
-      // v0.4.96: popup が開かれた = user が結果を見た → badge を clear する。
-      // postingState 自体は保持 (popup を閉じて再 open でも結果が見えるように)。
-      // v0.4.100: 投稿中 (postingInMemory=true) は clear しない (進捗が見えなくなる
-      // bug の原因)。 完了済 state を user が popup で確認したタイミング =
-      // postingInMemory=false かつ postingStateInMemory.done=true の場合のみ clear。
-      if (postingState.shouldClearBadgeOnRead()) {
-        clearBadge();
-      }
-      sendResponse(postingState.snapshot());
-      return true;
-    }
-
-    if (msg.type === 'GET_EXTENSION_UPDATE_STATE') {
-      void extensionUpdateManager.getState()
-        .then((state) => sendResponse({ state }))
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          sendResponse({ error: message });
-        });
-      return true;
-    }
-
-    if (msg.type === 'APPLY_EXTENSION_UPDATE') {
-      void extensionUpdateManager.applyUpdate()
-        .then((result) => sendResponse(result))
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          sendResponse({ ok: false, error: 'reload_failed', detail: message });
-        });
-      return true;
-    }
-
-    // P19: content script からの chunked binary 取得 (tabs.sendMessage 64MB cap 回避)
-    if (msg.type === 'GET_BINARY_CHUNK') {
-      void handleBinaryChunkRequest(msg, sendResponse);
-      return true;
-    }
-
-    if (msg.type === 'LOG_APPEND') {
-      logBuffer.append(msg.entry);
-      return; // fire-and-forget
-    }
-    if (msg.type === 'LOG_EXPORT_REQUEST') {
-      sendResponse({ entries: logBuffer.entries() });
-      return true;
-    }
-    if (msg.type === 'LOG_CLEAR') {
-      logBuffer.clear();
-      return; // fire-and-forget
-    }
-
-    if (msg.type === 'DIAGNOSE_REQUEST') {
-      void buildDiagnosticsReport({ platforms: msg.platforms })
-        .then((report) => sendResponse({ report }))
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          sendResponse({ error: message });
-        });
-      return true;
-    }
-
-    if (msg.type !== 'POST_REQUEST') return;
-
-    void handlePostRequest(msg)
-      .then((results) => sendResponse({ results }))
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        sendResponse({ error: message });
-      });
-
-    return true;
-  });
+  browser.runtime.onMessage.addListener(handleRuntimeMessage);
 });
-
-async function handlePostRequest(
-  request: PostRequestMessage,
-): Promise<PostResultMessage[]> {
-  let adjustedImages: PostRequestMessage['images'];
-  let postingStateStarted = false;
-  let autoPost = false;
-  return await executeGuardedSubmission<SubmissionGuardReservation, PostResultMessage[]>({
-    reserve: async () => {
-      const settings = await getSettings();
-      autoPost = request.autoPost ?? settings.autoPost;
-      return await submissionGuard.reserve({
-        requestId: request.requestId,
-        intent: request.intent,
-        text: request.text,
-        platforms: request.platforms,
-        images: request.images,
-        autoPost,
-      });
-    },
-    run: async (reservation) => {
-      const platforms = reservation.allowedPlatforms;
-      const requestedPlatforms = reservation.decisions.map(({ platform }) => platform);
-
-      // Guard reservation が確定するまで tab / posting side effect を開始しない。
-      // POST_REQUEST ごとに cleanup 所有権を切り、前回 state を完全上書きする。
-      openedTabRegistry.clear();
-      postingState.start(requestedPlatforms);
-      postingStateStarted = true;
-      for (const rejected of reservation.rejectedResults) {
-        const guard = rejected.submissionGuard;
-        logBuffer.appendBackground(
-          `SubmissionGuard decision=${guard?.decision ?? 'indeterminate'} ` +
-          `reason=${guard?.reason ?? 'unknown'} requestId=${request.requestId} ` +
-          `platform=${rejected.platform}`,
-        );
-        recordPlatformProgress(rejected);
-      }
-
-      if (platforms.length === 0) {
-        clearBadge();
-        openedTabRegistry.clear();
-        return reservation.rejectedResults;
-      }
-
-      // P16/P81: 投稿前に動画を安全な MP4/H.264/AAC へ正規化し、
-      // 必要に応じて size/trim/letterbox も同じ経路で処理する。
-      adjustedImages = await maybeCompressVideoForBudget(
-        platforms,
-        request.images,
-        request.trimVideoToSeconds,
-        {
-          onConversionFinished: () => {
-            postingState.setCompression(null);
-          },
-        },
-      );
-      const hasVideo = adjustedImages?.some((image) => image.type.startsWith('video/')) === true;
-      const executionResults = await runPostScheduler({
-        platforms,
-        autoPost,
-        planOptions: { hasVideo },
-        post: async (platform, execution) => normalizePostEvidence(
-          await platformPoster.postToPlatform(
-            platform,
-            request.text,
-            adjustedImages,
-            request.cw,
-            request.visibility,
-            autoPost,
-            { forceForeground: execution.forceForeground },
-          ),
-        ),
-        onResult: recordPlatformProgress,
-      });
-      const results = [...reservation.rejectedResults, ...executionResults];
-
-      if (shouldRunPostCompletionSideEffects(autoPost, executionResults)) {
-        notifyResults(results);
-        // v0.5.5: schema v1 用の metadata 計算 → addToPostHistory に渡す
-        await recordHistoryEntry(request.text, results, adjustedImages, {
-          bodyHash: reservation.fingerprint,
-        });
-        // v0.5.7: 成功 SNS の compose / share タブを cleanup (Tutti が新規 open したものに限る)
-        void openedTabRegistry.cleanup(results);
-      } else {
-        clearBadge();
-        openedTabRegistry.clear();
-      }
-      return results;
-    },
-    cleanup: async () => {
-      // IndexedDB binary-transfer の cleanup (元 dataRef + 圧縮結果 dataRef 両方)。
-      // guard block / compression failure でも必ず解放する。
-      await releasePostAttachments(request.images, adjustedImages);
-      // v0.4.96: postingStateInMemory は null 化せず、 done=true + finishedAt で
-      // 「完了済結果」 として保持。 popup 再 open 時に GET_BG_STATE で結果が
-      // 戻る。 次の POST_REQUEST 起動時に上書き、 もしくは popup から
-      // CLEAR_POSTING_STATE で明示クリア。
-      if (postingStateStarted) postingState.markDone();
-    },
-  });
-}
-
-function recordPlatformProgress(result: PostResultMessage): void {
-  // background 側の state を更新 (popup 再 open 時に GET_BG_STATE で復元される)
-  postingState.recordResult(result);
-  // popup へストリーム配信(popup が開いていれば届く、閉じてれば↑の state で復元)
-  void browser.runtime
-    .sendMessage({ type: 'PLATFORM_PROGRESS', result })
-    .catch(() => { /* popup 閉じてれば失敗、無視 */ });
-}

--- a/src/background/message-router.test.ts
+++ b/src/background/message-router.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Message, PostRequestMessage, PostResultMessage } from '../messages';
+import {
+  BACKGROUND_MESSAGE_TYPES,
+  createBackgroundMessageRouter,
+  type BackgroundMessageRouterOptions,
+} from './message-router';
+
+function createOptions(
+  overrides: Partial<BackgroundMessageRouterOptions> = {},
+): BackgroundMessageRouterOptions {
+  return {
+    logBuffer: {
+      load: vi.fn(async () => {}),
+      entries: vi.fn(() => []),
+      append: vi.fn(),
+      appendBackground: vi.fn(),
+      clear: vi.fn(),
+    },
+    userActionNotifier: {
+      notify: vi.fn(async () => {}),
+      handleNotificationClick: vi.fn(() => false),
+    },
+    userRefreshBroadcaster: {
+      broadcast: vi.fn(),
+    },
+    postingState: {
+      setCompression: vi.fn(),
+      clearPostingState: vi.fn(),
+      shouldClearBadgeOnRead: vi.fn(() => false),
+      snapshot: vi.fn(() => ({
+        compression: null,
+        posting: false,
+        postingState: null,
+      })),
+    },
+    extensionUpdateManager: {
+      getState: vi.fn(async () => ({ available: false })),
+      applyUpdate: vi.fn(async () => ({ ok: true as const })),
+    },
+    setLastSeenUser: vi.fn(async () => {}),
+    clearBadge: vi.fn(),
+    handleBinaryChunkRequest: vi.fn(async () => {}),
+    buildDiagnosticsReport: vi.fn(async () => ({} as never)),
+    handlePostRequest: vi.fn(async () => []),
+    ...overrides,
+  };
+}
+
+describe('background message router', () => {
+  it('declares the complete background-owned message registry', () => {
+    expect(BACKGROUND_MESSAGE_TYPES).toEqual([
+      'USER_ACTION_REQUIRED',
+      'CURRENT_USER',
+      'BROADCAST_REFRESH_USERS',
+      'CONVERSION_PROGRESS',
+      'CONVERSION_COMPLETE',
+      'CONVERSION_ERROR',
+      'CLEAR_POSTING_STATE',
+      'GET_BG_STATE',
+      'GET_EXTENSION_UPDATE_STATE',
+      'APPLY_EXTENSION_UPDATE',
+      'GET_BINARY_CHUNK',
+      'LOG_APPEND',
+      'LOG_EXPORT_REQUEST',
+      'LOG_CLEAR',
+      'DIAGNOSE_REQUEST',
+      'POST_REQUEST',
+    ]);
+  });
+
+  it('ignores malformed and non-background messages', () => {
+    const options = createOptions();
+    const router = createBackgroundMessageRouter(options);
+    const sendResponse = vi.fn();
+
+    expect(router({ nope: true }, {}, sendResponse)).toBeUndefined();
+    expect(router(
+      {
+        type: 'POST_RESULT',
+        platform: 'x',
+        success: true,
+      } satisfies Message,
+      {},
+      sendResponse,
+    )).toBeUndefined();
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it('routes sender-aware fire-and-forget handlers', () => {
+    const options = createOptions();
+    const router = createBackgroundMessageRouter(options);
+
+    expect(router(
+      {
+        type: 'USER_ACTION_REQUIRED',
+        platform: 'threads',
+        reason: 'captcha',
+      },
+      { tab: { id: 42 } },
+      vi.fn(),
+    )).toBeUndefined();
+    expect(options.userActionNotifier.notify).toHaveBeenCalledWith('threads', 'captcha', 42);
+  });
+
+  it('routes storage, progress, refresh, and log commands without responses', () => {
+    const options = createOptions();
+    const router = createBackgroundMessageRouter(options);
+    const sendResponse = vi.fn();
+    const entry = {
+      ts: 1,
+      level: 'INFO' as const,
+      context: 'test',
+      message: 'hello',
+    };
+
+    expect(router(
+      { type: 'CURRENT_USER', platform: 'x', username: 'alice' },
+      {},
+      sendResponse,
+    )).toBeUndefined();
+    expect(router({ type: 'BROADCAST_REFRESH_USERS' }, {}, sendResponse)).toBeUndefined();
+    expect(router(
+      { type: 'CONVERSION_PROGRESS', progress: 0.5, stage: 'load' },
+      {},
+      sendResponse,
+    )).toBeUndefined();
+    expect(router({ type: 'CONVERSION_COMPLETE', outputRef: 'ref', outputBytes: 10 }, {}, sendResponse))
+      .toBeUndefined();
+    expect(router({ type: 'CONVERSION_ERROR', error: 'failed' }, {}, sendResponse))
+      .toBeUndefined();
+    expect(router({ type: 'LOG_APPEND', entry }, {}, sendResponse)).toBeUndefined();
+    expect(router({ type: 'LOG_CLEAR' }, {}, sendResponse)).toBeUndefined();
+
+    expect(options.setLastSeenUser).toHaveBeenCalledWith({
+      type: 'CURRENT_USER',
+      platform: 'x',
+      username: 'alice',
+    });
+    expect(options.userRefreshBroadcaster.broadcast).toHaveBeenCalledOnce();
+    expect(options.postingState.setCompression).toHaveBeenNthCalledWith(1, {
+      progress: 0.5,
+      stage: 'load',
+    });
+    expect(options.postingState.setCompression).toHaveBeenNthCalledWith(2, null);
+    expect(options.postingState.setCompression).toHaveBeenNthCalledWith(3, null);
+    expect(options.logBuffer.append).toHaveBeenCalledWith(entry);
+    expect(options.logBuffer.clear).toHaveBeenCalledOnce();
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it('preserves synchronous response and keep-alive behavior', () => {
+    const options = createOptions();
+    vi.mocked(options.postingState.shouldClearBadgeOnRead).mockReturnValue(true);
+    const router = createBackgroundMessageRouter(options);
+    const sendResponse = vi.fn();
+
+    expect(router({ type: 'GET_BG_STATE' }, {}, sendResponse)).toBe(true);
+    expect(options.clearBadge).toHaveBeenCalledOnce();
+    expect(sendResponse).toHaveBeenCalledWith({
+      compression: null,
+      posting: false,
+      postingState: null,
+    });
+  });
+
+  it('keeps async diagnostics and binary responses alive', async () => {
+    const report = { version: 'test' };
+    const buildDiagnosticsReport = vi.fn(async () => report as never);
+    const handleBinaryChunkRequest = vi.fn(async (
+      _message: Extract<Message, { type: 'GET_BINARY_CHUNK' }>,
+      sendResponse: (response?: unknown) => void,
+    ) => {
+      sendResponse({ chunk: 'AA==', totalSize: 1, end: 1 });
+    });
+    const options = createOptions({ buildDiagnosticsReport, handleBinaryChunkRequest });
+    const router = createBackgroundMessageRouter(options);
+    const diagnoseResponse = vi.fn();
+    const binaryResponse = vi.fn();
+
+    expect(router(
+      { type: 'DIAGNOSE_REQUEST', platforms: ['x'] },
+      {},
+      diagnoseResponse,
+    )).toBe(true);
+    expect(router(
+      { type: 'GET_BINARY_CHUNK', dataRef: 'ref', offset: 0, length: 1 },
+      {},
+      binaryResponse,
+    )).toBe(true);
+
+    await vi.waitFor(() => expect(diagnoseResponse).toHaveBeenCalledWith({ report }));
+    await vi.waitFor(() => expect(binaryResponse).toHaveBeenCalledWith({
+      chunk: 'AA==',
+      totalSize: 1,
+      end: 1,
+    }));
+    expect(buildDiagnosticsReport).toHaveBeenCalledWith(['x']);
+  });
+
+  it('decodes conservative POST_REQUEST defaults before async dispatch', async () => {
+    const result: PostResultMessage = {
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      preview: true,
+    };
+    const handlePostRequest = vi.fn<
+      (message: PostRequestMessage) => Promise<PostResultMessage[]>
+    >(async () => [result]);
+    const options = createOptions({ handlePostRequest });
+    const router = createBackgroundMessageRouter(options);
+    const sendResponse = vi.fn();
+
+    expect(router(
+      {
+        type: 'POST_REQUEST',
+        text: 'hello',
+        platforms: ['x'],
+        autoPost: true,
+      },
+      {},
+      sendResponse,
+    )).toBe(true);
+
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalledWith({ results: [result] }));
+    const routed = handlePostRequest.mock.calls[0]![0];
+    expect(routed.requestId).toEqual(expect.any(String));
+    expect(routed.requestId.length).toBeGreaterThan(0);
+    expect(routed.intent).toBe('retry');
+    expect(options.logBuffer.appendBackground).toHaveBeenCalledWith(
+      expect.stringContaining('POST_REQUEST contract defaulted requestId,intent'),
+    );
+  });
+});

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -1,0 +1,229 @@
+import type {
+  Message,
+  PostRequestMessage,
+  PostResultMessage,
+} from '../messages';
+import {
+  decodeMessageWithDiagnostics,
+  type MessageDecodeDiagnostics,
+} from '../utils/message-decoder';
+import type { DiagnosticsReport } from './diagnostics';
+import type { ApplyExtensionUpdateResult } from './extension-update';
+import type { PersistentLogBuffer } from './log-buffer';
+import type { createPostingStateManager } from './posting-state';
+import type { UserActionNotifier } from './user-action-notifier';
+import type { UserRefreshBroadcaster } from './user-refresh';
+
+export const BACKGROUND_MESSAGE_TYPES = [
+  'USER_ACTION_REQUIRED',
+  'CURRENT_USER',
+  'BROADCAST_REFRESH_USERS',
+  'CONVERSION_PROGRESS',
+  'CONVERSION_COMPLETE',
+  'CONVERSION_ERROR',
+  'CLEAR_POSTING_STATE',
+  'GET_BG_STATE',
+  'GET_EXTENSION_UPDATE_STATE',
+  'APPLY_EXTENSION_UPDATE',
+  'GET_BINARY_CHUNK',
+  'LOG_APPEND',
+  'LOG_EXPORT_REQUEST',
+  'LOG_CLEAR',
+  'DIAGNOSE_REQUEST',
+  'POST_REQUEST',
+] as const satisfies readonly Message['type'][];
+
+export type BackgroundMessageType = (typeof BACKGROUND_MESSAGE_TYPES)[number];
+type BackgroundMessage = Extract<Message, { type: BackgroundMessageType }>;
+type MessageOf<T extends BackgroundMessageType> = Extract<BackgroundMessage, { type: T }>;
+
+export interface RuntimeMessageSender {
+  tab?: {
+    id?: number;
+  };
+}
+
+export type RuntimeSendResponse = (response?: unknown) => void;
+export type RuntimeMessageListener = (
+  rawMessage: unknown,
+  sender: RuntimeMessageSender,
+  sendResponse: RuntimeSendResponse,
+) => boolean | void;
+
+interface HandlerContext {
+  sender: RuntimeMessageSender;
+  sendResponse: RuntimeSendResponse;
+}
+
+type TypedHandler<T extends BackgroundMessageType> = (
+  message: MessageOf<T>,
+  context: HandlerContext,
+) => boolean | void;
+
+type TypedHandlerRegistry = {
+  [T in BackgroundMessageType]: TypedHandler<T>;
+};
+
+interface PostingStateManager {
+  setCompression: ReturnType<typeof createPostingStateManager>['setCompression'];
+  clearPostingState: ReturnType<typeof createPostingStateManager>['clearPostingState'];
+  shouldClearBadgeOnRead: ReturnType<typeof createPostingStateManager>['shouldClearBadgeOnRead'];
+  snapshot: ReturnType<typeof createPostingStateManager>['snapshot'];
+}
+
+interface ExtensionUpdateManager {
+  getState(): Promise<unknown>;
+  applyUpdate(): Promise<ApplyExtensionUpdateResult>;
+}
+
+export interface BackgroundMessageRouterOptions {
+  logBuffer: PersistentLogBuffer;
+  userActionNotifier: UserActionNotifier;
+  userRefreshBroadcaster: UserRefreshBroadcaster;
+  postingState: PostingStateManager;
+  extensionUpdateManager: ExtensionUpdateManager;
+  setLastSeenUser(message: MessageOf<'CURRENT_USER'>): Promise<void>;
+  clearBadge(): void;
+  handleBinaryChunkRequest(
+    message: MessageOf<'GET_BINARY_CHUNK'>,
+    sendResponse: RuntimeSendResponse,
+  ): Promise<void>;
+  buildDiagnosticsReport(
+    platforms: MessageOf<'DIAGNOSE_REQUEST'>['platforms'],
+  ): Promise<DiagnosticsReport>;
+  handlePostRequest(message: PostRequestMessage): Promise<PostResultMessage[]>;
+}
+
+export function createBackgroundMessageRouter(
+  options: BackgroundMessageRouterOptions,
+): RuntimeMessageListener {
+  const handlers = defineHandlers({
+    USER_ACTION_REQUIRED: (message, { sender }) => {
+      const tabId = sender.tab?.id;
+      if (typeof tabId === 'number') {
+        void options.userActionNotifier.notify(message.platform, message.reason, tabId);
+      }
+    },
+    CURRENT_USER: (message) => {
+      void options.setLastSeenUser(message);
+    },
+    BROADCAST_REFRESH_USERS: () => {
+      options.userRefreshBroadcaster.broadcast();
+    },
+    CONVERSION_PROGRESS: (message) => {
+      options.postingState.setCompression({
+        progress: message.progress,
+        stage: message.stage ?? 'transcode',
+      });
+    },
+    CONVERSION_COMPLETE: () => {
+      options.postingState.setCompression(null);
+    },
+    CONVERSION_ERROR: () => {
+      options.postingState.setCompression(null);
+    },
+    CLEAR_POSTING_STATE: (_message, { sendResponse }) => {
+      options.postingState.clearPostingState();
+      options.clearBadge();
+      sendResponse({ ok: true });
+      return false;
+    },
+    GET_BG_STATE: (_message, { sendResponse }) => {
+      if (options.postingState.shouldClearBadgeOnRead()) {
+        options.clearBadge();
+      }
+      sendResponse(options.postingState.snapshot());
+      return true;
+    },
+    GET_EXTENSION_UPDATE_STATE: (_message, { sendResponse }) => {
+      void options.extensionUpdateManager.getState()
+        .then((state) => sendResponse({ state }))
+        .catch((error: unknown) => sendResponse({ error: errorMessage(error) }));
+      return true;
+    },
+    APPLY_EXTENSION_UPDATE: (_message, { sendResponse }) => {
+      void options.extensionUpdateManager.applyUpdate()
+        .then((result) => sendResponse(result))
+        .catch((error: unknown) => {
+          sendResponse({
+            ok: false,
+            error: 'reload_failed',
+            detail: errorMessage(error),
+          });
+        });
+      return true;
+    },
+    GET_BINARY_CHUNK: (message, { sendResponse }) => {
+      void options.handleBinaryChunkRequest(message, sendResponse);
+      return true;
+    },
+    LOG_APPEND: (message) => {
+      options.logBuffer.append(message.entry);
+    },
+    LOG_EXPORT_REQUEST: (_message, { sendResponse }) => {
+      sendResponse({ entries: options.logBuffer.entries() });
+      return true;
+    },
+    LOG_CLEAR: () => {
+      options.logBuffer.clear();
+    },
+    DIAGNOSE_REQUEST: (message, { sendResponse }) => {
+      void options.buildDiagnosticsReport(message.platforms)
+        .then((report) => sendResponse({ report }))
+        .catch((error: unknown) => sendResponse({ error: errorMessage(error) }));
+      return true;
+    },
+    POST_REQUEST: (message, { sendResponse }) => {
+      void options.handlePostRequest(message)
+        .then((results) => sendResponse({ results }))
+        .catch((error: unknown) => sendResponse({ error: errorMessage(error) }));
+      return true;
+    },
+  });
+
+  return (rawMessage, sender, sendResponse) => {
+    const decoded = decodeMessageWithDiagnostics(rawMessage);
+    if (!decoded) return;
+
+    logContractDefaults(decoded.message, decoded.diagnostics, options.logBuffer);
+    if (!isBackgroundMessage(decoded.message)) return;
+
+    const handler = handlers[decoded.message.type] as TypedHandler<BackgroundMessageType>;
+    return handler(decoded.message, { sender, sendResponse });
+  };
+}
+
+function defineHandlers(registry: TypedHandlerRegistry): TypedHandlerRegistry {
+  return registry;
+}
+
+const BACKGROUND_MESSAGE_TYPE_SET = new Set<Message['type']>(BACKGROUND_MESSAGE_TYPES);
+
+function isBackgroundMessage(message: Message): message is BackgroundMessage {
+  return BACKGROUND_MESSAGE_TYPE_SET.has(message.type);
+}
+
+function logContractDefaults(
+  message: Message,
+  diagnostics: MessageDecodeDiagnostics,
+  logBuffer: PersistentLogBuffer,
+): void {
+  if (message.type !== 'POST_REQUEST' ||
+      (!diagnostics.requestIdDefaulted && !diagnostics.intentDefaulted)) {
+    return;
+  }
+  const detail = [
+    diagnostics.requestIdDefaulted ? 'requestId' : '',
+    diagnostics.intentDefaulted
+      ? `intent${diagnostics.receivedIntent ? `(${diagnostics.receivedIntent})` : ''}`
+      : '',
+  ].filter(Boolean).join(',');
+  logBuffer.appendBackground(
+    `POST_REQUEST contract defaulted ${detail}; ` +
+    `requestId=${message.requestId} intent=${message.intent}`,
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/background/post-request-handler.ts
+++ b/src/background/post-request-handler.ts
@@ -1,0 +1,145 @@
+import type { PostRequestMessage, PostResultMessage } from '../messages';
+import { getSettings } from '../storage';
+import { releasePostAttachments, recordHistoryEntry } from './history-recorder';
+import { maybeCompressVideoForBudget } from './media-preprocess';
+import type { OpenedTabRegistry } from './opened-tab-registry';
+import type { createPlatformPoster } from './platform-poster';
+import {
+  normalizePostEvidence,
+  shouldRunPostCompletionSideEffects,
+} from './post-result-policy';
+import { runPostScheduler } from './post-scheduler';
+import { clearBadge, notifyResults } from './post-status-ui';
+import type { createPostingStateManager } from './posting-state';
+import { executeGuardedSubmission } from './submission-execution';
+import type {
+  createSubmissionGuard,
+  SubmissionGuardReservation,
+} from './submission-guard';
+
+type PostingStateManager = ReturnType<typeof createPostingStateManager>;
+type PlatformPoster = ReturnType<typeof createPlatformPoster>;
+type SubmissionGuard = ReturnType<typeof createSubmissionGuard>;
+
+export interface PostRequestHandlerOptions {
+  submissionGuard: SubmissionGuard;
+  openedTabs: OpenedTabRegistry;
+  postingState: PostingStateManager;
+  platformPoster: PlatformPoster;
+  appendBackgroundLog(message: string): void;
+  sendRuntimeMessage(message: unknown): Promise<unknown>;
+}
+
+export function createPostRequestHandler(options: PostRequestHandlerOptions) {
+  const {
+    submissionGuard,
+    openedTabs,
+    postingState,
+    platformPoster,
+    appendBackgroundLog,
+    sendRuntimeMessage,
+  } = options;
+
+  function recordPlatformProgress(result: PostResultMessage): void {
+    // background 側の state を更新 (popup 再 open 時に GET_BG_STATE で復元される)
+    postingState.recordResult(result);
+    // popup へストリーム配信。閉じていれば state から復元するので送信失敗は無視。
+    void sendRuntimeMessage({ type: 'PLATFORM_PROGRESS', result }).catch(() => {});
+  }
+
+  return async function handlePostRequest(
+    request: PostRequestMessage,
+  ): Promise<PostResultMessage[]> {
+    let adjustedImages: PostRequestMessage['images'];
+    let postingStateStarted = false;
+    let autoPost = false;
+    return await executeGuardedSubmission<SubmissionGuardReservation, PostResultMessage[]>({
+      reserve: async () => {
+        const settings = await getSettings();
+        autoPost = request.autoPost ?? settings.autoPost;
+        return await submissionGuard.reserve({
+          requestId: request.requestId,
+          intent: request.intent,
+          text: request.text,
+          platforms: request.platforms,
+          images: request.images,
+          autoPost,
+        });
+      },
+      run: async (reservation) => {
+        const platforms = reservation.allowedPlatforms;
+        const requestedPlatforms = reservation.decisions.map(({ platform }) => platform);
+
+        // Guard reservation が確定するまで tab / posting side effect を開始しない。
+        // POST_REQUEST ごとに cleanup 所有権を切り、前回 state を完全上書きする。
+        openedTabs.clear();
+        postingState.start(requestedPlatforms);
+        postingStateStarted = true;
+        for (const rejected of reservation.rejectedResults) {
+          const guard = rejected.submissionGuard;
+          appendBackgroundLog(
+            `SubmissionGuard decision=${guard?.decision ?? 'indeterminate'} ` +
+            `reason=${guard?.reason ?? 'unknown'} requestId=${request.requestId} ` +
+            `platform=${rejected.platform}`,
+          );
+          recordPlatformProgress(rejected);
+        }
+
+        if (platforms.length === 0) {
+          clearBadge();
+          openedTabs.clear();
+          return reservation.rejectedResults;
+        }
+
+        // 投稿前に動画を安全な MP4/H.264/AAC へ正規化し、必要に応じて
+        // size/trim/letterbox も同じ経路で処理する。
+        adjustedImages = await maybeCompressVideoForBudget(
+          platforms,
+          request.images,
+          request.trimVideoToSeconds,
+          {
+            onConversionFinished: () => {
+              postingState.setCompression(null);
+            },
+          },
+        );
+        const hasVideo = adjustedImages?.some((image) => image.type.startsWith('video/')) === true;
+        const executionResults = await runPostScheduler({
+          platforms,
+          autoPost,
+          planOptions: { hasVideo },
+          post: async (platform, execution) => normalizePostEvidence(
+            await platformPoster.postToPlatform(
+              platform,
+              request.text,
+              adjustedImages,
+              request.cw,
+              request.visibility,
+              autoPost,
+              { forceForeground: execution.forceForeground },
+            ),
+          ),
+          onResult: recordPlatformProgress,
+        });
+        const results = [...reservation.rejectedResults, ...executionResults];
+
+        if (shouldRunPostCompletionSideEffects(autoPost, executionResults)) {
+          notifyResults(results);
+          await recordHistoryEntry(request.text, results, adjustedImages, {
+            bodyHash: reservation.fingerprint,
+          });
+          void openedTabs.cleanup(results);
+        } else {
+          clearBadge();
+          openedTabs.clear();
+        }
+        return results;
+      },
+      cleanup: async () => {
+        // 元 dataRef と圧縮結果 dataRef の双方を、失敗経路も含めて必ず解放する。
+        await releasePostAttachments(request.images, adjustedImages);
+        if (postingStateStarted) postingState.markDone();
+      },
+    });
+  };
+}

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+
+type EntrypointCategory = 'background' | 'content' | 'offscreen' | 'ui';
+
+const ALLOWED_SRC_IMPORTS: Record<EntrypointCategory, readonly string[]> = {
+  background: [
+    'src/background/',
+    'src/messages',
+    'src/storage',
+    'src/types/',
+    'src/utils/',
+  ],
+  content: [
+    'src/adapters/',
+    'src/messages',
+    'src/storage',
+    'src/types/',
+    'src/utils/',
+  ],
+  offscreen: [
+    'src/messages',
+    'src/types/',
+    'src/utils/',
+  ],
+  ui: [
+    'src/adapters/',
+    'src/api/',
+    'src/messages',
+    'src/popup/',
+    'src/storage',
+    'src/types/',
+    'src/utils/',
+  ],
+};
+
+describe('entrypoint architecture guard', () => {
+  it('keeps src imports inside each entrypoint category boundary', () => {
+    const violations: string[] = [];
+    for (const path of entrypointSourceFiles('entrypoints')) {
+      const source = readFileSync(path, 'utf8');
+      const category = categorize(path);
+      for (const specifier of importSpecifiers(source)) {
+        if (!specifier.startsWith('.')) continue;
+        const resolved = normalize(relative('.', resolve(dirname(path), specifier)));
+        if (!resolved.startsWith('src/')) continue;
+        if (ALLOWED_SRC_IMPORTS[category].some((allowed) => isAllowedImport(resolved, allowed))) {
+          continue;
+        }
+        violations.push(`${normalize(relative('.', path))}: ${category} -> ${resolved}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps runtime message branching out of the background entrypoint', () => {
+    const source = readFileSync('entrypoints/background.ts', 'utf8');
+    expect(source).toContain('browser.runtime.onMessage.addListener(handleRuntimeMessage)');
+    expect(source).not.toMatch(/\b(?:msg|message)\.type\s*(?:===|!==)/);
+    expect(source).not.toMatch(/function\s+handlePostRequest\b/);
+  });
+});
+
+function categorize(path: string): EntrypointCategory {
+  const normalized = normalize(relative('.', path));
+  if (normalized === 'entrypoints/background.ts') return 'background';
+  if (normalized.endsWith('.content.ts')) return 'content';
+  if (normalized.startsWith('entrypoints/offscreen/')) return 'offscreen';
+  return 'ui';
+}
+
+function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)) {
+    if (match[1]) specifiers.push(match[1]);
+  }
+  for (const match of source.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) {
+    if (match[1]) specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+function entrypointSourceFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const name of readdirSync(root)) {
+    const path = resolve(root, name);
+    if (statSync(path).isDirectory()) {
+      files.push(...entrypointSourceFiles(path));
+    } else if (path.endsWith('.ts') || path.endsWith('.svelte')) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function normalize(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function isAllowedImport(path: string, allowed: string): boolean {
+  return allowed.endsWith('/') ? path.startsWith(allowed) : path === allowed;
+}


### PR DESCRIPTION
## Summary
- replace the background entrypoint's message-type branch chain with a typed handler registry
- move the guarded `POST_REQUEST` workflow into a dedicated background service
- keep runtime decoding and response keep-alive behavior unchanged
- add entrypoint-category import boundaries and prevent message routing from returning to `entrypoints/background.ts`

## Verification
- `npm run verify:commit`: PASS (86 files / 658 tests + build)
- `npm run test:stability`: PASS (5/5)
- GitHub CI: PASS
- Surface exact-artifact preview matrix: PASS (20 runs / 160 results; failures `[]`; unsafe `[]`)
- Surface command used `--case-timeout-ms 360000`; the same artifact's grouped nine-platform video run measured 161.1 seconds, confirming #20's 180-second budget flake
- Extension version: `0.5.49`
- Artifact SHA-256: `C064DED5A6FAF79DCD15313928CE6FD9B323A1213F216A1DF2F1890456A13DDE`
- No CWS upload/submission

Closes #66
Parent: #12 Phase 3
