### PR TITLE
refactor: route media state through composer controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -71,12 +71,6 @@
     revokeVideoPreview,
   } from '../../src/popup/media-preview';
   import {
-    addFilesToMediaState,
-    moveImageAt,
-    removeImageAt,
-    removeVideoFromState,
-  } from '../../src/popup/media-state';
-  import {
     openPopupGitHubIssue,
     submitPopupErrorReport,
     type PopupReportContext,
@@ -583,7 +577,7 @@
   );
 
   async function processFiles(files: File[]) {
-    const next = await addFilesToMediaState({ images, video, imageAlts }, files);
+    const next = await composerController.addFiles({ images, video, imageAlts }, files);
     images = next.images;
     video = next.video;
     imageAlts = next.imageAlts;
@@ -638,7 +632,7 @@
   }
 
   function removeImage(i: number) {
-    const next = removeImageAt({ images, video, imageAlts }, i);
+    const next = composerController.removeImage({ images, video, imageAlts }, i);
     images = next.images;
     imageAlts = next.imageAlts;
   }
@@ -676,13 +670,13 @@
   }
 
   function moveImage(i: number, delta: -1 | 1): void {
-    const next = moveImageAt({ images, video, imageAlts }, i, delta);
+    const next = composerController.moveImage({ images, video, imageAlts }, i, delta);
     images = next.images;
     imageAlts = next.imageAlts;
   }
 
   function removeVideo() {
-    const next = removeVideoFromState({ images, video, imageAlts });
+    const next = composerController.removeVideo({ images, video, imageAlts });
     video = next.video;
   }
 
@@ -691,9 +685,8 @@
   }
 
   function setImageAlt(index: number, value: string): void {
-    const next = imageAlts.slice();
-    next[index] = value;
-    imageAlts = next;
+    const next = composerController.setImageAlt({ images, video, imageAlts }, index, value);
+    imageAlts = next.imageAlts;
   }
 
   function openFailureReportDialog(text: string): void {

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -115,4 +115,38 @@ describe('composer persistence controller', () => {
     expect(saveDraft).not.toHaveBeenCalled();
     expect(saveSelectedPlatforms).not.toHaveBeenCalled();
   });
+
+  it('coordinates media order, removal, and alt state transitions', () => {
+    const controller = createComposerController();
+    const state = {
+      images: [
+        {
+          name: 'a.png',
+          type: 'image/png',
+          data: 'AA==',
+          previewUrl: 'blob:a',
+        },
+        {
+          name: 'b.png',
+          type: 'image/png',
+          data: 'AA==',
+          previewUrl: 'blob:b',
+        },
+      ],
+      video: null,
+      imageAlts: ['alt a', 'alt b'],
+    };
+
+    const moved = controller.moveImage(state, 1, -1);
+    expect(moved.images.map((image) => image.name)).toEqual(['b.png', 'a.png']);
+    expect(moved.imageAlts).toEqual(['alt b', 'alt a']);
+
+    const withAlt = controller.setImageAlt(moved, 0, 'updated');
+    expect(withAlt.imageAlts).toEqual(['updated', 'alt a']);
+    expect(moved.imageAlts).toEqual(['alt b', 'alt a']);
+
+    const removed = controller.removeImage(withAlt, 1);
+    expect(removed.images.map((image) => image.name)).toEqual(['b.png']);
+    expect(removed.imageAlts).toEqual(['updated']);
+  });
 });

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -13,6 +13,12 @@ import {
   serializeImagesForDraft,
   serializeVideoForDraft,
 } from './media-preview';
+import {
+  addFilesToMediaState,
+  moveImageAt,
+  removeImageAt,
+  removeVideoFromState,
+} from './media-state';
 import type { ImagePreview, VideoPreview } from './types';
 
 export interface ComposerDraftState {
@@ -25,6 +31,12 @@ export interface ComposerDraftSnapshot {
   text: string;
   images: readonly ImagePreview[];
   video: VideoPreview | null;
+}
+
+export interface ComposerMediaState {
+  images: ImagePreview[];
+  video: VideoPreview | null;
+  imageAlts: string[];
 }
 
 export interface ComposerControllerOptions {
@@ -102,6 +114,39 @@ export function createComposerController(options: ComposerControllerOptions = {}
         selectionTimer = undefined;
       }
       await writeSelected({ ...selected });
+    },
+
+    async addFiles(
+      state: ComposerMediaState,
+      files: readonly File[],
+    ): Promise<ComposerMediaState> {
+      return await addFilesToMediaState(state, files);
+    },
+
+    removeImage(state: ComposerMediaState, index: number): ComposerMediaState {
+      return removeImageAt(state, index);
+    },
+
+    moveImage(
+      state: ComposerMediaState,
+      index: number,
+      delta: -1 | 1,
+    ): ComposerMediaState {
+      return moveImageAt(state, index, delta);
+    },
+
+    removeVideo(state: ComposerMediaState): ComposerMediaState {
+      return removeVideoFromState(state);
+    },
+
+    setImageAlt(
+      state: ComposerMediaState,
+      index: number,
+      value: string,
+    ): ComposerMediaState {
+      const imageAlts = state.imageAlts.slice();
+      imageAlts[index] = value;
+      return { ...state, imageAlts };
     },
 
     dispose(): void {


### PR DESCRIPTION
## Summary
- extend the existing composer controller with add/remove/reorder/video/alt media transitions
- keep DOM event extraction in `App.svelte` while routing composer mutations through one controller boundary
- reuse existing media-state helpers and preserve their preview cleanup behavior

## Verification
- `npm run verify:commit`: PASS (89 files / 668 tests + build)
- `npm run e2e:smoke:no-build`: PASS (runtime preview, popup UI, Mastodon simple flow, Instagram wizard flow)
- focused composer/media state tests: PASS
- Surface gate not required: POST_REQUEST dispatch and platform injection are unchanged
- No CWS upload/submission

Closes #74
Parent: #12 Phase 4
