### PR TITLE
refactor: move popup submission orchestration into composer controller

### DIFF
--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -6,7 +6,6 @@
   import { getAdapter } from '../../src/adapters/registry';
   import { initLogLevelFromSettings } from '../../src/utils/logger';
   import {
-    clearDraft,
     getLastSeenUsers,
     getSettings,
     saveSettings,
@@ -30,14 +29,7 @@
     VideoPreview,
     Visibility,
   } from '../../src/popup/types';
-  import {
-    failedRetryPlatforms,
-    mergePostResults,
-    normalizeRetryGuardResults,
-    sendPostRequest,
-    shouldClearDraftAfterSubmit,
-    uncertainPlatforms,
-  } from '../../src/popup/post-submit';
+  import { uncertainPlatforms } from '../../src/popup/post-submit';
   import {
     applyPresetSelection,
     createPresetFromSelection,
@@ -59,12 +51,12 @@
   import {
     filesFromClipboardItems,
     isFileDrag,
-    revokeImagePreviews,
-    revokeVideoPreview,
   } from '../../src/popup/media-preview';
   import {
     createComposerController,
     type ComposerReportContext,
+    type ComposerSubmissionInput,
+    type ComposerSubmissionPatch,
   } from '../../src/popup/composer-controller';
   import HeaderBar from './components/HeaderBar.svelte';
   import AutoPostControl from './components/AutoPostControl.svelte';
@@ -375,6 +367,41 @@
     });
   }
 
+  function currentSubmissionInput(): ComposerSubmissionInput {
+    return {
+      text,
+      selectedIds,
+      images,
+      video,
+      imageAlts,
+      cw,
+      visibility,
+      trimToS,
+      autoPost,
+      backgroundNoResponseMessage: t('backgroundNoResponse'),
+    };
+  }
+
+  function applySubmissionPatch(patch: ComposerSubmissionPatch): void {
+    if (patch.posting !== undefined) posting = patch.posting;
+    if (patch.pendingPlatforms) pendingPlatforms = patch.pendingPlatforms;
+    if ('lastResults' in patch) lastResults = patch.lastResults ?? null;
+    if ('errorMessage' in patch) errorMessage = patch.errorMessage ?? null;
+    if (patch.draft) {
+      text = patch.draft.text;
+      images = patch.draft.images;
+      video = patch.draft.video;
+    }
+    if (patch.lastResultDraftKey !== undefined) {
+      lastResultDraftKey = patch.lastResultDraftKey;
+    }
+  }
+
+  const submissionCallbacks = {
+    getLastResults: () => lastResults,
+    applyPatch: applySubmissionPatch,
+  };
+
   $effect(() => {
     void refreshExtensionUpdateState();
   });
@@ -672,73 +699,20 @@
    * 正規化する。
    */
   async function handleRetryFailed() {
-    if (!lastResults || posting) return;
-    const failedIds = failedRetryPlatforms(lastResults);
-    if (failedIds.length === 0) return;
-
-    // 既存の失敗 entry だけ消す。成功 entry は維持して result panel に表示し続ける
-    lastResults = lastResults.filter((r) => r.success);
-    await submitPostFor(failedIds, /* isRetry */ true);
+    await composerController.retryFailed(
+      currentSubmissionInput(),
+      posting,
+      submissionCallbacks,
+    );
   }
 
   async function submitPostFor(platforms: PlatformId[], isRetry: boolean) {
-    if (platforms.length === 0) return;
-    const requestAutoPost = autoPost;
-    const submissionDraftKey = currentDraftKey();
-    posting = true;
-    if (!isRetry) {
-      lastResults = [];
-    }
-    pendingPlatforms = [...platforms];
-    errorMessage = null;
-
-    try {
-      const response = await sendPostRequest({
-        text,
-        platforms,
-        images,
-        video,
-        imageAlts,
-        autoPost: requestAutoPost,
-        cw,
-        visibility,
-        trimToS,
-        intent: isRetry ? 'retry' : 'new',
-      });
-      if (!response) {
-        errorMessage = t('backgroundNoResponse');
-      } else if (response.error) {
-        errorMessage = response.error;
-      } else if (response.results) {
-        // retry の場合は既存の成功 entries を残してマージ。新規 (= 失敗だった
-        // platform の新結果) を上書き、別の platform は既存 entry を維持。
-        const normalizedResults = isRetry
-          ? normalizeRetryGuardResults(response.results)
-          : response.results;
-        lastResults = mergePostResults(lastResults, normalizedResults, isRetry);
-        pendingPlatforms = []; // 進捗ストリームの取りこぼし保険
-        // 全成功(retry 後を含む)で下書きをクリア。retry 後の lastResults に
-        // failure が 1 件でも残ってたら text / media は維持する (= 再々送可能)
-        // preview は SNS compose への投入成功であり実投稿ではないため、draft は残す。
-        if (shouldClearDraftAfterSubmit(requestAutoPost, lastResults)) {
-          text = '';
-          revokeImagePreviews(images);
-          images = [];
-          revokeVideoPreview(video);
-          video = null;
-          void clearDraft();
-          lastResultDraftKey = currentDraftKey();
-        } else {
-          lastResultDraftKey = submissionDraftKey;
-        }
-      }
-    } catch (err) {
-      errorMessage = err instanceof Error ? err.message : String(err);
-    } finally {
-      posting = false;
-      pendingPlatforms = [];
-      void composerController.refreshHistory(); // v0.5.9〜 常時表示なので必ず refresh
-    }
+    await composerController.submitPlatforms(
+      currentSubmissionInput(),
+      platforms,
+      isRetry,
+      submissionCallbacks,
+    );
   }
 </script>
 

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -85,6 +85,16 @@ describe('entrypoint architecture guard', () => {
     expect(source).not.toContain("type: 'DIAGNOSE_REQUEST'");
     expect(source).not.toContain("type: 'APPLY_EXTENSION_UPDATE'");
   });
+
+  it('keeps popup submission orchestration in the composer controller', () => {
+    const source = readFileSync('entrypoints/popup/App.svelte', 'utf8');
+    expect(source).toContain('composerController.submitPlatforms');
+    expect(source).toContain('composerController.retryFailed');
+    expect(source).not.toContain('sendPostRequest');
+    expect(source).not.toContain('mergePostResults');
+    expect(source).not.toContain('shouldClearDraftAfterSubmit');
+    expect(source).not.toContain('failedRetryPlatforms');
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/popup/composer-controller.test.ts
+++ b/src/popup/composer-controller.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { PostResultMessage } from '../messages';
 import { DEFAULT_SELECTED_PLATFORMS } from './platforms';
 import {
   createComposerController,
@@ -322,5 +323,136 @@ describe('composer controller', () => {
       note: 'note',
       overflowNote: 'overflow',
     });
+  });
+
+  it('owns successful submission transitions and durable draft cleanup', async () => {
+    const clearDraft = vi.fn(async () => {});
+    const revokeImagePreviews = vi.fn();
+    const revokeVideoPreview = vi.fn();
+    const sendPostRequest = vi.fn(async () => ({
+      results: [{
+        type: 'POST_RESULT' as const,
+        platform: 'x' as const,
+        success: true,
+        url: 'https://x.com/alice/status/123',
+      }],
+    }));
+    const controller = createComposerController({
+      sendPostRequest,
+      clearDraft,
+      revokeImagePreviews,
+      revokeVideoPreview,
+      loadHistory: vi.fn(async () => ({
+        entries: [],
+        thumbs: {},
+        objectUrls: [],
+      })),
+    });
+    const image = {
+      name: 'image.png',
+      type: 'image/png',
+      data: 'AA==',
+      previewUrl: 'blob:image',
+    };
+    let results: PostResultMessage[] | null = null;
+    const patches: unknown[] = [];
+    const input = {
+      text: 'hello',
+      selectedIds: ['x' as const],
+      images: [image],
+      video: null,
+      imageAlts: ['alt'],
+      cw: '',
+      visibility: 'public' as const,
+      trimToS: null,
+      autoPost: true,
+      backgroundNoResponseMessage: 'no response',
+    };
+
+    await controller.submitPlatforms(input, ['x'], false, {
+      getLastResults: () => results,
+      applyPatch: (patch) => {
+        patches.push(patch);
+        if ('lastResults' in patch) results = patch.lastResults as never;
+      },
+    });
+
+    expect(sendPostRequest).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'hello',
+      platforms: ['x'],
+      autoPost: true,
+      intent: 'new',
+    }));
+    expect(patches[0]).toEqual({
+      posting: true,
+      lastResults: [],
+      pendingPlatforms: ['x'],
+      errorMessage: null,
+    });
+    expect(patches).toContainEqual(expect.objectContaining({
+      pendingPlatforms: [],
+      draft: { text: '', images: [], video: null },
+      lastResultDraftKey: expect.any(String),
+    }));
+    expect(patches.at(-1)).toEqual({ posting: false, pendingPlatforms: [] });
+    expect(revokeImagePreviews).toHaveBeenCalledWith([image]);
+    expect(revokeVideoPreview).toHaveBeenCalledWith(null);
+    expect(clearDraft).toHaveBeenCalledOnce();
+  });
+
+  it('retries only failed platforms and preserves successful results', async () => {
+    const sendPostRequest = vi.fn(async () => ({
+      results: [{
+        type: 'POST_RESULT' as const,
+        platform: 'threads' as const,
+        success: true,
+        preview: true,
+      }],
+    }));
+    const controller = createComposerController({
+      sendPostRequest,
+      loadHistory: vi.fn(async () => ({
+        entries: [],
+        thumbs: {},
+        objectUrls: [],
+      })),
+    });
+    let results: PostResultMessage[] = [
+      { type: 'POST_RESULT' as const, platform: 'x' as const, success: true },
+      { type: 'POST_RESULT' as const, platform: 'threads' as const, success: false },
+    ];
+    const input = {
+      text: 'retry',
+      selectedIds: ['x' as const, 'threads' as const],
+      images: [],
+      video: null,
+      imageAlts: [],
+      cw: '',
+      visibility: 'public' as const,
+      trimToS: null,
+      autoPost: false,
+      backgroundNoResponseMessage: 'no response',
+    };
+
+    await controller.retryFailed(input, false, {
+      getLastResults: () => results,
+      applyPatch: (patch) => {
+        if ('lastResults' in patch && patch.lastResults) results = patch.lastResults;
+      },
+    });
+
+    expect(sendPostRequest).toHaveBeenCalledWith(expect.objectContaining({
+      platforms: ['threads'],
+      intent: 'retry',
+    }));
+    expect(results).toEqual([
+      { type: 'POST_RESULT', platform: 'x', success: true },
+      {
+        type: 'POST_RESULT',
+        platform: 'threads',
+        success: true,
+        preview: true,
+      },
+    ]);
   });
 });

--- a/src/popup/composer-controller.ts
+++ b/src/popup/composer-controller.ts
@@ -1,7 +1,8 @@
-import type { ExtensionUpdateState } from '../messages';
+import type { ExtensionUpdateState, PostResultMessage } from '../messages';
 import type { PlatformId } from '../types/platform';
 import { decodeMessage } from '../utils/message-decoder';
 import {
+  clearDraft,
   getDraft,
   getSelectedPlatforms,
   saveDraft,
@@ -23,6 +24,8 @@ import {
 import {
   restoreImagePreviews,
   restoreVideoPreview,
+  revokeImagePreviews,
+  revokeVideoPreview,
   serializeImagesForDraft,
   serializeVideoForDraft,
 } from './media-preview';
@@ -38,6 +41,15 @@ import {
   type BgStateResponse,
   type PostingViewState,
 } from './posting-progress';
+import {
+  failedRetryPlatforms,
+  mergePostResults,
+  normalizeRetryGuardResults,
+  sendPostRequest,
+  shouldClearDraftAfterSubmit,
+  type PostSubmissionResponse,
+} from './post-submit';
+import { buildDraftKey, type DraftKeyInput } from './draft-key';
 import type {
   ImagePreview,
   ReportResult,
@@ -91,6 +103,28 @@ export interface ComposerUpdateApplyResult {
   detail?: string;
 }
 
+export interface ComposerSubmissionInput extends DraftKeyInput {
+  backgroundNoResponseMessage: string;
+}
+
+export interface ComposerSubmissionPatch {
+  posting?: boolean;
+  pendingPlatforms?: PlatformId[];
+  lastResults?: PostResultMessage[] | null;
+  errorMessage?: string | null;
+  draft?: {
+    text: string;
+    images: ImagePreview[];
+    video: VideoPreview | null;
+  };
+  lastResultDraftKey?: string;
+}
+
+export interface ComposerSubmissionCallbacks {
+  getLastResults: () => PostResultMessage[] | null;
+  applyPatch: (patch: ComposerSubmissionPatch) => void;
+}
+
 export interface ComposerControllerOptions {
   getDraft?: () => Promise<Draft | null>;
   saveDraft?: (draft: Draft) => Promise<void>;
@@ -109,6 +143,12 @@ export interface ComposerControllerOptions {
   openGitHubIssue?: typeof openPopupGitHubIssue;
   writeClipboard?: (text: string) => Promise<void>;
   reportEndpoint?: string;
+  sendPostRequest?: (
+    input: Parameters<typeof sendPostRequest>[0],
+  ) => Promise<PostSubmissionResponse | undefined>;
+  clearDraft?: () => Promise<void>;
+  revokeImagePreviews?: (images: readonly ImagePreview[]) => void;
+  revokeVideoPreview?: (video: VideoPreview | null | undefined) => void;
   draftDebounceMs?: number;
   selectionDebounceMs?: number;
 }
@@ -146,6 +186,10 @@ export function createComposerController(options: ComposerControllerOptions = {}
   const writeClipboard = options.writeClipboard ??
     ((text: string) => navigator.clipboard.writeText(text));
   const reportEndpoint = options.reportEndpoint ?? DEFAULT_REPORT_ENDPOINT;
+  const postRequest = options.sendPostRequest ?? sendPostRequest;
+  const clearStoredDraft = options.clearDraft ?? clearDraft;
+  const revokeImages = options.revokeImagePreviews ?? revokeImagePreviews;
+  const revokeVideo = options.revokeVideoPreview ?? revokeVideoPreview;
   const draftDebounceMs = options.draftDebounceMs ?? 300;
   const selectionDebounceMs = options.selectionDebounceMs ?? 200;
   let draftTimer: ReturnType<typeof setTimeout> | undefined;
@@ -167,6 +211,79 @@ export function createComposerController(options: ComposerControllerOptions = {}
     revokeHistory(historyObjectUrls);
     historyObjectUrls = objectUrls;
     historySubscriber?.({ entries, thumbs });
+  };
+
+  const submitPlatforms = async (
+    input: ComposerSubmissionInput,
+    platforms: readonly PlatformId[],
+    isRetry: boolean,
+    callbacks: ComposerSubmissionCallbacks,
+  ): Promise<void> => {
+    if (platforms.length === 0) return;
+    const submissionDraftKey = buildDraftKey(input);
+    callbacks.applyPatch({
+      posting: true,
+      ...(isRetry ? {} : { lastResults: [] }),
+      pendingPlatforms: [...platforms],
+      errorMessage: null,
+    });
+
+    try {
+      const response = await postRequest({
+        text: input.text,
+        platforms: [...platforms],
+        images: input.images,
+        video: input.video,
+        imageAlts: input.imageAlts,
+        autoPost: input.autoPost,
+        cw: input.cw,
+        visibility: input.visibility,
+        trimToS: input.trimToS,
+        intent: isRetry ? 'retry' : 'new',
+      });
+      if (!response) {
+        callbacks.applyPatch({ errorMessage: input.backgroundNoResponseMessage });
+      } else if (response.error) {
+        callbacks.applyPatch({ errorMessage: response.error });
+      } else if (response.results) {
+        const normalizedResults = isRetry
+          ? normalizeRetryGuardResults(response.results)
+          : response.results;
+        const lastResults = mergePostResults(
+          callbacks.getLastResults(),
+          normalizedResults,
+          isRetry,
+        );
+        if (shouldClearDraftAfterSubmit(input.autoPost, lastResults)) {
+          revokeImages(input.images);
+          revokeVideo(input.video);
+          void clearStoredDraft().catch(() => {});
+          const clearedDraft = { text: '', images: [], video: null };
+          callbacks.applyPatch({
+            lastResults,
+            pendingPlatforms: [],
+            draft: clearedDraft,
+            lastResultDraftKey: buildDraftKey({
+              ...input,
+              ...clearedDraft,
+            }),
+          });
+        } else {
+          callbacks.applyPatch({
+            lastResults,
+            pendingPlatforms: [],
+            lastResultDraftKey: submissionDraftKey,
+          });
+        }
+      }
+    } catch (error) {
+      callbacks.applyPatch({
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      callbacks.applyPatch({ posting: false, pendingPlatforms: [] });
+      void refreshHistory().catch(() => {});
+    }
   };
 
   return {
@@ -387,6 +504,23 @@ export function createComposerController(options: ComposerControllerOptions = {}
       overflowNote: string,
     ): Promise<void> {
       await openGitHubIssue({ errorText, context, note, overflowNote });
+    },
+
+    submitPlatforms,
+
+    async retryFailed(
+      input: ComposerSubmissionInput,
+      posting: boolean,
+      callbacks: ComposerSubmissionCallbacks,
+    ): Promise<void> {
+      const current = callbacks.getLastResults();
+      if (!current || posting) return;
+      const failed = failedRetryPlatforms(current);
+      if (failed.length === 0) return;
+      callbacks.applyPatch({
+        lastResults: current.filter((result) => result.success),
+      });
+      await submitPlatforms(input, failed, true, callbacks);
     },
 
     dispose(): void {


### PR DESCRIPTION
## Summary

- move POST_REQUEST dispatch, response handling, retry normalization/merge, and failed retry selection into the existing composer controller
- centralize durable-success draft clearing, media preview cleanup, and history refresh
- keep compatibility validation, localization, and Svelte state assignment in App.svelte
- add unit and architecture guards for the submission boundary

## Verification

- `npm run verify:commit` PASS (89 files / 677 tests + build)
- `npm run e2e:smoke:no-build` PASS
- Surface exact-artifact preview matrix: pending
- no CWS upload or submission

Closes #82
Parent #12 Phase 4