### PR TITLE
refactor: consolidate Options API credential editors

### DIFF
--- a/entrypoints/options/Options.svelte
+++ b/entrypoints/options/Options.svelte
@@ -12,16 +12,17 @@
     getOverrides,
   } from '../../src/utils/selector-overrides';
   import { fetchOverridesFrom } from '../../src/utils/selector-feed-runtime';
+  import { getApiCredentials } from '../../src/utils/api-credentials';
   import {
-    getApiCredentials,
-    setApiCredentials,
-    clearApiCredentials,
-  } from '../../src/utils/api-credentials';
-  import { testCredentials as testBluesky } from '../../src/api/bluesky';
-  import { testCredentials as testMastodon } from '../../src/api/mastodon';
-  import { testCredentials as testMisskey } from '../../src/api/misskey';
+    API_CREDENTIAL_PROVIDERS,
+    clearProviderApiCredential,
+    createApiCredentialEditorStates,
+    testAndSaveApiCredential,
+    type ApiCredentialProviderDescriptor,
+  } from '../../src/options/api-credential-providers';
   import { t, TUTTI_LOCALES } from '../../src/utils/i18n';
   import ResponsibleUseDialog from '../popup/components/ResponsibleUseDialog.svelte';
+  import ApiCredentialEditor from './components/ApiCredentialEditor.svelte';
 
   let mastodonInstance = $state('https://mastodon.social');
   let misskeyInstance = $state('https://misskey.io');
@@ -49,20 +50,7 @@
   let historyCleared = $state(false);
 
   // ── API 連携 (P15 Phase 1: Bluesky / Mastodon / Misskey) ────────
-  let bskyId = $state('');
-  let bskyPw = $state('');
-  let bskyStatus = $state<{ ok?: boolean; msg: string } | null>(null);
-  let bskyBusy = $state(false);
-
-  let mstdInstance = $state('https://mastodon.social');
-  let mstdToken = $state('');
-  let mstdStatus = $state<{ ok?: boolean; msg: string } | null>(null);
-  let mstdBusy = $state(false);
-
-  let mskyInstance = $state('https://misskey.io');
-  let mskyToken = $state('');
-  let mskyStatus = $state<{ ok?: boolean; msg: string } | null>(null);
-  let mskyBusy = $state(false);
+  let credentialEditors = $state(createApiCredentialEditorStates());
 
   const version = browser.runtime.getManifest().version;
   // v0.5.2: t() は src/utils/i18n から import 済。 Settings.uiLanguage で切替可能。
@@ -85,21 +73,7 @@
       responsibleUseAcceptedAt = s.responsibleUseAcceptedAt ?? null;
       overrideFetchedAt = at;
       overrideCount = Object.values(ov).reduce((sum, v) => sum + Object.keys(v ?? {}).length, 0);
-      // API credentials のロード (パスワード / トークンは UI に出すと見えるので
-      // 既存値が居れば「設定済」表示だけにし、再入力時のみ更新する設計でもいいが、
-      // 簡単のため bind で出す。option page は user 自身しか見ないので妥当)
-      if (creds.bluesky) {
-        bskyId = creds.bluesky.identifier;
-        bskyPw = creds.bluesky.appPassword;
-      }
-      if (creds.mastodon) {
-        mstdInstance = creds.mastodon.instance;
-        mstdToken = creds.mastodon.accessToken;
-      }
-      if (creds.misskey) {
-        mskyInstance = creds.misskey.instance;
-        mskyToken = creds.misskey.accessToken;
-      }
+      credentialEditors = createApiCredentialEditorStates(creds);
       loading = false;
     });
     // background から現在の log buffer サイズを取得
@@ -172,80 +146,46 @@
   // ── API 連携 handlers ──────────────────────────────────────────
   // 「テスト & 保存」ボタン: 認証確認 → 通れば保存。失敗時は保存しない (= 既存
   // creds は壊さない)。「解除」ボタンで個別 platform の credentials を削除。
-  async function handleBskySave() {
-    if (!bskyId.trim() || !bskyPw.trim()) {
-      bskyStatus = { ok: false, msg: t('apiBskyMissing') };
+  async function handleCredentialSave(
+    provider: ApiCredentialProviderDescriptor,
+  ): Promise<void> {
+    const editor = credentialEditors[provider.id];
+    if (!provider.prepare(editor)) {
+      editor.status = { ok: false, msg: t(provider.missingMessageKey) };
       return;
     }
-    bskyBusy = true;
-    bskyStatus = { msg: t('apiTesting') };
-    const result = await testBluesky({ identifier: bskyId.trim(), appPassword: bskyPw.trim() });
+    editor.busy = true;
+    editor.status = { msg: t('apiTesting') };
+    const result = await testAndSaveApiCredential(provider, editor);
     if (result.ok) {
-      await setApiCredentials({ bluesky: { identifier: bskyId.trim(), appPassword: bskyPw.trim() } });
-      bskyStatus = { ok: true, msg: `✓ ${t('apiConnected', result.identifier ?? '')}` };
+      editor.status = {
+        ok: true,
+        msg: `✓ ${t(
+          'apiConnected',
+          provider.formatIdentifier(result.identifier ?? ''),
+        )}`,
+      };
+    } else if (result.reason === 'permission-denied') {
+      editor.status = { ok: false, msg: `✗ ${t('apiHostPermissionDenied')}` };
+    } else if (result.reason === 'missing') {
+      editor.status = { ok: false, msg: t(provider.missingMessageKey) };
     } else {
-      bskyStatus = { ok: false, msg: `✗ ${result.error ?? t('apiConnectError')}` };
+      editor.status = {
+        ok: false,
+        msg: `✗ ${result.error ?? t('apiConnectError')}`,
+      };
     }
-    bskyBusy = false;
-  }
-  async function handleBskyClear() {
-    await clearApiCredentials('bluesky');
-    bskyId = ''; bskyPw = '';
-    bskyStatus = { ok: true, msg: `✓ ${t('apiCleared')}` };
+    editor.busy = false;
   }
 
-  async function handleMstdSave() {
-    const inst = normalizeUrl(mstdInstance);
-    if (!inst || !mstdToken.trim()) {
-      mstdStatus = { ok: false, msg: t('apiInstanceTokenMissing') };
-      return;
-    }
-    if (!(await ensurePermission(inst, 'https://mastodon.social'))) {
-      mstdStatus = { ok: false, msg: `✗ ${t('apiHostPermissionDenied')}` };
-      return;
-    }
-    mstdBusy = true;
-    mstdStatus = { msg: t('apiTesting') };
-    const result = await testMastodon({ instance: inst, accessToken: mstdToken.trim() });
-    if (result.ok) {
-      await setApiCredentials({ mastodon: { instance: inst, accessToken: mstdToken.trim() } });
-      mstdStatus = { ok: true, msg: `✓ ${t('apiConnected', '@' + (result.identifier ?? ''))}` };
-    } else {
-      mstdStatus = { ok: false, msg: `✗ ${result.error ?? t('apiConnectError')}` };
-    }
-    mstdBusy = false;
-  }
-  async function handleMstdClear() {
-    await clearApiCredentials('mastodon');
-    mstdToken = '';
-    mstdStatus = { ok: true, msg: `✓ ${t('apiCleared')}` };
-  }
-
-  async function handleMskySave() {
-    const inst = normalizeUrl(mskyInstance);
-    if (!inst || !mskyToken.trim()) {
-      mskyStatus = { ok: false, msg: t('apiInstanceTokenMissing') };
-      return;
-    }
-    if (!(await ensurePermission(inst, 'https://misskey.io'))) {
-      mskyStatus = { ok: false, msg: `✗ ${t('apiHostPermissionDenied')}` };
-      return;
-    }
-    mskyBusy = true;
-    mskyStatus = { msg: t('apiTesting') };
-    const result = await testMisskey({ instance: inst, accessToken: mskyToken.trim() });
-    if (result.ok) {
-      await setApiCredentials({ misskey: { instance: inst, accessToken: mskyToken.trim() } });
-      mskyStatus = { ok: true, msg: `✓ ${t('apiConnected', result.identifier ?? '')}` };
-    } else {
-      mskyStatus = { ok: false, msg: `✗ ${result.error ?? t('apiConnectError')}` };
-    }
-    mskyBusy = false;
-  }
-  async function handleMskyClear() {
-    await clearApiCredentials('misskey');
-    mskyToken = '';
-    mskyStatus = { ok: true, msg: `✓ ${t('apiCleared')}` };
+  async function handleCredentialClear(
+    provider: ApiCredentialProviderDescriptor,
+  ): Promise<void> {
+    await clearProviderApiCredential(provider);
+    const editor = credentialEditors[provider.id];
+    if (provider.clearPrimaryOnClear) editor.primary = '';
+    editor.secret = '';
+    editor.status = { ok: true, msg: `✓ ${t('apiCleared')}` };
   }
 
   async function handleClearHistory() {
@@ -385,71 +325,21 @@
       <h2 class="text-sm font-semibold text-gray-800 mb-1">{t('apiSectionTitle')} <span class="text-xs text-amber-700">{t('apiSectionAdvancedBadge')}</span></h2>
       <p class="text-xs text-gray-500 mb-4 leading-relaxed">{t('apiSectionHint')}</p>
 
-      <!-- Bluesky -->
-      <div class="space-y-2 mb-5 pb-4 border-b border-gray-200">
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-medium">Bluesky</h3>
-          <a href="https://bsky.app/settings/app-passwords" target="_blank" rel="noopener"
-             class="text-xs text-blue-600 hover:underline">{t('apiBlueskyMakePassword')}</a>
-        </div>
-        <input type="text" bind:value={bskyId} placeholder="user.bsky.social"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <input type="password" bind:value={bskyPw} placeholder="xxxx-xxxx-xxxx-xxxx (App Password)"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <div class="flex items-center gap-2">
-          <button onclick={handleBskySave} disabled={bskyBusy}
-            class="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:bg-gray-300">{t('apiTestSave')}</button>
-          <button onclick={handleBskyClear}
-            class="px-3 py-1 bg-white border border-gray-300 text-gray-700 rounded text-xs hover:bg-gray-50">{t('apiClear')}</button>
-          {#if bskyStatus}
-            <span class="text-xs" class:text-green-600={bskyStatus.ok === true} class:text-red-600={bskyStatus.ok === false}>{bskyStatus.msg}</span>
-          {/if}
-        </div>
-      </div>
-
-      <!-- Mastodon -->
-      <div class="space-y-2 mb-5 pb-4 border-b border-gray-200">
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-medium">Mastodon</h3>
-          <a href="{mstdInstance}/settings/applications" target="_blank" rel="noopener"
-             class="text-xs text-blue-600 hover:underline">{t('apiMastodonMakeApp')}</a>
-        </div>
-        <input type="url" bind:value={mstdInstance} placeholder="https://mastodon.social"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <input type="password" bind:value={mstdToken} placeholder="access token (write:statuses + write:media)"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <div class="flex items-center gap-2">
-          <button onclick={handleMstdSave} disabled={mstdBusy}
-            class="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:bg-gray-300">{t('apiTestSave')}</button>
-          <button onclick={handleMstdClear}
-            class="px-3 py-1 bg-white border border-gray-300 text-gray-700 rounded text-xs hover:bg-gray-50">{t('apiClear')}</button>
-          {#if mstdStatus}
-            <span class="text-xs" class:text-green-600={mstdStatus.ok === true} class:text-red-600={mstdStatus.ok === false}>{mstdStatus.msg}</span>
-          {/if}
-        </div>
-      </div>
-
-      <!-- Misskey -->
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-medium">Misskey</h3>
-          <a href="{mskyInstance}/settings/api" target="_blank" rel="noopener"
-             class="text-xs text-blue-600 hover:underline">{t('apiMisskeyMakeToken')}</a>
-        </div>
-        <input type="url" bind:value={mskyInstance} placeholder="https://misskey.io"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <input type="password" bind:value={mskyToken} placeholder="access token (write:notes + write:drive)"
-          class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" />
-        <div class="flex items-center gap-2">
-          <button onclick={handleMskySave} disabled={mskyBusy}
-            class="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:bg-gray-300">{t('apiTestSave')}</button>
-          <button onclick={handleMskyClear}
-            class="px-3 py-1 bg-white border border-gray-300 text-gray-700 rounded text-xs hover:bg-gray-50">{t('apiClear')}</button>
-          {#if mskyStatus}
-            <span class="text-xs" class:text-green-600={mskyStatus.ok === true} class:text-red-600={mskyStatus.ok === false}>{mskyStatus.msg}</span>
-          {/if}
-        </div>
-      </div>
+      {#each API_CREDENTIAL_PROVIDERS as provider, index (provider.id)}
+        {@const editor = credentialEditors[provider.id]}
+        <ApiCredentialEditor
+          {provider}
+          primary={editor.primary}
+          secret={editor.secret}
+          busy={editor.busy}
+          status={editor.status}
+          last={index === API_CREDENTIAL_PROVIDERS.length - 1}
+          onPrimaryChange={(value) => { editor.primary = value; }}
+          onSecretChange={(value) => { editor.secret = value; }}
+          onSave={() => { void handleCredentialSave(provider); }}
+          onClear={() => { void handleCredentialClear(provider); }}
+        />
+      {/each}
     </section>
 
     <section class="mb-6">

--- a/entrypoints/options/components/ApiCredentialEditor.svelte
+++ b/entrypoints/options/components/ApiCredentialEditor.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type {
+    ApiCredentialProviderDescriptor,
+  } from '../../../src/options/api-credential-providers';
+  import { t } from '../../../src/utils/i18n';
+
+  interface Props {
+    provider: ApiCredentialProviderDescriptor;
+    primary: string;
+    secret: string;
+    busy: boolean;
+    status: { ok?: boolean; msg: string } | null;
+    last: boolean;
+    onPrimaryChange: (value: string) => void;
+    onSecretChange: (value: string) => void;
+    onSave: () => void;
+    onClear: () => void;
+  }
+
+  let {
+    provider,
+    primary,
+    secret,
+    busy,
+    status,
+    last,
+    onPrimaryChange,
+    onSecretChange,
+    onSave,
+    onClear,
+  }: Props = $props();
+</script>
+
+<div class="space-y-2" class:mb-5={!last} class:pb-4={!last} class:border-b={!last} class:border-gray-200={!last}>
+  <div class="flex items-center justify-between">
+    <h3 class="text-sm font-medium">{provider.name}</h3>
+    <a
+      href={provider.helpUrl(primary)}
+      target="_blank"
+      rel="noopener"
+      class="text-xs text-blue-600 hover:underline"
+    >{t(provider.helpLabelKey)}</a>
+  </div>
+  <input
+    id={`api-${provider.id}-primary`}
+    type={provider.primaryInputType}
+    value={primary}
+    oninput={(event) => onPrimaryChange((event.currentTarget as HTMLInputElement).value)}
+    placeholder={provider.primaryPlaceholder}
+    class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+  />
+  <input
+    id={`api-${provider.id}-secret`}
+    type="password"
+    value={secret}
+    oninput={(event) => onSecretChange((event.currentTarget as HTMLInputElement).value)}
+    placeholder={provider.secretPlaceholder}
+    class="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+  />
+  <div class="flex items-center gap-2">
+    <button
+      type="button"
+      onclick={onSave}
+      disabled={busy}
+      class="px-3 py-1 bg-blue-600 text-white rounded text-xs font-medium hover:bg-blue-700 disabled:bg-gray-300"
+    >{t('apiTestSave')}</button>
+    <button
+      type="button"
+      onclick={onClear}
+      class="px-3 py-1 bg-white border border-gray-300 text-gray-700 rounded text-xs hover:bg-gray-50"
+    >{t('apiClear')}</button>
+    {#if status}
+      <span
+        class="text-xs"
+        class:text-green-600={status.ok === true}
+        class:text-red-600={status.ok === false}
+      >{status.msg}</span>
+    {/if}
+  </div>
+</div>

--- a/scripts/e2e/mock-browser-smoke.mjs
+++ b/scripts/e2e/mock-browser-smoke.mjs
@@ -4,9 +4,10 @@
  * This launches a fresh Chromium profile with the built MV3 extension loaded,
  * serves mock compose pages via Playwright routing, then exercises:
  *   1. X popup/background/content preview via chrome.runtime.sendMessage
- *   2. X popup UI preview submission
- *   3. Mastodon executePostFlow preview
- *   4. Instagram executeMultiStepFlow wizard preview
+ *   2. Options API credential editor rendering
+ *   3. X popup UI preview submission
+ *   4. Mastodon executePostFlow preview
+ *   5. Instagram executeMultiStepFlow wizard preview
  *
  * It does not log in to or post to any real SNS. On failure, artifacts are
  * written under .tmp/e2e-smoke-*.
@@ -70,6 +71,7 @@ try {
   await ensureMockXComposePage(context);
 
   await runRuntimePreviewSmoke(popupPage);
+  await runOptionsCredentialEditorSmoke(context, extensionId);
   await runPopupPreviewSmoke(context, extensionId);
   await runMastodonSimplePreviewSmoke(context, popupPage);
   await runInstagramWizardPreviewSmoke(context, popupPage);
@@ -218,6 +220,29 @@ async function runRuntimePreviewSmoke(page) {
   assert(bgState.postingState.results[0]?.preview === true, `background retained non-preview result: ${JSON.stringify(bgState)}`);
 
   await page.evaluate(() => chrome.runtime.sendMessage({ type: 'CLEAR_POSTING_STATE' }));
+}
+
+async function runOptionsCredentialEditorSmoke(ctx, extensionId) {
+  console.log('[mock-smoke] Options API credential editor smoke');
+  const page = await openExtensionPage(ctx, extensionId, 'options.html');
+  const providerIds = ['bluesky', 'mastodon', 'misskey'];
+  for (const provider of providerIds) {
+    await page.locator(`#api-${provider}-primary`).waitFor();
+    await page.locator(`#api-${provider}-secret`).waitFor();
+  }
+  assert(
+    await page.locator('button', { hasText: 'Test & Save' }).count() === providerIds.length,
+    'Options did not render one shared credential editor per provider',
+  );
+  assert(
+    await page.locator('#api-mastodon-primary').inputValue() === 'https://mastodon.social',
+    'Options did not preserve the Mastodon default instance',
+  );
+  assert(
+    await page.locator('#api-misskey-primary').inputValue() === 'https://misskey.io',
+    'Options did not preserve the Misskey default instance',
+  );
+  await page.close();
 }
 
 async function runPopupPreviewSmoke(ctx, extensionId) {

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -28,6 +28,7 @@ const ALLOWED_SRC_IMPORTS: Record<EntrypointCategory, readonly string[]> = {
     'src/adapters/',
     'src/api/',
     'src/messages',
+    'src/options/',
     'src/popup/',
     'src/storage',
     'src/types/',
@@ -94,6 +95,14 @@ describe('entrypoint architecture guard', () => {
     expect(source).not.toContain('mergePostResults');
     expect(source).not.toContain('shouldClearDraftAfterSubmit');
     expect(source).not.toContain('failedRetryPlatforms');
+  });
+
+  it('keeps Options API credentials behind the provider editor boundary', () => {
+    const source = readFileSync('entrypoints/options/Options.svelte', 'utf8');
+    expect(source).toContain('API_CREDENTIAL_PROVIDERS');
+    expect(source).toContain('<ApiCredentialEditor');
+    expect(source).not.toMatch(/handle(?:Bsky|Mstd|Msky)(?:Save|Clear)/);
+    expect(source.match(/<ApiCredentialEditor/g)).toHaveLength(1);
   });
 });
 

--- a/src/options/api-credential-providers.test.ts
+++ b/src/options/api-credential-providers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  API_CREDENTIAL_PROVIDERS,
+  clearProviderApiCredential,
+  createApiCredentialEditorStates,
+  testAndSaveApiCredential,
+} from './api-credential-providers';
+
+describe('Options API credential providers', () => {
+  it('defines one complete descriptor per stored provider', () => {
+    expect(API_CREDENTIAL_PROVIDERS.map((provider) => provider.id)).toEqual([
+      'bluesky',
+      'mastodon',
+      'misskey',
+    ]);
+    expect(new Set(API_CREDENTIAL_PROVIDERS.map((provider) => provider.id)).size)
+      .toBe(API_CREDENTIAL_PROVIDERS.length);
+  });
+
+  it('loads stored credential shapes into shared editor state', () => {
+    const states = createApiCredentialEditorStates({
+      bluesky: { identifier: 'alice.bsky.social', appPassword: 'app-pass' },
+      mastodon: { instance: 'https://social.example', accessToken: 'mastodon-token' },
+    });
+
+    expect(states.bluesky).toMatchObject({
+      primary: 'alice.bsky.social',
+      secret: 'app-pass',
+      busy: false,
+      status: null,
+    });
+    expect(states.mastodon).toMatchObject({
+      primary: 'https://social.example',
+      secret: 'mastodon-token',
+    });
+    expect(states.misskey).toMatchObject({
+      primary: 'https://misskey.io',
+      secret: '',
+    });
+  });
+
+  it('normalizes a custom instance, requests permission, tests, and saves', async () => {
+    const provider = API_CREDENTIAL_PROVIDERS.find(({ id }) => id === 'mastodon')!;
+    const requestPermission = vi.fn(async () => true);
+    const testCredentials = vi.fn(async () => ({ ok: true, identifier: 'alice@example.social' }));
+    const setCredentials = vi.fn(async () => {});
+
+    await expect(testAndSaveApiCredential(
+      provider,
+      { primary: ' https://example.social/ ', secret: ' token ' },
+      { requestPermission, testCredentials, setCredentials },
+    )).resolves.toEqual({ ok: true, identifier: 'alice@example.social' });
+
+    expect(requestPermission).toHaveBeenCalledWith('https://example.social');
+    expect(testCredentials).toHaveBeenCalledWith(provider, {
+      mastodon: {
+        instance: 'https://example.social',
+        accessToken: 'token',
+      },
+    });
+    expect(setCredentials).toHaveBeenCalledWith({
+      mastodon: {
+        instance: 'https://example.social',
+        accessToken: 'token',
+      },
+    });
+  });
+
+  it('does not test or save missing fields or denied custom origins', async () => {
+    const provider = API_CREDENTIAL_PROVIDERS.find(({ id }) => id === 'misskey')!;
+    const testCredentials = vi.fn(async () => ({ ok: true }));
+    const setCredentials = vi.fn(async () => {});
+
+    await expect(testAndSaveApiCredential(
+      provider,
+      { primary: 'https://misskey.io', secret: '' },
+      { testCredentials, setCredentials },
+    )).resolves.toEqual({ ok: false, reason: 'missing' });
+    await expect(testAndSaveApiCredential(
+      provider,
+      { primary: 'https://custom.example', secret: 'token' },
+      {
+        requestPermission: vi.fn(async () => false),
+        testCredentials,
+        setCredentials,
+      },
+    )).resolves.toEqual({ ok: false, reason: 'permission-denied' });
+
+    expect(testCredentials).not.toHaveBeenCalled();
+    expect(setCredentials).not.toHaveBeenCalled();
+  });
+
+  it('clears through the provider id', async () => {
+    const provider = API_CREDENTIAL_PROVIDERS[0]!;
+    const clearCredentials = vi.fn(async () => {});
+
+    await clearProviderApiCredential(provider, clearCredentials);
+
+    expect(clearCredentials).toHaveBeenCalledWith('bluesky');
+  });
+});

--- a/src/options/api-credential-providers.ts
+++ b/src/options/api-credential-providers.ts
@@ -1,0 +1,216 @@
+import { testCredentials as testBluesky } from '../api/bluesky';
+import { testCredentials as testMastodon } from '../api/mastodon';
+import { testCredentials as testMisskey } from '../api/misskey';
+import type { ApiTestResult } from '../api/types';
+import {
+  clearApiCredentials,
+  setApiCredentials,
+  type ApiCredentials,
+} from '../utils/api-credentials';
+
+export type ApiCredentialProviderId = keyof ApiCredentials;
+
+export interface ApiCredentialFields {
+  primary: string;
+  secret: string;
+}
+
+export interface ApiCredentialEditorState extends ApiCredentialFields {
+  busy: boolean;
+  status: { ok?: boolean; msg: string } | null;
+}
+
+interface PreparedCredential {
+  credentials: Partial<ApiCredentials>;
+  permission?: {
+    origin: string;
+    defaultOrigin: string;
+  };
+}
+
+export interface ApiCredentialProviderDescriptor {
+  id: ApiCredentialProviderId;
+  name: string;
+  primaryInputType: 'text' | 'url';
+  primaryPlaceholder: string;
+  secretPlaceholder: string;
+  defaultPrimary: string;
+  helpLabelKey: string;
+  missingMessageKey: string;
+  clearPrimaryOnClear: boolean;
+  helpUrl: (primary: string) => string;
+  readFields: (credentials: ApiCredentials) => ApiCredentialFields;
+  prepare: (fields: ApiCredentialFields) => PreparedCredential | null;
+  test: (credentials: Partial<ApiCredentials>) => Promise<ApiTestResult>;
+  formatIdentifier: (identifier: string) => string;
+}
+
+const MASTODON_DEFAULT = 'https://mastodon.social';
+const MISSKEY_DEFAULT = 'https://misskey.io';
+
+export const API_CREDENTIAL_PROVIDERS: readonly ApiCredentialProviderDescriptor[] = [
+  {
+    id: 'bluesky',
+    name: 'Bluesky',
+    primaryInputType: 'text',
+    primaryPlaceholder: 'user.bsky.social',
+    secretPlaceholder: 'xxxx-xxxx-xxxx-xxxx (App Password)',
+    defaultPrimary: '',
+    helpLabelKey: 'apiBlueskyMakePassword',
+    missingMessageKey: 'apiBskyMissing',
+    clearPrimaryOnClear: true,
+    helpUrl: () => 'https://bsky.app/settings/app-passwords',
+    readFields: (credentials) => ({
+      primary: credentials.bluesky?.identifier ?? '',
+      secret: credentials.bluesky?.appPassword ?? '',
+    }),
+    prepare: (fields) => {
+      const identifier = fields.primary.trim();
+      const appPassword = fields.secret.trim();
+      return identifier && appPassword
+        ? { credentials: { bluesky: { identifier, appPassword } } }
+        : null;
+    },
+    test: (credentials) => testBluesky(credentials.bluesky!),
+    formatIdentifier: (identifier) => identifier,
+  },
+  {
+    id: 'mastodon',
+    name: 'Mastodon',
+    primaryInputType: 'url',
+    primaryPlaceholder: MASTODON_DEFAULT,
+    secretPlaceholder: 'access token (write:statuses + write:media)',
+    defaultPrimary: MASTODON_DEFAULT,
+    helpLabelKey: 'apiMastodonMakeApp',
+    missingMessageKey: 'apiInstanceTokenMissing',
+    clearPrimaryOnClear: false,
+    helpUrl: (primary) =>
+      `${normalizeCredentialUrl(primary) ?? MASTODON_DEFAULT}/settings/applications`,
+    readFields: (credentials) => ({
+      primary: credentials.mastodon?.instance ?? MASTODON_DEFAULT,
+      secret: credentials.mastodon?.accessToken ?? '',
+    }),
+    prepare: (fields) => {
+      const instance = normalizeCredentialUrl(fields.primary);
+      const accessToken = fields.secret.trim();
+      return instance && accessToken
+        ? {
+            credentials: { mastodon: { instance, accessToken } },
+            permission: { origin: instance, defaultOrigin: MASTODON_DEFAULT },
+          }
+        : null;
+    },
+    test: (credentials) => testMastodon(credentials.mastodon!),
+    formatIdentifier: (identifier) => `@${identifier}`,
+  },
+  {
+    id: 'misskey',
+    name: 'Misskey',
+    primaryInputType: 'url',
+    primaryPlaceholder: MISSKEY_DEFAULT,
+    secretPlaceholder: 'access token (write:notes + write:drive)',
+    defaultPrimary: MISSKEY_DEFAULT,
+    helpLabelKey: 'apiMisskeyMakeToken',
+    missingMessageKey: 'apiInstanceTokenMissing',
+    clearPrimaryOnClear: false,
+    helpUrl: (primary) =>
+      `${normalizeCredentialUrl(primary) ?? MISSKEY_DEFAULT}/settings/api`,
+    readFields: (credentials) => ({
+      primary: credentials.misskey?.instance ?? MISSKEY_DEFAULT,
+      secret: credentials.misskey?.accessToken ?? '',
+    }),
+    prepare: (fields) => {
+      const instance = normalizeCredentialUrl(fields.primary);
+      const accessToken = fields.secret.trim();
+      return instance && accessToken
+        ? {
+            credentials: { misskey: { instance, accessToken } },
+            permission: { origin: instance, defaultOrigin: MISSKEY_DEFAULT },
+          }
+        : null;
+    },
+    test: (credentials) => testMisskey(credentials.misskey!),
+    formatIdentifier: (identifier) => identifier,
+  },
+];
+
+export function createApiCredentialEditorStates(
+  credentials: ApiCredentials = {},
+): Record<ApiCredentialProviderId, ApiCredentialEditorState> {
+  return Object.fromEntries(API_CREDENTIAL_PROVIDERS.map((provider) => [
+    provider.id,
+    {
+      ...provider.readFields(credentials),
+      busy: false,
+      status: null,
+    },
+  ])) as Record<ApiCredentialProviderId, ApiCredentialEditorState>;
+}
+
+export type ApiCredentialSaveResult =
+  | { ok: true; identifier?: string }
+  | {
+      ok: false;
+      reason: 'missing' | 'permission-denied' | 'test-failed';
+      error?: string;
+    };
+
+export async function testAndSaveApiCredential(
+  provider: ApiCredentialProviderDescriptor,
+  fields: ApiCredentialFields,
+  dependencies: {
+    requestPermission?: (origin: string) => Promise<boolean>;
+    testCredentials?: (
+      provider: ApiCredentialProviderDescriptor,
+      credentials: Partial<ApiCredentials>,
+    ) => Promise<ApiTestResult>;
+    setCredentials?: (credentials: Partial<ApiCredentials>) => Promise<void>;
+  } = {},
+): Promise<ApiCredentialSaveResult> {
+  const prepared = provider.prepare(fields);
+  if (!prepared) return { ok: false, reason: 'missing' };
+
+  try {
+    if (prepared.permission &&
+        prepared.permission.origin !== prepared.permission.defaultOrigin) {
+      const requestPermission = dependencies.requestPermission ??
+        ((origin: string) => browser.permissions.request({
+          origins: [`${origin}/*`],
+        }));
+      if (!await requestPermission(prepared.permission.origin)) {
+        return { ok: false, reason: 'permission-denied' };
+      }
+    }
+
+    const result = dependencies.testCredentials
+      ? await dependencies.testCredentials(provider, prepared.credentials)
+      : await provider.test(prepared.credentials);
+    if (!result.ok) {
+      return {
+        ok: false,
+        reason: 'test-failed',
+        error: result.error,
+      };
+    }
+    await (dependencies.setCredentials ?? setApiCredentials)(prepared.credentials);
+    return { ok: true, identifier: result.identifier };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'test-failed',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function clearProviderApiCredential(
+  provider: ApiCredentialProviderDescriptor,
+  clearCredentials: typeof clearApiCredentials = clearApiCredentials,
+): Promise<void> {
+  await clearCredentials(provider.id);
+}
+
+export function normalizeCredentialUrl(input: string): string | null {
+  const url = input.trim().replace(/\/$/, '');
+  return url.startsWith('https://') ? url : null;
+}


### PR DESCRIPTION
Closes #84

## Summary
- add one descriptor registry for Bluesky, Mastodon, and Misskey credential metadata and behavior
- render all three through one reusable Options editor component
- centralize test, permission, save, and clear workflows while preserving existing storage shapes and defaults
- add architecture/unit coverage and Options rendering to the extension smoke suite

## Verification
- `npm run verify:commit` (90 files, 684 tests, production build PASS)
- `npm run e2e:smoke:no-build` (Options credential editors + existing popup flows PASS)

No background API posting or platform-driver behavior changed. No CWS upload or submission was performed; this slice does not require an actual-post Surface gate.