### PR TITLE
refactor: introduce composer persistence controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -8,12 +8,8 @@
   import { decodeMessage } from '../../src/utils/message-decoder';
   import {
     clearDraft,
-    getDraft,
     getLastSeenUsers,
-    getSelectedPlatforms,
     getSettings,
-    saveDraft,
-    saveSelectedPlatforms,
     saveSettings,
     RESPONSIBLE_USE_ACK_VERSION,
     type HistoryEntry,
@@ -71,12 +67,8 @@
   import {
     filesFromClipboardItems,
     isFileDrag,
-    restoreImagePreviews,
-    restoreVideoPreview,
     revokeImagePreviews,
     revokeVideoPreview,
-    serializeImagesForDraft,
-    serializeVideoForDraft,
   } from '../../src/popup/media-preview';
   import {
     addFilesToMediaState,
@@ -89,6 +81,7 @@
     submitPopupErrorReport,
     type PopupReportContext,
   } from '../../src/popup/error-report-submit';
+  import { createComposerController } from '../../src/popup/composer-controller';
   import HeaderBar from './components/HeaderBar.svelte';
   import AutoPostControl from './components/AutoPostControl.svelte';
   import MediaComposer from './components/MediaComposer.svelte';
@@ -103,6 +96,7 @@
   import ResponsibleUseDialog from './components/ResponsibleUseDialog.svelte';
 
   const platforms: PlatformOption[] = POPUP_PLATFORMS;
+  const composerController = createComposerController();
 
   let text = $state('');
   // Pixiv / DeviantArt / Instagram は image-only、TikTok / YouTube は video-only で
@@ -268,14 +262,8 @@
   let selectedLoaded = $state(false);
   $effect(() => {
     if (selectedLoaded) return;
-    void getSelectedPlatforms().then((s) => {
-      if (s) {
-        for (const [k, v] of Object.entries(s)) {
-          if (typeof v === 'boolean' && k in selected) {
-            selected[k as PlatformId] = v;
-          }
-        }
-      }
+    void composerController.loadSelectedPlatforms(selected).then((next) => {
+      selected = next;
       selectedLoaded = true;
     });
   });
@@ -283,47 +271,39 @@
   // 下書き(text + media)を読み込む(マウント時に 1 回)
   $effect(() => {
     if (draftLoaded) return;
-    void getDraft().then((draft) => {
+    void composerController.loadDraft().then((draft) => {
       if (draft) {
         text = draft.text;
-        images = restoreImagePreviews(draft.images);
-        video = restoreVideoPreview(draft.video);
+        images = draft.images;
+        video = draft.video;
       }
       draftLoaded = true;
     });
   });
 
   // 下書き(text/メディア)の自動保存(300ms デバウンス)
-  let saveTimer: ReturnType<typeof setTimeout> | undefined;
   $effect(() => {
     text;
     images.length; video;
     if (!draftLoaded) return;
-    if (saveTimer) clearTimeout(saveTimer);
-    saveTimer = setTimeout(() => {
-      void saveDraft({
-        text,
-        images: serializeImagesForDraft(images),
-        video: serializeVideoForDraft(video),
-      });
-    }, 300);
+    composerController.scheduleDraftSave({ text, images, video });
   });
 
   // SNS 選択の永続保存(変わったら即保存)
   // v0.4.100: 新 SNS (pixiv / deviantart / instagram / tiktok / youtube) が
   // $effect の dependency に入っておらず、 これらを toggle しても save が走らず
   // 「checkbox が毎回外れる」 bug の原因だった。 全 11 platform を tracker に追加。
-  let selectedSaveTimer: ReturnType<typeof setTimeout> | undefined;
   $effect(() => {
     selected.x; selected.bluesky; selected.threads;
     selected.mastodon; selected.misskey; selected.tumblr;
     selected.pixiv; selected.deviantart; selected.instagram;
     selected.tiktok; selected.youtube;
     if (!selectedLoaded) return;
-    if (selectedSaveTimer) clearTimeout(selectedSaveTimer);
-    selectedSaveTimer = setTimeout(() => {
-      void saveSelectedPlatforms({ ...selected });
-    }, 200);
+    composerController.scheduleSelectedPlatformsSave(selected);
+  });
+
+  $effect(() => {
+    return () => composerController.dispose();
   });
 
   // Diagnostics: SNS が動かない時の障害切り分け用 dump を生成
@@ -673,7 +653,7 @@
    */
   function applyPreset(preset: SnsPreset): void {
     selected = applyPresetSelection(selected, preset);
-    void saveSelectedPlatforms(selected);
+    void composerController.saveSelectedPlatforms(selected);
   }
 
   /**

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SELECTED_PLATFORMS } from './platforms';
+import {
+  createComposerController,
+  type ComposerDraftSnapshot,
+} from './composer-controller';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('composer persistence controller', () => {
+  it('loads draft and merges only known persisted platform keys', async () => {
+    const controller = createComposerController({
+      getDraft: vi.fn(async () => ({ text: 'saved draft' })),
+      getSelectedPlatforms: vi.fn(async () => ({
+        x: false,
+        bluesky: true,
+        unknown: true,
+      } as never)),
+    });
+
+    await expect(controller.loadDraft()).resolves.toEqual({
+      text: 'saved draft',
+      images: [],
+      video: null,
+    });
+    const selected = await controller.loadSelectedPlatforms(DEFAULT_SELECTED_PLATFORMS);
+    expect(selected.x).toBe(false);
+    expect(selected.bluesky).toBe(true);
+    expect(selected).not.toHaveProperty('unknown');
+    expect(DEFAULT_SELECTED_PLATFORMS.x).toBe(true);
+  });
+
+  it('merges persisted selection into the latest caller state', async () => {
+    let resolveStored!: (value: { x: boolean }) => void;
+    const stored = new Promise<{ x: boolean }>((resolve) => {
+      resolveStored = resolve;
+    });
+    const controller = createComposerController({
+      getSelectedPlatforms: () => stored,
+    });
+    const selected = { ...DEFAULT_SELECTED_PLATFORMS };
+
+    const loading = controller.loadSelectedPlatforms(selected);
+    selected.youtube = true;
+    resolveStored({ x: false });
+
+    await expect(loading).resolves.toMatchObject({ x: false, youtube: true });
+  });
+
+  it('debounces and serializes draft snapshots', async () => {
+    vi.useFakeTimers();
+    const saveDraft = vi.fn(async () => {});
+    const controller = createComposerController({ saveDraft });
+    const first: ComposerDraftSnapshot = {
+      text: 'first',
+      images: [],
+      video: null,
+    };
+    const second: ComposerDraftSnapshot = {
+      text: 'second',
+      images: [{
+        name: 'image.png',
+        type: 'image/png',
+        data: 'AA==',
+        previewUrl: 'blob:test',
+      }],
+      video: null,
+    };
+
+    controller.scheduleDraftSave(first);
+    controller.scheduleDraftSave(second);
+    await vi.advanceTimersByTimeAsync(299);
+    expect(saveDraft).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(saveDraft).toHaveBeenCalledOnce();
+    expect(saveDraft).toHaveBeenCalledWith({
+      text: 'second',
+      images: [{ name: 'image.png', type: 'image/png', data: 'AA==' }],
+      video: null,
+    });
+  });
+
+  it('clones selection snapshots and lets immediate saves supersede pending work', async () => {
+    vi.useFakeTimers();
+    const saveSelectedPlatforms = vi.fn(async () => {});
+    const controller = createComposerController({ saveSelectedPlatforms });
+    const selected = { ...DEFAULT_SELECTED_PLATFORMS };
+
+    controller.scheduleSelectedPlatformsSave(selected);
+    selected.x = false;
+    await controller.saveSelectedPlatforms(selected);
+    await vi.runAllTimersAsync();
+
+    expect(saveSelectedPlatforms).toHaveBeenCalledOnce();
+    expect(saveSelectedPlatforms).toHaveBeenCalledWith({
+      ...DEFAULT_SELECTED_PLATFORMS,
+      x: false,
+    });
+  });
+
+  it('cancels pending persistence on disposal', async () => {
+    vi.useFakeTimers();
+    const saveDraft = vi.fn(async () => {});
+    const saveSelectedPlatforms = vi.fn(async () => {});
+    const controller = createComposerController({ saveDraft, saveSelectedPlatforms });
+
+    controller.scheduleDraftSave({ text: 'draft', images: [], video: null });
+    controller.scheduleSelectedPlatformsSave(DEFAULT_SELECTED_PLATFORMS);
+    controller.dispose();
+    await vi.runAllTimersAsync();
+
+    expect(saveDraft).not.toHaveBeenCalled();
+    expect(saveSelectedPlatforms).not.toHaveBeenCalled();
+  });
+});

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -1,0 +1,114 @@
+import type { PlatformId } from '../types/platform';
+import {
+  getDraft,
+  getSelectedPlatforms,
+  saveDraft,
+  saveSelectedPlatforms,
+  type Draft,
+  type SelectedPlatforms,
+} from '../storage';
+import {
+  restoreImagePreviews,
+  restoreVideoPreview,
+  serializeImagesForDraft,
+  serializeVideoForDraft,
+} from './media-preview';
+import type { ImagePreview, VideoPreview } from './types';
+
+export interface ComposerDraftState {
+  text: string;
+  images: ImagePreview[];
+  video: VideoPreview | null;
+}
+
+export interface ComposerDraftSnapshot {
+  text: string;
+  images: readonly ImagePreview[];
+  video: VideoPreview | null;
+}
+
+export interface ComposerControllerOptions {
+  getDraft?: () => Promise<Draft | null>;
+  saveDraft?: (draft: Draft) => Promise<void>;
+  getSelectedPlatforms?: () => Promise<SelectedPlatforms | null>;
+  saveSelectedPlatforms?: (selected: SelectedPlatforms) => Promise<void>;
+  draftDebounceMs?: number;
+  selectionDebounceMs?: number;
+}
+
+export function createComposerController(options: ComposerControllerOptions = {}) {
+  const readDraft = options.getDraft ?? getDraft;
+  const writeDraft = options.saveDraft ?? saveDraft;
+  const readSelected = options.getSelectedPlatforms ?? getSelectedPlatforms;
+  const writeSelected = options.saveSelectedPlatforms ?? saveSelectedPlatforms;
+  const draftDebounceMs = options.draftDebounceMs ?? 300;
+  const selectionDebounceMs = options.selectionDebounceMs ?? 200;
+  let draftTimer: ReturnType<typeof setTimeout> | undefined;
+  let selectionTimer: ReturnType<typeof setTimeout> | undefined;
+
+  return {
+    async loadDraft(): Promise<ComposerDraftState | null> {
+      const draft = await readDraft();
+      if (!draft) return null;
+      return {
+        text: draft.text,
+        images: restoreImagePreviews(draft.images),
+        video: restoreVideoPreview(draft.video),
+      };
+    },
+
+    async loadSelectedPlatforms(
+      defaults: Readonly<Record<PlatformId, boolean>>,
+    ): Promise<Record<PlatformId, boolean>> {
+      const stored = await readSelected();
+      const selected = { ...defaults };
+      if (!stored) return selected;
+      for (const [key, value] of Object.entries(stored)) {
+        if (typeof value === 'boolean' && key in selected) {
+          selected[key as PlatformId] = value;
+        }
+      }
+      return selected;
+    },
+
+    scheduleDraftSave(snapshot: ComposerDraftSnapshot): void {
+      if (draftTimer) clearTimeout(draftTimer);
+      draftTimer = setTimeout(() => {
+        draftTimer = undefined;
+        void writeDraft({
+          text: snapshot.text,
+          images: serializeImagesForDraft(snapshot.images),
+          video: serializeVideoForDraft(snapshot.video),
+        });
+      }, draftDebounceMs);
+    },
+
+    scheduleSelectedPlatformsSave(
+      selected: Readonly<Record<PlatformId, boolean>>,
+    ): void {
+      if (selectionTimer) clearTimeout(selectionTimer);
+      const snapshot = { ...selected };
+      selectionTimer = setTimeout(() => {
+        selectionTimer = undefined;
+        void writeSelected(snapshot);
+      }, selectionDebounceMs);
+    },
+
+    async saveSelectedPlatforms(
+      selected: Readonly<Record<PlatformId, boolean>>,
+    ): Promise<void> {
+      if (selectionTimer) {
+        clearTimeout(selectionTimer);
+        selectionTimer = undefined;
+      }
+      await writeSelected({ ...selected });
+    },
+
+    dispose(): void {
+      if (draftTimer) clearTimeout(draftTimer);
+      if (selectionTimer) clearTimeout(selectionTimer);
+      draftTimer = undefined;
+      selectionTimer = undefined;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- introduce the single popup composer controller with persisted draft/selection as its first responsibility
- move draft restore/serialization and both debounce timers behind the controller
- preserve latest-state merge semantics while loading persisted platform selection
- add one disposal path and route preset immediate saves through the same controller

## Verification
- `npm run verify:commit`: PASS (89 files / 667 tests + build)
- `npm run e2e:smoke:no-build`: PASS (runtime preview, popup UI, Mastodon simple flow, Instagram wizard flow)
- focused fake-timer controller tests: PASS
- Surface gate not required: POST_REQUEST dispatch, media injection, and platform behavior are unchanged
- No CWS upload/submission

Closes #72
Parent: #12 Phase 4
