### PR TITLE
refactor: move popup history lifecycle into composer controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -40,10 +40,6 @@
     uncertainPlatforms,
   } from '../../src/popup/post-submit';
   import {
-    loadPopupHistoryThumbs,
-    revokeHistoryThumbUrls,
-  } from '../../src/popup/history-thumbs';
-  import {
     applyPresetSelection,
     createPresetFromSelection,
     removePresetById,
@@ -109,7 +105,6 @@
   // v0.5.9〜 履歴は popup 下部に常時表示 (compact strip)。 詳細・検索・編集は History tab 側で。
   let history = $state<HistoryEntry[]>([]);
   let historyThumbs = $state<Record<string, string[]>>({});
-  let historyThumbUrls: string[] = [];
   let draftLoaded = $state(false);
   let lastSeenUsers = $state<LastSeenUsers>({});
   /** v0.4.86: 失敗 hint card を expand してる platform (null = 全て collapse) */
@@ -328,22 +323,12 @@
     } catch { /* ignore */ }
   }
 
-  async function loadHistory() {
-    revokeHistoryThumbUrls(historyThumbUrls);
-    const { entries, thumbs, objectUrls } = await loadPopupHistoryThumbs();
-    history = entries;
-    historyThumbs = thumbs;
-    historyThumbUrls = objectUrls;
-  }
-
   // v0.5.9: 履歴は常時表示なので popup mount 時に load + storage 変更で auto refresh
   $effect(() => {
-    void loadHistory();
-    const listener = (changes: Record<string, unknown>, area: string): void => {
-      if (area === 'local' && 'postHistory' in changes) void loadHistory();
-    };
-    chrome.storage.onChanged.addListener(listener as Parameters<typeof chrome.storage.onChanged.addListener>[0]);
-    return () => chrome.storage.onChanged.removeListener(listener as Parameters<typeof chrome.storage.onChanged.removeListener>[0]);
+    return composerController.subscribeHistory((next) => {
+      history = next.entries;
+      historyThumbs = next.thumbs;
+    });
   });
 
   // P16: 動画圧縮の進捗 (offscreen から broadcast)
@@ -803,7 +788,7 @@
     } finally {
       posting = false;
       pendingPlatforms = [];
-      void loadHistory(); // v0.5.9〜 常時表示なので必ず refresh
+      void composerController.refreshHistory(); // v0.5.9〜 常時表示なので必ず refresh
     }
   }
 </script>

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -60,6 +60,13 @@ describe('entrypoint architecture guard', () => {
     expect(source).not.toMatch(/\b(?:msg|message)\.type\s*(?:===|!==)/);
     expect(source).not.toMatch(/function\s+handlePostRequest\b/);
   });
+
+  it('keeps popup history lifecycle in the composer controller', () => {
+    const source = readFileSync('entrypoints/popup/App.svelte', 'utf8');
+    expect(source).toContain('composerController.subscribeHistory');
+    expect(source).not.toContain('loadPopupHistoryThumbs');
+    expect(source).not.toContain('storage.onChanged');
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('composer persistence controller', () => {
+describe('composer controller', () => {
   it('loads draft and merges only known persisted platform keys', async () => {
     const controller = createComposerController({
       getDraft: vi.fn(async () => ({ text: 'saved draft' })),
@@ -148,5 +148,54 @@ describe('composer persistence controller', () => {
     const removed = controller.removeImage(withAlt, 1);
     expect(removed.images.map((image) => image.name)).toEqual(['b.png']);
     expect(removed.imageAlts).toEqual(['updated']);
+  });
+
+  it('owns history refresh, storage subscription, and object URL cleanup', async () => {
+    let storageListener:
+      | ((changes: Record<string, unknown>, area: string) => void)
+      | undefined;
+    const unsubscribe = vi.fn();
+    const revokeHistoryUrls = vi.fn();
+    const loadHistory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        entries: [{ id: 'first' }],
+        thumbs: { first: ['blob:first'] },
+        objectUrls: ['blob:first'],
+      })
+      .mockResolvedValueOnce({
+        entries: [{ id: 'second' }],
+        thumbs: { second: ['blob:second'] },
+        objectUrls: ['blob:second'],
+      });
+    const subscriber = vi.fn();
+    const controller = createComposerController({
+      loadHistory,
+      revokeHistoryUrls,
+      subscribeStorageChanges: (listener) => {
+        storageListener = listener;
+        return unsubscribe;
+      },
+    });
+
+    const stop = controller.subscribeHistory(subscriber);
+    await vi.waitFor(() => expect(subscriber).toHaveBeenCalledOnce());
+    expect(subscriber).toHaveBeenLastCalledWith({
+      entries: [{ id: 'first' }],
+      thumbs: { first: ['blob:first'] },
+    });
+
+    storageListener?.({ unrelated: {} }, 'local');
+    storageListener?.({ postHistory: {} }, 'sync');
+    expect(loadHistory).toHaveBeenCalledOnce();
+
+    storageListener?.({ postHistory: {} }, 'local');
+    await vi.waitFor(() => expect(subscriber).toHaveBeenCalledTimes(2));
+    expect(revokeHistoryUrls).toHaveBeenCalledWith(['blob:first']);
+
+    stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    controller.dispose();
+    expect(revokeHistoryUrls).toHaveBeenLastCalledWith(['blob:second']);
   });
 });

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -5,8 +5,14 @@ import {
   saveDraft,
   saveSelectedPlatforms,
   type Draft,
+  type HistoryEntry,
   type SelectedPlatforms,
 } from '../storage';
+import {
+  loadPopupHistoryThumbs,
+  revokeHistoryThumbUrls,
+  type PopupHistoryThumbs,
+} from './history-thumbs';
 import {
   restoreImagePreviews,
   restoreVideoPreview,
@@ -39,13 +45,38 @@ export interface ComposerMediaState {
   imageAlts: string[];
 }
 
+export interface ComposerHistoryState {
+  entries: HistoryEntry[];
+  thumbs: Record<string, string[]>;
+}
+
+type HistoryStorageChangeListener = (
+  changes: Record<string, unknown>,
+  area: string,
+) => void;
+
 export interface ComposerControllerOptions {
   getDraft?: () => Promise<Draft | null>;
   saveDraft?: (draft: Draft) => Promise<void>;
   getSelectedPlatforms?: () => Promise<SelectedPlatforms | null>;
   saveSelectedPlatforms?: (selected: SelectedPlatforms) => Promise<void>;
+  loadHistory?: () => Promise<PopupHistoryThumbs>;
+  revokeHistoryUrls?: (urls: readonly string[]) => void;
+  subscribeStorageChanges?: (
+    listener: HistoryStorageChangeListener,
+  ) => () => void;
   draftDebounceMs?: number;
   selectionDebounceMs?: number;
+}
+
+function subscribeStorageChanges(
+  listener: HistoryStorageChangeListener,
+): () => void {
+  const rawListener = listener as Parameters<
+    typeof browser.storage.onChanged.addListener
+  >[0];
+  browser.storage.onChanged.addListener(rawListener);
+  return () => browser.storage.onChanged.removeListener(rawListener);
 }
 
 export function createComposerController(options: ComposerControllerOptions = {}) {
@@ -53,10 +84,30 @@ export function createComposerController(options: ComposerControllerOptions = {}
   const writeDraft = options.saveDraft ?? saveDraft;
   const readSelected = options.getSelectedPlatforms ?? getSelectedPlatforms;
   const writeSelected = options.saveSelectedPlatforms ?? saveSelectedPlatforms;
+  const readHistory = options.loadHistory ?? loadPopupHistoryThumbs;
+  const revokeHistory = options.revokeHistoryUrls ?? revokeHistoryThumbUrls;
+  const watchStorage = options.subscribeStorageChanges ?? subscribeStorageChanges;
   const draftDebounceMs = options.draftDebounceMs ?? 300;
   const selectionDebounceMs = options.selectionDebounceMs ?? 200;
   let draftTimer: ReturnType<typeof setTimeout> | undefined;
   let selectionTimer: ReturnType<typeof setTimeout> | undefined;
+  let historyObjectUrls: string[] = [];
+  let historySubscriber: ((state: ComposerHistoryState) => void) | undefined;
+  let stopHistorySubscription: (() => void) | undefined;
+  let historyRequest = 0;
+  let disposed = false;
+
+  const refreshHistory = async (): Promise<void> => {
+    const request = ++historyRequest;
+    const { entries, thumbs, objectUrls } = await readHistory();
+    if (disposed || request !== historyRequest) {
+      revokeHistory(objectUrls);
+      return;
+    }
+    revokeHistory(historyObjectUrls);
+    historyObjectUrls = objectUrls;
+    historySubscriber?.({ entries, thumbs });
+  };
 
   return {
     async loadDraft(): Promise<ComposerDraftState | null> {
@@ -149,11 +200,39 @@ export function createComposerController(options: ComposerControllerOptions = {}
       return { ...state, imageAlts };
     },
 
+    refreshHistory,
+
+    subscribeHistory(
+      subscriber: (state: ComposerHistoryState) => void,
+    ): () => void {
+      historySubscriber = subscriber;
+      stopHistorySubscription?.();
+      const onStorageChange: HistoryStorageChangeListener = (changes, area) => {
+        if (area === 'local' && 'postHistory' in changes) {
+          void refreshHistory().catch(() => {});
+        }
+      };
+      stopHistorySubscription = watchStorage(onStorageChange);
+      void refreshHistory().catch(() => {});
+      return () => {
+        if (historySubscriber === subscriber) historySubscriber = undefined;
+        stopHistorySubscription?.();
+        stopHistorySubscription = undefined;
+      };
+    },
+
     dispose(): void {
+      disposed = true;
       if (draftTimer) clearTimeout(draftTimer);
       if (selectionTimer) clearTimeout(selectionTimer);
       draftTimer = undefined;
       selectionTimer = undefined;
+      historyRequest++;
+      stopHistorySubscription?.();
+      stopHistorySubscription = undefined;
+      historySubscriber = undefined;
+      revokeHistory(historyObjectUrls);
+      historyObjectUrls = [];
     },
   };
 }


### PR DESCRIPTION
## Summary

- move popup history loading and storage-change refresh into the existing composer controller
- centralize thumbnail object URL replacement and disposal
- add unit and architecture guards for the controller boundary

## Verification

- `npm run verify:commit` PASS (89 files / 670 tests + build)
- `npm run e2e:smoke:no-build` PASS
- Surface not required: posting dispatch and platform injection are unchanged
- no CWS upload or submission

Closes #76
Parent #12 Phase 4