### PR TITLE
refactor: map page-world request modes

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -34,6 +34,12 @@ import {
   type PostCapturePlatform,
   type PostCaptureResult,
 } from '../src/page-world/post-capture-rules';
+import {
+  decodeInjectRequestMode,
+  dispatchInjectRequest,
+  type InjectRequestHandlerMap,
+  type InjectRequestMode,
+} from '../src/page-world/request-mode-dispatch';
 
 const REQ_TAG = 'tutti-inject-req-v1';
 const RES_TAG = 'tutti-inject-res-v1';
@@ -81,7 +87,7 @@ interface InjectRequest {
    * 'tag-list' = Pixiv の tag input のような「value 入力 → Enter で確定 →
    *           input がクリア → 次の値」を繰り返す UI。tags[] を順次入れる
    */
-  mode: 'input' | 'drop' | 'text' | 'tumblr-text' | 'tag-list' | 'click' | 'x-post-url';
+  mode: InjectRequestMode;
   selector: string;
   files: InjectFileSpec[];
   /** mode === 'text' 専用: 挿入するテキスト */
@@ -1315,16 +1321,20 @@ export default defineContentScript({
       return false;
     }
 
+    const requestHandlers: InjectRequestHandlerMap<InjectRequest, InjectResponse> = {
+      input: injectIntoInput,
+      drop: injectViaDrop,
+      text: injectText,
+      'tumblr-text': injectTumblrText,
+      'tag-list': injectTagList,
+      click: clickElement,
+      'x-post-url': readLatestXPostUrl,
+    };
+
     async function handle(req: InjectRequest): Promise<InjectResponse> {
       try {
         installUploadHook();
-        if (req.mode === 'text') return await injectText(req);
-        if (req.mode === 'tumblr-text') return await injectTumblrText(req);
-        if (req.mode === 'drop') return await injectViaDrop(req);
-        if (req.mode === 'tag-list') return await injectTagList(req);
-        if (req.mode === 'click') return await clickElement(req);
-        if (req.mode === 'x-post-url') return await readLatestXPostUrl(req);
-        return await injectIntoInput(req);
+        return await dispatchInjectRequest(req, requestHandlers);
       } catch (e) {
         return {
           source: RES_TAG,
@@ -1344,17 +1354,10 @@ export default defineContentScript({
       const data = ev.data as Partial<InjectRequest> | undefined;
       if (!data || data.source !== REQ_TAG || typeof data.id !== 'string') return;
       if (typeof data.selector !== 'string' || !Array.isArray(data.files)) return;
-      const mode: InjectRequest['mode'] =
-        data.mode === 'drop' ? 'drop' :
-        data.mode === 'text' ? 'text' :
-        data.mode === 'tumblr-text' ? 'tumblr-text' :
-        data.mode === 'tag-list' ? 'tag-list' :
-        data.mode === 'click' ? 'click' :
-        data.mode === 'x-post-url' ? 'x-post-url' : 'input';
       const req: InjectRequest = {
         source: REQ_TAG,
         id: data.id,
-        mode,
+        mode: decodeInjectRequestMode(data.mode),
         selector: data.selector,
         files: data.files,
         text: typeof data.text === 'string' ? data.text : undefined,

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -125,6 +125,16 @@ describe('entrypoint architecture guard', () => {
     expect(observer.match(/\bxhrPrototype\.open\s*=\s*function observedOpen/g)).toHaveLength(1);
     expect(observer.match(/\bxhrPrototype\.send\s*=\s*function observedSend/g)).toHaveLength(1);
   });
+
+  it('keeps page-world request modes behind the exhaustive handler map', () => {
+    const entrypoint = readFileSync('entrypoints/inject-helper.content.ts', 'utf8');
+    const dispatch = readFileSync('src/page-world/request-mode-dispatch.ts', 'utf8');
+
+    expect(entrypoint).toContain('dispatchInjectRequest(req, requestHandlers)');
+    expect(entrypoint).toContain('mode: decodeInjectRequestMode(data.mode)');
+    expect(entrypoint).not.toMatch(/\b(?:req|data)\.mode\s*===/);
+    expect(dispatch).toContain('[Mode in InjectRequestMode]');
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/page-world/request-mode-dispatch.test.ts
+++ b/src/page-world/request-mode-dispatch.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decodeInjectRequestMode,
+  dispatchInjectRequest,
+  INJECT_REQUEST_MODES,
+  type InjectRequestHandlerMap,
+  type InjectRequestMode,
+} from './request-mode-dispatch';
+
+interface TestRequest {
+  mode: InjectRequestMode;
+  value: string;
+}
+
+function createHandlers(): InjectRequestHandlerMap<TestRequest, string> {
+  const handler = (mode: InjectRequestMode) =>
+    vi.fn((request: TestRequest) => `${mode}:${request.value}`);
+  return {
+    input: handler('input'),
+    drop: handler('drop'),
+    text: handler('text'),
+    'tumblr-text': handler('tumblr-text'),
+    'tag-list': handler('tag-list'),
+    click: handler('click'),
+    'x-post-url': handler('x-post-url'),
+  };
+}
+
+describe('request mode dispatch', () => {
+  it('keeps the v1 wire mode set explicit', () => {
+    expect(INJECT_REQUEST_MODES).toEqual([
+      'input',
+      'drop',
+      'text',
+      'tumblr-text',
+      'tag-list',
+      'click',
+      'x-post-url',
+    ]);
+  });
+
+  it.each(INJECT_REQUEST_MODES)('decodes supported mode %s', (mode) => {
+    expect(decodeInjectRequestMode(mode)).toBe(mode);
+  });
+
+  it.each([undefined, null, '', 'unknown', 1, {}])(
+    'preserves input fallback for unsupported mode %p',
+    (mode) => {
+      expect(decodeInjectRequestMode(mode)).toBe('input');
+    },
+  );
+
+  it('dispatches through exactly the selected handler', async () => {
+    const handlers = createHandlers();
+
+    await expect(dispatchInjectRequest(
+      { mode: 'tag-list', value: 'example' },
+      handlers,
+    )).resolves.toBe('tag-list:example');
+
+    for (const mode of INJECT_REQUEST_MODES) {
+      expect(handlers[mode]).toHaveBeenCalledTimes(mode === 'tag-list' ? 1 : 0);
+    }
+  });
+
+  it('propagates handler failures to the entrypoint error boundary', async () => {
+    const handlers = createHandlers();
+    handlers.click = vi.fn().mockRejectedValue(new Error('click failed'));
+
+    await expect(dispatchInjectRequest(
+      { mode: 'click', value: 'example' },
+      handlers,
+    )).rejects.toThrow('click failed');
+  });
+});

--- a/src/page-world/request-mode-dispatch.ts
+++ b/src/page-world/request-mode-dispatch.ts
@@ -1,0 +1,36 @@
+export const INJECT_REQUEST_MODES = [
+  'input',
+  'drop',
+  'text',
+  'tumblr-text',
+  'tag-list',
+  'click',
+  'x-post-url',
+] as const;
+
+export type InjectRequestMode = (typeof INJECT_REQUEST_MODES)[number];
+
+const injectRequestModes = new Set<string>(INJECT_REQUEST_MODES);
+
+export function decodeInjectRequestMode(value: unknown): InjectRequestMode {
+  return typeof value === 'string' && injectRequestModes.has(value)
+    ? value as InjectRequestMode
+    : 'input';
+}
+
+export type InjectRequestHandler<Request, Response> =
+  (request: Request) => Response | Promise<Response>;
+
+export type InjectRequestHandlerMap<Request, Response> = {
+  [Mode in InjectRequestMode]: InjectRequestHandler<Request, Response>;
+};
+
+export async function dispatchInjectRequest<
+  Request extends { mode: InjectRequestMode },
+  Response,
+>(
+  request: Request,
+  handlers: InjectRequestHandlerMap<Request, Response>,
+): Promise<Response> {
+  return await handlers[request.mode](request);
+}


### PR DESCRIPTION
Closes #94

## Summary
- centralize the seven page-world request mode IDs and runtime decoder
- replace request-mode condition chains with one exhaustive typed handler map
- preserve the v1 wire fallback from missing/unknown modes to `input`
- keep the existing structured exception boundary and all mode implementations unchanged
- add focused unit coverage and an architecture guard against conditional dispatch returning

## Verification
- focused request-dispatch + architecture: 2 files / 25 tests PASS
- `npm run verify:commit`: architecture 15 files / 98 tests; full 95 files / 729 tests; typecheck and production build PASS
- `npm run e2e:smoke:no-build` PASS
- generated `inject-helper.js`: 37.94 kB (previous 38.02 kB)

## Release gate
- [x] exact commit/artifact staged on Surface
- [ ] preview matrix PASS
- [ ] evidence recorded before merge

No CWS upload or submission.
