### PR TITLE
refactor: extract page-world element commands

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -40,6 +40,11 @@ import {
   type InjectRequestHandlerMap,
   type InjectRequestMode,
 } from '../src/page-world/request-mode-dispatch';
+import {
+  findElementBySelectorList,
+  handleClickCommand,
+  handleTagListCommand,
+} from '../src/page-world/element-commands';
 
 const REQ_TAG = 'tutti-inject-req-v1';
 const RES_TAG = 'tutti-inject-res-v1';
@@ -502,23 +507,13 @@ export default defineContentScript({
       return (clone.innerText ?? clone.textContent ?? '').replace(/\s+/g, ' ').trim();
     }
 
-    function findEl(
+    const findEl = (
       selector: string,
       options: { preferVisible?: boolean } = {},
-    ): { el: HTMLElement; matchedPart: string } | null {
-      let fallback: { el: HTMLElement; matchedPart: string } | null = null;
-      for (const part of selector.split(',').map((s) => s.trim()).filter(Boolean)) {
-        const elements = Array.from(document.querySelectorAll<HTMLElement>(part));
-        if (!fallback && elements[0]) fallback = { el: elements[0], matchedPart: part };
-        if (options.preferVisible) {
-          const visible = elements.find(isVisibleMediaElement);
-          if (visible) return { el: visible, matchedPart: part };
-        } else if (elements[0]) {
-          return { el: elements[0], matchedPart: part };
-        }
-      }
-      return fallback;
-    }
+    ): { el: HTMLElement; matchedPart: string } | null => findElementBySelectorList(selector, {
+      ...options,
+      isVisible: isVisibleMediaElement,
+    });
 
     function base64ToUint8Array(b64: string): Uint8Array {
       const binary = atob(b64);
@@ -1179,122 +1174,6 @@ export default defineContentScript({
       };
     }
 
-    async function injectTagList(req: InjectRequest): Promise<InjectResponse> {
-      const found = findEl(req.selector);
-      if (!found) {
-        return {
-          source: RES_TAG,
-          id: req.id,
-          ok: false,
-          error: `tag input not found: ${req.selector}`,
-        };
-      }
-      const input = found.el as HTMLInputElement | HTMLTextAreaElement;
-      // v0.4.73: textarea も許容 (Tumblr の "Tags editor" は textarea)。
-      const isTextarea = input instanceof HTMLTextAreaElement;
-      if (!(input instanceof HTMLInputElement) && !isTextarea) {
-        return {
-          source: RES_TAG,
-          id: req.id,
-          ok: false,
-          error: 'tag-list mode only supports <input> and <textarea> elements',
-        };
-      }
-      const tags = req.tags ?? [];
-      console.log(`[Tutti inject-helper] tag-list: ${tags.length} tags into "${found.matchedPart}" (${isTextarea ? 'textarea' : 'input'})`);
-      const setter = isTextarea
-        ? Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
-        : Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-
-      // React は controlled input/textarea に対して内部で _valueTracker を持つ。
-      function setReactValue(el: HTMLInputElement | HTMLTextAreaElement, value: string): void {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const tracker = (el as any)._valueTracker as { setValue: (v: string) => void } | undefined;
-        if (tracker) tracker.setValue('');
-        if (setter) setter.call(el, value);
-        else el.value = value;
-      }
-      // 旧名 alias (function 内で使ってる古い名前のため)
-      const setReactInputValue = setReactValue;
-
-      let committed = 0;
-      for (const tag of tags) {
-        input.focus();
-        setReactInputValue(input, tag);
-        // input + change を両方発火。React は input イベントを listener として
-        // 登録するが、formik / react-hook-form 等は change を見ることもある
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        input.dispatchEvent(new Event('change', { bubbles: true }));
-        await new Promise((r) => setTimeout(r, 150));
-        // Enter で commit。React 系は keydown を見るので 3 種 dispatch
-        const opts = { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true };
-        input.dispatchEvent(new KeyboardEvent('keydown', opts));
-        input.dispatchEvent(new KeyboardEvent('keypress', opts));
-        input.dispatchEvent(new KeyboardEvent('keyup', opts));
-        // Enter 後 input が空に戻れば commit 成功 (chip 化された証拠)。最大 1.5s 待つ
-        const cleared = await waitFor(() => input.value === '', 1500);
-        if (cleared) {
-          committed++;
-          console.log(`[Tutti inject-helper] tag committed: "${tag}"`);
-        } else {
-          console.warn(`[Tutti inject-helper] tag NOT committed (input not cleared): "${tag}" current="${input.value}"`);
-          // Enter が効いてない場合のフォールバック: keydown だけ再試行
-          input.dispatchEvent(new KeyboardEvent('keydown', opts));
-          await new Promise((r) => setTimeout(r, 400));
-          if (input.value === '') {
-            committed++;
-            console.log(`[Tutti inject-helper] tag committed on retry: "${tag}"`);
-          }
-        }
-      }
-      return {
-        source: RES_TAG,
-        id: req.id,
-        ok: committed > 0,
-        error: committed === 0 ? `no tags committed (tried ${tags.length})` : undefined,
-      };
-    }
-
-    async function clickElement(req: InjectRequest): Promise<InjectResponse> {
-      const texts = req.texts ?? [];
-      for (const part of req.selector.split(',').map((s) => s.trim()).filter(Boolean)) {
-        for (const el of document.querySelectorAll<HTMLElement>(part)) {
-          if (texts.length > 0 && !clickTextMatches(el, texts)) continue;
-          if (el.getAttribute('aria-disabled') === 'true' || (el as HTMLButtonElement).disabled) continue;
-          console.log(`[Tutti inject-helper] click target matched "${part}"`);
-          if (
-            /^(x|twitter)\.com$/.test(location.hostname) &&
-            (el.getAttribute('data-testid') === 'addButton' || /add post/i.test(el.getAttribute('aria-label') ?? ''))
-          ) {
-            el.focus();
-            const init = {
-              bubbles: true,
-              cancelable: true,
-              composed: true,
-              key: 'Enter',
-              code: 'Enter',
-            };
-            el.dispatchEvent(new KeyboardEvent('keydown', init));
-            el.dispatchEvent(new KeyboardEvent('keypress', init));
-            el.dispatchEvent(new KeyboardEvent('keyup', init));
-            return { source: RES_TAG, id: req.id, ok: true };
-          }
-          el.click();
-          return { source: RES_TAG, id: req.id, ok: true };
-        }
-      }
-      return { source: RES_TAG, id: req.id, ok: false, error: 'click target not found' };
-    }
-
-    function clickTextMatches(el: HTMLElement, texts: string[]): boolean {
-      const values = [
-        el.textContent,
-        el.getAttribute('aria-label'),
-        el.getAttribute('title'),
-      ].map((value) => (value ?? '').replace(/\s+/g, ' ').trim());
-      return values.some((value) => value && texts.includes(value));
-    }
-
     async function readLatestXPostUrl(req: InjectRequest): Promise<InjectResponse> {
       let captured = window.__tuttiXLatestPostId;
       try {
@@ -1326,8 +1205,8 @@ export default defineContentScript({
       drop: injectViaDrop,
       text: injectText,
       'tumblr-text': injectTumblrText,
-      'tag-list': injectTagList,
-      click: clickElement,
+      'tag-list': (request) => handleTagListCommand(request, RES_TAG),
+      click: (request) => handleClickCommand(request, RES_TAG),
       'x-post-url': readLatestXPostUrl,
     };
 

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -135,6 +135,14 @@ describe('entrypoint architecture guard', () => {
     expect(entrypoint).not.toMatch(/\b(?:req|data)\.mode\s*===/);
     expect(dispatch).toContain('[Mode in InjectRequestMode]');
   });
+
+  it('keeps page-world tag and click commands out of the entrypoint', () => {
+    const entrypoint = readFileSync('entrypoints/inject-helper.content.ts', 'utf8');
+
+    expect(entrypoint).toContain('handleTagListCommand(request, RES_TAG)');
+    expect(entrypoint).toContain('handleClickCommand(request, RES_TAG)');
+    expect(entrypoint).not.toMatch(/\bfunction (?:injectTagList|clickElement|clickTextMatches)\b/);
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/page-world/element-commands.test.ts
+++ b/src/page-world/element-commands.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  findElementBySelectorList,
+  handleClickCommand,
+  handleTagListCommand,
+} from './element-commands';
+
+const SOURCE = 'tutti-inject-res-v1';
+const noSleep = async (): Promise<void> => {};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('page-world element commands', () => {
+  it('resolves selector lists in order and can prefer visible targets', () => {
+    document.body.innerHTML = `
+      <button class="first">hidden</button>
+      <button class="first visible">visible</button>
+      <button class="second">second</button>
+    `;
+
+    const first = findElementBySelectorList('.first, .second');
+    const visible = findElementBySelectorList('.first, .second', {
+      preferVisible: true,
+      isVisible: (element) => element.classList.contains('visible'),
+    });
+
+    expect(first?.el.textContent).toBe('hidden');
+    expect(first?.matchedPart).toBe('.first');
+    expect(visible?.el.textContent).toBe('visible');
+  });
+
+  it('commits tags through the controlled-input event sequence', async () => {
+    document.body.innerHTML = '<input class="tags">';
+    const input = document.querySelector<HTMLInputElement>('input')!;
+    const events: string[] = [];
+    const tracker = { setValue: vi.fn() };
+    Object.assign(input, { _valueTracker: tracker });
+    for (const type of ['input', 'change', 'keydown', 'keypress', 'keyup']) {
+      input.addEventListener(type, () => {
+        events.push(type);
+        if (type === 'keydown') input.value = '';
+      });
+    }
+
+    const result = await handleTagListCommand({
+      id: 'tag-1',
+      selector: '.tags',
+      tags: ['tutti', 'test1'],
+    }, SOURCE, { sleep: noSleep });
+
+    expect(result).toEqual({ source: SOURCE, id: 'tag-1', ok: true, error: undefined });
+    expect(tracker.setValue).toHaveBeenCalledTimes(2);
+    expect(events).toEqual([
+      'input', 'change', 'keydown', 'keypress', 'keyup',
+      'input', 'change', 'keydown', 'keypress', 'keyup',
+    ]);
+  });
+
+  it('preserves tag target and uncommitted errors', async () => {
+    document.body.innerHTML = '<div class="not-input"></div>';
+    await expect(handleTagListCommand({
+      id: 'tag-2',
+      selector: '.not-input',
+      tags: ['tutti'],
+    }, SOURCE)).resolves.toMatchObject({
+      ok: false,
+      error: 'tag-list mode only supports <input> and <textarea> elements',
+    });
+
+    document.body.innerHTML = '<textarea class="tags"></textarea>';
+    await expect(handleTagListCommand({
+      id: 'tag-3',
+      selector: '.tags',
+      tags: ['tutti'],
+    }, SOURCE, {
+      sleep: noSleep,
+      waitFor: async () => false,
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'no tags committed (tried 1)',
+    });
+  });
+
+  it('clicks the first enabled exact-text match', async () => {
+    document.body.innerHTML = `
+      <button aria-label="Post" disabled>disabled</button>
+      <button aria-label="Cancel">Post</button>
+      <button aria-label="Post now">target</button>
+    `;
+    const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('button'));
+    const clicks = buttons.map((button) => vi.spyOn(button, 'click'));
+
+    const result = await handleClickCommand({
+      id: 'click-1',
+      selector: 'button',
+      texts: ['Post now'],
+    }, SOURCE, { hostname: 'example.com' });
+
+    expect(result.ok).toBe(true);
+    expect(clicks.map((click) => click.mock.calls.length)).toEqual([0, 0, 1]);
+  });
+
+  it('uses Enter events for the X add-post control', async () => {
+    document.body.innerHTML = '<button data-testid="addButton">Add</button>';
+    const button = document.querySelector<HTMLButtonElement>('button')!;
+    const click = vi.spyOn(button, 'click');
+    const keys: string[] = [];
+    for (const type of ['keydown', 'keypress', 'keyup']) {
+      button.addEventListener(type, () => keys.push(type));
+    }
+
+    const result = await handleClickCommand({
+      id: 'click-2',
+      selector: 'button',
+    }, SOURCE, { hostname: 'x.com' });
+
+    expect(result.ok).toBe(true);
+    expect(click).not.toHaveBeenCalled();
+    expect(keys).toEqual(['keydown', 'keypress', 'keyup']);
+  });
+
+  it('rejects missing or disabled click targets', async () => {
+    document.body.innerHTML = '<button aria-disabled="true">Post</button>';
+
+    await expect(handleClickCommand({
+      id: 'click-3',
+      selector: 'button, a',
+      texts: ['Post'],
+    }, SOURCE)).resolves.toEqual({
+      source: SOURCE,
+      id: 'click-3',
+      ok: false,
+      error: 'click target not found',
+    });
+  });
+});

--- a/src/page-world/element-commands.ts
+++ b/src/page-world/element-commands.ts
@@ -1,0 +1,209 @@
+export interface ElementCommandRequest {
+  id: string;
+  selector: string;
+  tags?: string[];
+  texts?: string[];
+}
+
+export interface ElementCommandResponse<Source extends string> {
+  source: Source;
+  id: string;
+  ok: boolean;
+  error?: string;
+}
+
+interface FindElementOptions {
+  root?: ParentNode;
+  preferVisible?: boolean;
+  isVisible?: (element: HTMLElement) => boolean;
+}
+
+interface TagListCommandOptions {
+  root?: ParentNode;
+  sleep?: (ms: number) => Promise<void>;
+  waitFor?: (predicate: () => boolean, timeoutMs: number) => Promise<boolean>;
+}
+
+interface ClickCommandOptions {
+  root?: ParentNode;
+  hostname?: string;
+}
+
+export function findElementBySelectorList(
+  selector: string,
+  options: FindElementOptions = {},
+): { el: HTMLElement; matchedPart: string } | null {
+  const root = options.root ?? document;
+  let fallback: { el: HTMLElement; matchedPart: string } | null = null;
+  for (const part of selector.split(',').map((value) => value.trim()).filter(Boolean)) {
+    const elements = Array.from(root.querySelectorAll<HTMLElement>(part));
+    if (!fallback && elements[0]) fallback = { el: elements[0], matchedPart: part };
+    if (options.preferVisible) {
+      const visible = elements.find(options.isVisible ?? isVisibleElement);
+      if (visible) return { el: visible, matchedPart: part };
+    } else if (elements[0]) {
+      return { el: elements[0], matchedPart: part };
+    }
+  }
+  return fallback;
+}
+
+export async function handleTagListCommand<Source extends string>(
+  request: ElementCommandRequest,
+  source: Source,
+  options: TagListCommandOptions = {},
+): Promise<ElementCommandResponse<Source>> {
+  const found = findElementBySelectorList(request.selector, { root: options.root });
+  if (!found) {
+    return {
+      source,
+      id: request.id,
+      ok: false,
+      error: `tag input not found: ${request.selector}`,
+    };
+  }
+  const input = found.el as HTMLInputElement | HTMLTextAreaElement;
+  const isTextarea = input instanceof HTMLTextAreaElement;
+  if (!(input instanceof HTMLInputElement) && !isTextarea) {
+    return {
+      source,
+      id: request.id,
+      ok: false,
+      error: 'tag-list mode only supports <input> and <textarea> elements',
+    };
+  }
+
+  const tags = request.tags ?? [];
+  console.log(
+    `[Tutti inject-helper] tag-list: ${tags.length} tags into ` +
+    `"${found.matchedPart}" (${isTextarea ? 'textarea' : 'input'})`,
+  );
+  const setter = isTextarea
+    ? Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+    : Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  const sleep = options.sleep ?? defaultSleep;
+  const waitFor = options.waitFor ?? defaultWaitFor;
+
+  function setReactValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+    const tracker = (element as HTMLInputElement & {
+      _valueTracker?: { setValue: (nextValue: string) => void };
+    })._valueTracker;
+    if (tracker) tracker.setValue('');
+    if (setter) setter.call(element, value);
+    else element.value = value;
+  }
+
+  let committed = 0;
+  for (const tag of tags) {
+    input.focus();
+    setReactValue(input, tag);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    await sleep(150);
+
+    const eventInit = {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      which: 13,
+      bubbles: true,
+      cancelable: true,
+    };
+    input.dispatchEvent(new KeyboardEvent('keydown', eventInit));
+    input.dispatchEvent(new KeyboardEvent('keypress', eventInit));
+    input.dispatchEvent(new KeyboardEvent('keyup', eventInit));
+    const cleared = await waitFor(() => input.value === '', 1500);
+    if (cleared) {
+      committed += 1;
+      console.log(`[Tutti inject-helper] tag committed: "${tag}"`);
+      continue;
+    }
+
+    console.warn(
+      `[Tutti inject-helper] tag NOT committed (input not cleared): ` +
+      `"${tag}" current="${input.value}"`,
+    );
+    input.dispatchEvent(new KeyboardEvent('keydown', eventInit));
+    await sleep(400);
+    if (input.value === '') {
+      committed += 1;
+      console.log(`[Tutti inject-helper] tag committed on retry: "${tag}"`);
+    }
+  }
+
+  return {
+    source,
+    id: request.id,
+    ok: committed > 0,
+    error: committed === 0 ? `no tags committed (tried ${tags.length})` : undefined,
+  };
+}
+
+export async function handleClickCommand<Source extends string>(
+  request: ElementCommandRequest,
+  source: Source,
+  options: ClickCommandOptions = {},
+): Promise<ElementCommandResponse<Source>> {
+  const root = options.root ?? document;
+  const hostname = options.hostname ?? location.hostname;
+  const texts = request.texts ?? [];
+  for (const part of request.selector.split(',').map((value) => value.trim()).filter(Boolean)) {
+    for (const element of root.querySelectorAll<HTMLElement>(part)) {
+      if (texts.length > 0 && !clickTextMatches(element, texts)) continue;
+      if (
+        element.getAttribute('aria-disabled') === 'true' ||
+        (element as HTMLButtonElement).disabled
+      ) continue;
+      console.log(`[Tutti inject-helper] click target matched "${part}"`);
+      if (
+        /^(x|twitter)\.com$/.test(hostname) &&
+        (
+          element.getAttribute('data-testid') === 'addButton' ||
+          /add post/i.test(element.getAttribute('aria-label') ?? '')
+        )
+      ) {
+        element.focus();
+        const eventInit = {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: 'Enter',
+          code: 'Enter',
+        };
+        element.dispatchEvent(new KeyboardEvent('keydown', eventInit));
+        element.dispatchEvent(new KeyboardEvent('keypress', eventInit));
+        element.dispatchEvent(new KeyboardEvent('keyup', eventInit));
+        return { source, id: request.id, ok: true };
+      }
+      element.click();
+      return { source, id: request.id, ok: true };
+    }
+  }
+  return { source, id: request.id, ok: false, error: 'click target not found' };
+}
+
+function clickTextMatches(element: HTMLElement, texts: string[]): boolean {
+  const values = [
+    element.textContent,
+    element.getAttribute('aria-label'),
+    element.getAttribute('title'),
+  ].map((value) => (value ?? '').replace(/\s+/g, ' ').trim());
+  return values.some((value) => value && texts.includes(value));
+}
+
+function isVisibleElement(element: HTMLElement): boolean {
+  return element.getClientRects().length > 0;
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function defaultWaitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await defaultSleep(50);
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #96

Depends on #95.

## Summary
- extract `tag-list` and `click` page-world commands from the MAIN-world entrypoint
- share selector-list target resolution without changing visible-target fallback behavior
- preserve controlled input/textarea value tracking, input/change/Enter ordering, retry, and error strings
- preserve exact-text/disabled click filtering and X add-post Enter activation
- keep media input/drop handlers for a separate upload-tracker slice
- add happy-dom fixtures and an architecture guard

## Verification
- focused element-command/request-dispatch/architecture: 3 files / 32 tests PASS
- `npm run verify:commit`: architecture 15 files / 99 tests; full 96 files / 736 tests; typecheck and production build PASS
- `npm run e2e:smoke:no-build` PASS

## Gate
- [ ] #95 merged and branch rebased on main
- [ ] exact-artifact Surface preview matrix PASS
- [ ] CI PASS
- [ ] evidence recorded before merge

No CWS upload or submission.