### PR TITLE
docs: decide production compatibility paths

### DIFF
--- a/docs/architecture-guards.md
+++ b/docs/architecture-guards.md
@@ -10,6 +10,7 @@ This command checks the scripts catalog, then runs the structural Vitest suite
 for import cycles, selector contracts, adapter/strategy completeness, docs
 alignment, platform literal policy, entrypoint import boundaries, background
 message routing, message/storage facades, and UI localization.
+It also rejects expired production compatibility switches.
 
 `npm test` remains the authoritative full test suite. The focused command is a
 fast local checkpoint and a named CI step; architecture tests must remain part

--- a/docs/compatibility-switch-decisions.md
+++ b/docs/compatibility-switch-decisions.md
@@ -1,0 +1,52 @@
+# Production compatibility switch decisions
+
+Issue #12 Phase 6 requires an independent decision for each high-risk Phase 7
+and Phase 8 migration. A production legacy path is allowed only when every
+criterion below is satisfied. The decision baseline is extension `0.5.49`.
+
+## Decision matrix
+
+| Criterion | Page injection | Post orchestrator |
+|---|---|---|
+| Environment-dependent failure with demonstrated user recovery | Not demonstrated. The current five platform-specific fetch/XHR wrapper pairs are not known to recover a failure of the planned tagged singleton observer. | Not demonstrated. The migration decomposes the same orchestration behavior; no environment is known where selecting the monolith recovers a next-path failure. |
+| Bounded legacy/next difference with supportable maintenance cost | Not met. Retention duplicates page-world interception and creates hook-order interactions with the single-observer design. | Not met. Retention duplicates the posting side-effect controller, including service-worker lifetime, tab/account state, retry, thread, and concurrency behavior. |
+| Options support control without raw storage editing | Not present. Adding UI and storage only to expose an unproven recovery path is not justified. | Not present for the same reason. |
+| Owner, introduction version, and removal version | Could be supplied, but metadata alone does not offset the failed criteria. | Could be supplied, but metadata alone does not offset the failed criteria. |
+| No added bundle, permission, or CWS constraint | Not met for bundle and review surface: production would carry both interception implementations. | Not met for bundle and review surface: production would carry both orchestration implementations. |
+
+Decisions:
+
+- `page-injection`: **no production legacy switch**
+- `post-orchestrator`: **no production legacy switch**
+
+Both decisions are independent; each fails multiple required criteria. A future
+change may revisit one scope without changing the other, but it must cite new
+field evidence and amend this decision before registering a switch.
+
+## Phase 7 contract
+
+- The compatibility path is fixed before installing any page-world hook.
+- Legacy comparison code may exist only behind `import.meta.env.DEV` while the
+  pilot is verified.
+- The production bundle contains only the tagged singleton observer path.
+- There is no automatic fallback and no simultaneous legacy/next hook install.
+- The upload candidate must pass exact-artifact Surface preview and affected
+  real-browser capture cases.
+
+## Phase 8 contract
+
+- Existing behavior is first fixed by characterization tests, then moved behind
+  the new responsibility boundaries.
+- Development-only comparison is allowed during migration, but one request,
+  retry, and thread chain remains on one implementation.
+- The production bundle contains only the decomposed next orchestrator.
+- There is no automatic fallback after DOM or API dispatch.
+- The upload candidate must pass exact-artifact Surface preview plus affected
+  real posting, URL capture, and verification cases.
+
+## Guard
+
+`PRODUCTION_COMPATIBILITY_SWITCHES` is intentionally empty. Any future exception
+must default to `next` and declare an owner issue, introduction version, and
+removal version. `architecture:check` fails invalid metadata, duplicate active
+scopes, or entries whose removal version has been reached.

--- a/src/compatibility/production-switches.test.ts
+++ b/src/compatibility/production-switches.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { assertArchitectureGuard } from '../../tests/architecture-guard';
+import {
+  PRODUCTION_COMPATIBILITY_SWITCHES,
+  type ProductionCompatibilitySwitch,
+} from './production-switches';
+
+const packageVersion = (
+  JSON.parse(readFileSync('package.json', 'utf8')) as { version: string }
+).version;
+
+describe('production compatibility switch policy', () => {
+  it('keeps rejected Phase 6 scopes out of the production registry', () => {
+    expect(PRODUCTION_COMPATIBILITY_SWITCHES).toEqual([]);
+  });
+
+  it('guards metadata, uniqueness, default path, and removal version', () => {
+    assertArchitectureGuard({
+      guard: 'production-compatibility-switches',
+      violations: compatibilitySwitchViolations(
+        PRODUCTION_COMPATIBILITY_SWITCHES,
+        packageVersion,
+      ),
+    });
+  });
+
+  it('detects an expired or unsafe synthetic switch', () => {
+    const invalid = {
+      id: 'legacy-page-hook',
+      scope: 'page-injection',
+      owner: 'Issue #88',
+      introducedVersion: '0.5.40',
+      removalVersion: '0.5.49',
+      defaultPath: 'legacy',
+    } as unknown as ProductionCompatibilitySwitch;
+
+    expect(compatibilitySwitchViolations([invalid], '0.5.49')).toEqual([
+      'legacy-page-hook: defaultPath must be next',
+      'legacy-page-hook: removalVersion 0.5.49 reached at 0.5.49',
+    ]);
+  });
+});
+
+function compatibilitySwitchViolations(
+  switches: readonly ProductionCompatibilitySwitch[],
+  currentVersion: string,
+): string[] {
+  const violations: string[] = [];
+  const ids = new Set<string>();
+  const scopes = new Set<string>();
+
+  for (const entry of switches) {
+    if (!entry.id.trim()) violations.push('(empty id): id is required');
+    if (ids.has(entry.id)) violations.push(`${entry.id}: duplicate id`);
+    ids.add(entry.id);
+
+    if (scopes.has(entry.scope)) {
+      violations.push(`${entry.id}: duplicate active scope ${entry.scope}`);
+    }
+    scopes.add(entry.scope);
+
+    if (!/^Issue #\d+$/.test(entry.owner)) {
+      violations.push(`${entry.id}: owner must be Issue #<number>`);
+    }
+    if (entry.defaultPath !== 'next') {
+      violations.push(`${entry.id}: defaultPath must be next`);
+    }
+
+    const introduced = parseVersion(entry.introducedVersion);
+    const removal = parseVersion(entry.removalVersion);
+    const current = parseVersion(currentVersion);
+    if (!introduced) {
+      violations.push(`${entry.id}: invalid introducedVersion ${entry.introducedVersion}`);
+    }
+    if (!removal) {
+      violations.push(`${entry.id}: invalid removalVersion ${entry.removalVersion}`);
+    }
+    if (!current) {
+      violations.push(`package: invalid current version ${currentVersion}`);
+    }
+    if (introduced && removal && compareVersion(introduced, removal) >= 0) {
+      violations.push(
+        `${entry.id}: removalVersion must be later than introducedVersion`,
+      );
+    }
+    if (current && removal && compareVersion(current, removal) >= 0) {
+      violations.push(
+        `${entry.id}: removalVersion ${entry.removalVersion} reached at ${currentVersion}`,
+      );
+    }
+  }
+
+  return violations.sort();
+}
+
+type ParsedVersion = readonly [number, number, number];
+
+function parseVersion(version: string): ParsedVersion | null {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  return match
+    ? [Number(match[1]), Number(match[2]), Number(match[3])]
+    : null;
+}
+
+function compareVersion(left: ParsedVersion, right: ParsedVersion): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index]! - right[index]!;
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}

--- a/src/compatibility/production-switches.ts
+++ b/src/compatibility/production-switches.ts
@@ -1,0 +1,20 @@
+export type ProductionCompatibilityScope =
+  | 'page-injection'
+  | 'post-orchestrator';
+
+export interface ProductionCompatibilitySwitch {
+  id: string;
+  scope: ProductionCompatibilityScope;
+  owner: `Issue #${number}`;
+  introducedVersion: `${number}.${number}.${number}`;
+  removalVersion: `${number}.${number}.${number}`;
+  defaultPath: 'next';
+}
+
+/**
+ * Production compatibility switches are exceptional and temporary. Phase 6
+ * rejected switches for both currently planned scopes, so this registry is
+ * intentionally empty. Development-only comparison paths do not belong here.
+ */
+export const PRODUCTION_COMPATIBILITY_SWITCHES = [
+] as const satisfies readonly ProductionCompatibilitySwitch[];

--- a/vitest.architecture.config.ts
+++ b/vitest.architecture.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'src/background/message-router.test.ts',
       'src/background/platform-architecture.test.ts',
       'src/background/platform-strategies.test.ts',
+      'src/compatibility/production-switches.test.ts',
       'src/entrypoint-architecture.test.ts',
       'src/messages/messages-architecture.test.ts',
       'src/storage/storage-architecture.test.ts',


### PR DESCRIPTION
Closes #88

## Decision
- reject a production legacy switch for `page-injection`
- independently reject a production legacy switch for `post-orchestrator`
- permit legacy comparison only in development during Phase 7/8 migration; production artifacts contain next only

Neither scope satisfies the required recovery-evidence, bounded-maintenance, Options-access, and bundle/review criteria. The decision record defines the exact Phase 7/8 contracts and Surface gates.

## Guard
- add an intentionally empty production-switch registry
- require any future exception to declare owner issue, introduced version, removal version, and default-next behavior
- fail `architecture:check` for unsafe metadata, duplicate active scopes, or reached removal versions

## Verification
- `npm run architecture:check` (15 files / 96 tests PASS)
- `npm run verify:commit` (92 files / 691 tests + production build PASS)

Decision/test-only slice; no Surface or CWS action was required or performed.