### PR TITLE
refactor: move popup background synchronization into composer controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -5,7 +5,6 @@
   } from '../../src/messages';
   import { getAdapter } from '../../src/adapters/registry';
   import { initLogLevelFromSettings } from '../../src/utils/logger';
-  import { decodeMessage } from '../../src/utils/message-decoder';
   import {
     clearDraft,
     getLastSeenUsers,
@@ -46,9 +45,6 @@
     selectedPlatformIds,
   } from '../../src/popup/presets';
   import {
-    applyBackgroundState,
-    applyProgressMessage,
-    type BgStateResponse,
     type CompressionProgress,
     type PostingViewState,
   } from '../../src/popup/posting-progress';
@@ -411,22 +407,6 @@
     });
   }
 
-  // P19 / v0.4.63: popup 閉じ→再 open 時、background が保持してる進行状態を
-  // 復元する。pending / 完了済 results / 圧縮進捗 を全部復元することで、
-  // 「2/7 完了済み、5 投稿中」のような中間状態でも閉じ→開きで正しく表示される。
-  // 旧コードは posting boolean だけ復元していたので、再 open すると pending /
-  // results が空 → 全 SNS が isQueued (「Queue...」) と誤表示されていた。
-  $effect(() => {
-    void browser.runtime.sendMessage({ type: 'GET_BG_STATE' }).then((res: unknown) => {
-      const r = res as BgStateResponse | undefined;
-      const next = applyBackgroundState(r, currentPostingViewState());
-      applyPostingViewState(next);
-      if (!next.posting && next.lastResults?.length) {
-        lastResultDraftKey = currentDraftKey();
-      }
-    }).catch(() => { /* background sleep してたら null 戻り、無視 */ });
-  });
-
   $effect(() => {
     void refreshExtensionUpdateState();
   });
@@ -443,21 +423,22 @@
     lastResultDraftKey = null;
   });
 
-  // background からの進捗ストリームを受信
+  // popup 再表示時の状態復元と background からの進捗ストリームを購読
   $effect(() => {
-    const listener = (rawMsg: unknown) => {
-      const msg = decodeMessage(rawMsg);
-      if (!msg) return;
-      const next = applyProgressMessage(msg, currentPostingViewState());
-      if (next) applyPostingViewState(next);
-      if (msg.type === 'EXTENSION_UPDATE_AVAILABLE') {
-        updateAvailableVersion = msg.state.version ?? '';
-        updateApplying = msg.state.applying === true;
+    return composerController.subscribeBackgroundSync({
+      getPostingState: currentPostingViewState,
+      onPostingState: (next, source) => {
+        applyPostingViewState(next);
+        if (source === 'restore' && !next.posting && next.lastResults?.length) {
+          lastResultDraftKey = currentDraftKey();
+        }
+      },
+      onUpdateAvailable: (state) => {
+        updateAvailableVersion = state.version ?? '';
+        updateApplying = state.applying === true;
         updateError = null;
-      }
-    };
-    browser.runtime.onMessage.addListener(listener);
-    return () => browser.runtime.onMessage.removeListener(listener);
+      },
+    });
   });
 
   function handleKeydown(e: KeyboardEvent) {

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -67,6 +67,14 @@ describe('entrypoint architecture guard', () => {
     expect(source).not.toContain('loadPopupHistoryThumbs');
     expect(source).not.toContain('storage.onChanged');
   });
+
+  it('keeps popup background synchronization in the composer controller', () => {
+    const source = readFileSync('entrypoints/popup/App.svelte', 'utf8');
+    expect(source).toContain('composerController.subscribeBackgroundSync');
+    expect(source).not.toContain("type: 'GET_BG_STATE'");
+    expect(source).not.toContain('runtime.onMessage.addListener');
+    expect(source).not.toContain('applyProgressMessage');
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -198,4 +198,72 @@ describe('composer controller', () => {
     controller.dispose();
     expect(revokeHistoryUrls).toHaveBeenLastCalledWith(['blob:second']);
   });
+
+  it('restores and streams background posting state and update notifications', async () => {
+    let runtimeListener: ((message: unknown) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const sendRuntimeMessage = vi.fn(async () => ({
+      posting: true,
+      postingState: {
+        pending: ['x'],
+        results: [],
+        done: false,
+      },
+    }));
+    let current = {
+      posting: false,
+      pendingPlatforms: [],
+      lastResults: null,
+      compressionProgress: null,
+      compressionStartedAt: null,
+      compressionEtaS: null,
+    };
+    const onPostingState = vi.fn((next) => {
+      current = next;
+    });
+    const onUpdateAvailable = vi.fn();
+    const controller = createComposerController({
+      sendRuntimeMessage,
+      subscribeRuntimeMessages: (listener) => {
+        runtimeListener = listener;
+        return unsubscribe;
+      },
+    });
+
+    const stop = controller.subscribeBackgroundSync({
+      getPostingState: () => current,
+      onPostingState,
+      onUpdateAvailable,
+    });
+    await vi.waitFor(() => expect(onPostingState).toHaveBeenCalledOnce());
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({ type: 'GET_BG_STATE' });
+    expect(onPostingState).toHaveBeenLastCalledWith({
+      ...current,
+      posting: true,
+      pendingPlatforms: ['x'],
+    }, 'restore');
+
+    runtimeListener?.({
+      type: 'CONVERSION_PROGRESS',
+      stage: 'load',
+      progress: 0.25,
+    });
+    expect(onPostingState).toHaveBeenLastCalledWith({
+      ...current,
+      compressionProgress: { stage: 'load', progress: 0.25 },
+    }, 'progress');
+
+    runtimeListener?.({
+      type: 'EXTENSION_UPDATE_AVAILABLE',
+      state: { available: true, version: '0.6.0', applying: false },
+    });
+    expect(onUpdateAvailable).toHaveBeenCalledWith({
+      available: true,
+      version: '0.6.0',
+      applying: false,
+    });
+
+    stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
 });

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -1,4 +1,6 @@
+import type { ExtensionUpdateState } from '../messages';
 import type { PlatformId } from '../types/platform';
+import { decodeMessage } from '../utils/message-decoder';
 import {
   getDraft,
   getSelectedPlatforms,
@@ -25,6 +27,12 @@ import {
   removeImageAt,
   removeVideoFromState,
 } from './media-state';
+import {
+  applyBackgroundState,
+  applyProgressMessage,
+  type BgStateResponse,
+  type PostingViewState,
+} from './posting-progress';
 import type { ImagePreview, VideoPreview } from './types';
 
 export interface ComposerDraftState {
@@ -55,6 +63,15 @@ type HistoryStorageChangeListener = (
   area: string,
 ) => void;
 
+export interface ComposerBackgroundSyncCallbacks {
+  getPostingState: () => PostingViewState;
+  onPostingState: (
+    state: PostingViewState,
+    source: 'restore' | 'progress',
+  ) => void;
+  onUpdateAvailable: (state: ExtensionUpdateState) => void;
+}
+
 export interface ComposerControllerOptions {
   getDraft?: () => Promise<Draft | null>;
   saveDraft?: (draft: Draft) => Promise<void>;
@@ -64,6 +81,10 @@ export interface ComposerControllerOptions {
   revokeHistoryUrls?: (urls: readonly string[]) => void;
   subscribeStorageChanges?: (
     listener: HistoryStorageChangeListener,
+  ) => () => void;
+  sendRuntimeMessage?: (message: unknown) => Promise<unknown>;
+  subscribeRuntimeMessages?: (
+    listener: (message: unknown) => void,
   ) => () => void;
   draftDebounceMs?: number;
   selectionDebounceMs?: number;
@@ -79,6 +100,13 @@ function subscribeStorageChanges(
   return () => browser.storage.onChanged.removeListener(rawListener);
 }
 
+function subscribeRuntimeMessages(
+  listener: (message: unknown) => void,
+): () => void {
+  browser.runtime.onMessage.addListener(listener);
+  return () => browser.runtime.onMessage.removeListener(listener);
+}
+
 export function createComposerController(options: ComposerControllerOptions = {}) {
   const readDraft = options.getDraft ?? getDraft;
   const writeDraft = options.saveDraft ?? saveDraft;
@@ -87,6 +115,9 @@ export function createComposerController(options: ComposerControllerOptions = {}
   const readHistory = options.loadHistory ?? loadPopupHistoryThumbs;
   const revokeHistory = options.revokeHistoryUrls ?? revokeHistoryThumbUrls;
   const watchStorage = options.subscribeStorageChanges ?? subscribeStorageChanges;
+  const sendRuntimeMessage = options.sendRuntimeMessage ??
+    ((message: unknown) => browser.runtime.sendMessage(message));
+  const watchRuntime = options.subscribeRuntimeMessages ?? subscribeRuntimeMessages;
   const draftDebounceMs = options.draftDebounceMs ?? 300;
   const selectionDebounceMs = options.selectionDebounceMs ?? 200;
   let draftTimer: ReturnType<typeof setTimeout> | undefined;
@@ -94,6 +125,7 @@ export function createComposerController(options: ComposerControllerOptions = {}
   let historyObjectUrls: string[] = [];
   let historySubscriber: ((state: ComposerHistoryState) => void) | undefined;
   let stopHistorySubscription: (() => void) | undefined;
+  let stopBackgroundSubscription: (() => void) | undefined;
   let historyRequest = 0;
   let disposed = false;
 
@@ -221,6 +253,43 @@ export function createComposerController(options: ComposerControllerOptions = {}
       };
     },
 
+    subscribeBackgroundSync(
+      callbacks: ComposerBackgroundSyncCallbacks,
+    ): () => void {
+      stopBackgroundSubscription?.();
+      let active = true;
+      const listener = (rawMessage: unknown): void => {
+        if (!active || disposed) return;
+        const message = decodeMessage(rawMessage);
+        if (!message) return;
+        const next = applyProgressMessage(message, callbacks.getPostingState());
+        if (next) callbacks.onPostingState(next, 'progress');
+        if (message.type === 'EXTENSION_UPDATE_AVAILABLE') {
+          callbacks.onUpdateAvailable(message.state);
+        }
+      };
+      const stop = watchRuntime(listener);
+      stopBackgroundSubscription = () => {
+        active = false;
+        stop();
+      };
+      void sendRuntimeMessage({ type: 'GET_BG_STATE' })
+        .then((response) => {
+          if (!active || disposed) return;
+          const next = applyBackgroundState(
+            response as BgStateResponse | undefined,
+            callbacks.getPostingState(),
+          );
+          callbacks.onPostingState(next, 'restore');
+        })
+        .catch(() => {});
+      return () => {
+        if (!active) return;
+        stopBackgroundSubscription?.();
+        stopBackgroundSubscription = undefined;
+      };
+    },
+
     dispose(): void {
       disposed = true;
       if (draftTimer) clearTimeout(draftTimer);
@@ -230,6 +299,8 @@ export function createComposerController(options: ComposerControllerOptions = {}
       historyRequest++;
       stopHistorySubscription?.();
       stopHistorySubscription = undefined;
+      stopBackgroundSubscription?.();
+      stopBackgroundSubscription = undefined;
       historySubscriber = undefined;
       revokeHistory(historyObjectUrls);
       historyObjectUrls = [];


### PR DESCRIPTION
## Summary

- move popup background state restoration into the existing composer controller
- centralize decoded progress/update message subscription and listener cleanup
- keep Svelte state assignment and draft-key coordination in App.svelte
- add unit and architecture guards for the synchronization boundary

## Verification

- `npm run verify:commit` PASS (89 files / 672 tests + build)
- `npm run e2e:smoke:no-build` PASS
- Surface not required: posting dispatch and platform injection are unchanged
- no CWS upload or submission

Closes #78
Parent #12 Phase 4