### PR TITLE
refactor: move popup support workflows into composer controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -63,11 +63,9 @@
     revokeVideoPreview,
   } from '../../src/popup/media-preview';
   import {
-    openPopupGitHubIssue,
-    submitPopupErrorReport,
-    type PopupReportContext,
-  } from '../../src/popup/error-report-submit';
-  import { createComposerController } from '../../src/popup/composer-controller';
+    createComposerController,
+    type ComposerReportContext,
+  } from '../../src/popup/composer-controller';
   import HeaderBar from './components/HeaderBar.svelte';
   import AutoPostControl from './components/AutoPostControl.svelte';
   import MediaComposer from './components/MediaComposer.svelte';
@@ -167,11 +165,7 @@
     }
   });
 
-  // CF Workers proxy が GitHub Issues に転送する。1-click で報告可能。
-  // proxy が落ちてた / network エラーの場合は GitHub URL fallback を提示。
-  const REPORT_ENDPOINT = 'https://tutti-report.komm64.workers.dev';
-
-  function buildReportContext(): PopupReportContext {
+  function buildReportContext(): ComposerReportContext {
     return {
       version,
       text,
@@ -194,12 +188,11 @@
     reportSubmitting = true;
     reportResult = null;
     try {
-      reportResult = await submitPopupErrorReport({
+      reportResult = await composerController.submitErrorReport(
         errorText,
-        context: buildReportContext(),
-        endpoint: REPORT_ENDPOINT,
-        dedupedMessage: (hours) => t('reportDeduped', String(hours)),
-      });
+        buildReportContext(),
+        (hours) => t('reportDeduped', String(hours)),
+      );
     } catch (e) {
       reportResult = { ok: false, error: e instanceof Error ? e.message : String(e) };
     } finally {
@@ -215,12 +208,12 @@
    * にも入れる、 GitHub new issue form の body field に user が paste する形。
    */
   async function openGitHubIssueDirect(errorText: string): Promise<void> {
-    await openPopupGitHubIssue({
+    await composerController.openGitHubIssue(
       errorText,
-      context: buildReportContext(),
-      note: t('reportEmailNote'),
-      overflowNote: t('reportClipboardOverflow'),
-    });
+      buildReportContext(),
+      t('reportEmailNote'),
+      t('reportClipboardOverflow'),
+    );
   }
   // 永続選択を読み込んだあとに autoPost トグルが変わったら保存
   $effect(() => {
@@ -298,25 +291,14 @@
   async function runDiagnostics() {
     diagnosticsRunning = true;
     diagnosticsText = null;
-    try {
-      const res = (await browser.runtime.sendMessage({ type: 'DIAGNOSE_REQUEST' })) as
-        | { report?: unknown; error?: string }
-        | undefined;
-      if (res?.error) diagnosticsText = `error: ${res.error}`;
-      else diagnosticsText = JSON.stringify(res?.report ?? null, null, 2);
-    } catch (e) {
-      diagnosticsText = `error: ${e instanceof Error ? e.message : String(e)}`;
-    } finally {
-      diagnosticsRunning = false;
-    }
+    diagnosticsText = await composerController.runDiagnostics();
+    diagnosticsRunning = false;
   }
   async function copyDiagnostics() {
     if (!diagnosticsText) return;
-    try {
-      await navigator.clipboard.writeText(diagnosticsText);
-      diagnosticsCopied = true;
-      setTimeout(() => { diagnosticsCopied = false; }, 1500);
-    } catch { /* ignore */ }
+    if (!await composerController.copyDiagnostics(diagnosticsText)) return;
+    diagnosticsCopied = true;
+    setTimeout(() => { diagnosticsCopied = false; }, 1500);
   }
 
   // v0.5.9: 履歴は常時表示なので popup mount 時に load + storage 変更で auto refresh
@@ -354,20 +336,10 @@
   }
 
   async function refreshExtensionUpdateState(): Promise<void> {
-    try {
-      const res = (await browser.runtime.sendMessage({ type: 'GET_EXTENSION_UPDATE_STATE' })) as
-        | { state?: { available?: boolean; version?: string; applying?: boolean }; error?: string }
-        | undefined;
-      if (res?.state?.available) {
-        updateAvailableVersion = res.state.version ?? '';
-        updateApplying = res.state.applying === true;
-      } else {
-        updateAvailableVersion = null;
-        updateApplying = false;
-      }
-    } catch {
-      // background が sleep 中なら次回 open / update event で拾えるので無視。
-    }
+    const state = await composerController.refreshExtensionUpdateState();
+    if (!state) return; // background sleep 中なら次回 open / update event で拾う
+    updateAvailableVersion = state.available ? state.version ?? '' : null;
+    updateApplying = state.available && state.applying === true;
   }
 
   function updateErrorMessage(error: string, detail?: string): string {
@@ -379,17 +351,13 @@
   async function applyExtensionUpdate(): Promise<void> {
     updateApplying = true;
     updateError = null;
-    try {
-      const res = (await browser.runtime.sendMessage({ type: 'APPLY_EXTENSION_UPDATE' })) as
-        | { ok?: boolean; error?: string; detail?: string }
-        | undefined;
-      if (!res?.ok) {
-        updateApplying = false;
-        updateError = updateErrorMessage(res?.error ?? 'reload_failed', res?.detail);
-      }
-    } catch (e) {
+    const result = await composerController.applyExtensionUpdate();
+    if (!result.ok) {
       updateApplying = false;
-      updateError = updateErrorMessage('reload_failed', e instanceof Error ? e.message : String(e));
+      updateError = updateErrorMessage(
+        result.error ?? 'reload_failed',
+        result.detail,
+      );
     }
   }
 

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -75,6 +75,16 @@ describe('entrypoint architecture guard', () => {
     expect(source).not.toContain('runtime.onMessage.addListener');
     expect(source).not.toContain('applyProgressMessage');
   });
+
+  it('keeps popup support workflows in the composer controller', () => {
+    const source = readFileSync('entrypoints/popup/App.svelte', 'utf8');
+    expect(source).toContain('composerController.runDiagnostics');
+    expect(source).toContain('composerController.submitErrorReport');
+    expect(source).toContain('composerController.applyExtensionUpdate');
+    expect(source).not.toContain('submitPopupErrorReport');
+    expect(source).not.toContain("type: 'DIAGNOSE_REQUEST'");
+    expect(source).not.toContain("type: 'APPLY_EXTENSION_UPDATE'");
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -266,4 +266,61 @@ describe('composer controller', () => {
     stop();
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
+
+  it('owns diagnostics, reporting, clipboard, and update workflows', async () => {
+    const sendRuntimeMessage = vi.fn(async (message: unknown) => {
+      const type = (message as { type?: string }).type;
+      if (type === 'DIAGNOSE_REQUEST') return { report: { status: 'ok' } };
+      if (type === 'GET_EXTENSION_UPDATE_STATE') {
+        return { state: { available: true, version: '0.6.0' } };
+      }
+      if (type === 'APPLY_EXTENSION_UPDATE') return { ok: false, error: 'posting_in_progress' };
+      return undefined;
+    });
+    const writeClipboard = vi.fn(async () => {});
+    const submitErrorReport = vi.fn(async () => ({ ok: true, issueUrl: 'https://example.test/1' }));
+    const openGitHubIssue = vi.fn(async () => {});
+    const controller = createComposerController({
+      sendRuntimeMessage,
+      writeClipboard,
+      submitErrorReport,
+      openGitHubIssue,
+      reportEndpoint: 'https://report.example.test',
+    });
+    const context = { version: '0.5.49' } as never;
+
+    await expect(controller.runDiagnostics()).resolves.toBe(
+      JSON.stringify({ status: 'ok' }, null, 2),
+    );
+    await expect(controller.copyDiagnostics('diagnostics')).resolves.toBe(true);
+    expect(writeClipboard).toHaveBeenCalledWith('diagnostics');
+    await expect(controller.refreshExtensionUpdateState()).resolves.toEqual({
+      available: true,
+      version: '0.6.0',
+    });
+    await expect(controller.applyExtensionUpdate()).resolves.toEqual({
+      ok: false,
+      error: 'posting_in_progress',
+    });
+
+    await expect(controller.submitErrorReport(
+      'failed',
+      context,
+      (hours) => `deduped ${hours}`,
+    )).resolves.toEqual({ ok: true, issueUrl: 'https://example.test/1' });
+    expect(submitErrorReport).toHaveBeenCalledWith({
+      errorText: 'failed',
+      context,
+      endpoint: 'https://report.example.test',
+      dedupedMessage: expect.any(Function),
+    });
+
+    await controller.openGitHubIssue('failed', context, 'note', 'overflow');
+    expect(openGitHubIssue).toHaveBeenCalledWith({
+      errorText: 'failed',
+      context,
+      note: 'note',
+      overflowNote: 'overflow',
+    });
+  });
 });

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -16,6 +16,11 @@ import {
   type PopupHistoryThumbs,
 } from './history-thumbs';
 import {
+  openPopupGitHubIssue,
+  submitPopupErrorReport,
+  type PopupReportContext,
+} from './error-report-submit';
+import {
   restoreImagePreviews,
   restoreVideoPreview,
   serializeImagesForDraft,
@@ -33,7 +38,13 @@ import {
   type BgStateResponse,
   type PostingViewState,
 } from './posting-progress';
-import type { ImagePreview, VideoPreview } from './types';
+import type {
+  ImagePreview,
+  ReportResult,
+  VideoPreview,
+} from './types';
+
+const DEFAULT_REPORT_ENDPOINT = 'https://tutti-report.komm64.workers.dev';
 
 export interface ComposerDraftState {
   text: string;
@@ -72,6 +83,14 @@ export interface ComposerBackgroundSyncCallbacks {
   onUpdateAvailable: (state: ExtensionUpdateState) => void;
 }
 
+export type ComposerReportContext = PopupReportContext;
+
+export interface ComposerUpdateApplyResult {
+  ok: boolean;
+  error?: string;
+  detail?: string;
+}
+
 export interface ComposerControllerOptions {
   getDraft?: () => Promise<Draft | null>;
   saveDraft?: (draft: Draft) => Promise<void>;
@@ -86,6 +105,10 @@ export interface ComposerControllerOptions {
   subscribeRuntimeMessages?: (
     listener: (message: unknown) => void,
   ) => () => void;
+  submitErrorReport?: typeof submitPopupErrorReport;
+  openGitHubIssue?: typeof openPopupGitHubIssue;
+  writeClipboard?: (text: string) => Promise<void>;
+  reportEndpoint?: string;
   draftDebounceMs?: number;
   selectionDebounceMs?: number;
 }
@@ -118,6 +141,11 @@ export function createComposerController(options: ComposerControllerOptions = {}
   const sendRuntimeMessage = options.sendRuntimeMessage ??
     ((message: unknown) => browser.runtime.sendMessage(message));
   const watchRuntime = options.subscribeRuntimeMessages ?? subscribeRuntimeMessages;
+  const submitReport = options.submitErrorReport ?? submitPopupErrorReport;
+  const openGitHubIssue = options.openGitHubIssue ?? openPopupGitHubIssue;
+  const writeClipboard = options.writeClipboard ??
+    ((text: string) => navigator.clipboard.writeText(text));
+  const reportEndpoint = options.reportEndpoint ?? DEFAULT_REPORT_ENDPOINT;
   const draftDebounceMs = options.draftDebounceMs ?? 300;
   const selectionDebounceMs = options.selectionDebounceMs ?? 200;
   let draftTimer: ReturnType<typeof setTimeout> | undefined;
@@ -288,6 +316,77 @@ export function createComposerController(options: ComposerControllerOptions = {}
         stopBackgroundSubscription?.();
         stopBackgroundSubscription = undefined;
       };
+    },
+
+    async runDiagnostics(): Promise<string> {
+      try {
+        const response = await sendRuntimeMessage({ type: 'DIAGNOSE_REQUEST' }) as
+          | { report?: unknown; error?: string }
+          | undefined;
+        return response?.error
+          ? `error: ${response.error}`
+          : JSON.stringify(response?.report ?? null, null, 2);
+      } catch (error) {
+        return `error: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    },
+
+    async copyDiagnostics(text: string): Promise<boolean> {
+      if (!text) return false;
+      try {
+        await writeClipboard(text);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    async refreshExtensionUpdateState(): Promise<ExtensionUpdateState | undefined> {
+      try {
+        const response = await sendRuntimeMessage({
+          type: 'GET_EXTENSION_UPDATE_STATE',
+        }) as { state?: ExtensionUpdateState } | undefined;
+        return response?.state ?? { available: false };
+      } catch {
+        return undefined;
+      }
+    },
+
+    async applyExtensionUpdate(): Promise<ComposerUpdateApplyResult> {
+      try {
+        const response = await sendRuntimeMessage({
+          type: 'APPLY_EXTENSION_UPDATE',
+        }) as ComposerUpdateApplyResult | undefined;
+        return response ?? { ok: false, error: 'reload_failed' };
+      } catch (error) {
+        return {
+          ok: false,
+          error: 'reload_failed',
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    async submitErrorReport(
+      errorText: string,
+      context: ComposerReportContext,
+      dedupedMessage: (hours: number) => string,
+    ): Promise<ReportResult> {
+      return await submitReport({
+        errorText,
+        context,
+        endpoint: reportEndpoint,
+        dedupedMessage,
+      });
+    },
+
+    async openGitHubIssue(
+      errorText: string,
+      context: ComposerReportContext,
+      note: string,
+      overflowNote: string,
+    ): Promise<void> {
+      await openGitHubIssue({ errorText, context, note, overflowNote });
     },
 
     dispose(): void {


### PR DESCRIPTION
## Summary

- route diagnostics generation and clipboard copy through the existing composer controller
- route error report submission and GitHub fallback through the same controller
- route extension update state/apply requests through the controller while keeping localized UI state in Svelte
- add unit and architecture guards for the support-workflow boundary

## Verification

- `npm run verify:commit` PASS (89 files / 674 tests + build)
- `npm run e2e:smoke:no-build` PASS
- Surface not required: posting dispatch and platform injection are unchanged
- no CWS upload or submission

Closes #80
Parent #12 Phase 4