### PR TITLE
refactor: extract page-world media command handlers

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -45,6 +45,7 @@ import {
   handleClickCommand,
   handleTagListCommand,
 } from '../src/page-world/element-commands';
+import { createMediaCommandHandlers } from '../src/page-world/media-commands';
 
 const REQ_TAG = 'tutti-inject-req-v1';
 const RES_TAG = 'tutti-inject-res-v1';
@@ -533,51 +534,6 @@ export default defineContentScript({
         dt.items.add(new File([blob], f.name, { type: f.type, lastModified: Date.now() }));
       }
       return { dt };
-    }
-
-    async function injectIntoInput(req: InjectRequest): Promise<InjectResponse> {
-      const found = findEl(req.selector, { preferVisible: true });
-      if (!found) {
-        return { source: RES_TAG, id: req.id, ok: false, error: 'file input not found' };
-      }
-      const input = found.el as HTMLInputElement;
-      const inDialog = !!input.closest('[role="dialog"]');
-      console.log(`[Tutti inject-helper] inject input matched "${found.matchedPart}" — inDialog=${inDialog}`);
-      const built = buildDataTransfer(req.files);
-      if ('error' in built) return { source: RES_TAG, id: req.id, ok: false, error: built.error };
-      const requireMediaAccepted =
-        req.requireMediaAccepted === true ||
-        (
-          req.requireVideoAccepted !== false &&
-          req.files.some((file) => file.type.startsWith('video/'))
-        );
-      const beforePreviewCount = countMediaPreviews(mediaPreviewScope(input));
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'files')?.set;
-      if (setter) setter.call(input, built.dt.files);
-      else input.files = built.dt.files;
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-      input.dispatchEvent(new Event('input', { bubbles: true }));
-      const wait = await waitForUploadComplete(req.uploadTimeoutMs ?? 30000, {
-        requireMediaAccepted,
-        requirePreviewAccepted: req.requireMediaPreview === true,
-        isMediaPreviewVisible: requireMediaAccepted
-          ? mediaAcceptedPredicate(input, beforePreviewCount)
-          : undefined,
-        getMediaRejectionMessage: requireMediaAccepted
-          ? () => mediaRejectionMessage(input)
-          : undefined,
-      });
-      const ok = !wait.error && (!wait.timedOut || wait.acceptedByPreview);
-      return {
-        source: RES_TAG,
-        id: req.id,
-        ok,
-        error: ok ? undefined : (wait.error ?? 'Timed out while waiting for the media upload or preview'),
-        fileCount: input.files?.length ?? 0,
-        uploadCount: wait.uploadCount,
-        acceptedByPreview: wait.acceptedByPreview,
-        uploadTimedOut: wait.timedOut,
-      };
     }
 
     async function injectText(req: InjectRequest): Promise<InjectResponse> {
@@ -1120,60 +1076,6 @@ export default defineContentScript({
       };
     }
 
-    async function injectViaDrop(req: InjectRequest): Promise<InjectResponse> {
-      const found = findEl(req.selector);
-      if (!found) {
-        return { source: RES_TAG, id: req.id, ok: false, error: 'drop target not found' };
-      }
-      const target = found.el;
-      console.log(`[Tutti inject-helper] drop target matched "${found.matchedPart}"`);
-      const built = buildDataTransfer(req.files);
-      if ('error' in built) return { source: RES_TAG, id: req.id, ok: false, error: built.error };
-      const requireMediaAccepted =
-        req.requireMediaAccepted === true ||
-        (
-          req.requireVideoAccepted !== false &&
-          req.files.some((file) => file.type.startsWith('video/'))
-        );
-      const beforePreviewCount = countMediaPreviews(mediaPreviewScope(target));
-      const rect = target.getBoundingClientRect();
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
-      for (const type of ['dragenter', 'dragover', 'drop'] as const) {
-        const ev = new DragEvent(type, {
-          bubbles: true,
-          cancelable: true,
-          composed: true,
-          dataTransfer: built.dt,
-          clientX: x,
-          clientY: y,
-        });
-        target.dispatchEvent(ev);
-      }
-      const wait = await waitForUploadComplete(req.uploadTimeoutMs ?? 30000, {
-        requireMediaAccepted,
-        requirePreviewAccepted: req.requireMediaPreview === true,
-        isMediaPreviewVisible: requireMediaAccepted
-          ? mediaAcceptedPredicate(target, beforePreviewCount)
-          : undefined,
-        getMediaRejectionMessage: requireMediaAccepted
-          ? () => mediaRejectionMessage(target)
-          : undefined,
-      });
-      const ok = !wait.error && (!wait.timedOut || wait.acceptedByPreview);
-      return {
-        source: RES_TAG,
-        id: req.id,
-        ok,
-        error: ok ? undefined : (wait.error ?? 'Timed out while waiting for the media upload or preview'),
-        fileCount: built.dt.files.length,
-        droppedOn: target.tagName,
-        uploadCount: wait.uploadCount,
-        acceptedByPreview: wait.acceptedByPreview,
-        uploadTimedOut: wait.timedOut,
-      };
-    }
-
     async function readLatestXPostUrl(req: InjectRequest): Promise<InjectResponse> {
       let captured = window.__tuttiXLatestPostId;
       try {
@@ -1200,9 +1102,18 @@ export default defineContentScript({
       return false;
     }
 
+    const mediaCommandHandlers = createMediaCommandHandlers(RES_TAG, {
+      findElement: findEl,
+      buildDataTransfer,
+      mediaPreviewScope,
+      countMediaPreviews,
+      mediaAcceptedPredicate,
+      mediaRejectionMessage,
+      waitForUploadComplete,
+    });
     const requestHandlers: InjectRequestHandlerMap<InjectRequest, InjectResponse> = {
-      input: injectIntoInput,
-      drop: injectViaDrop,
+      input: mediaCommandHandlers.input,
+      drop: mediaCommandHandlers.drop,
       text: injectText,
       'tumblr-text': injectTumblrText,
       'tag-list': (request) => handleTagListCommand(request, RES_TAG),

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -143,6 +143,15 @@ describe('entrypoint architecture guard', () => {
     expect(entrypoint).toContain('handleClickCommand(request, RES_TAG)');
     expect(entrypoint).not.toMatch(/\bfunction (?:injectTagList|clickElement|clickTextMatches)\b/);
   });
+
+  it('keeps page-world input and drop commands behind one media runtime', () => {
+    const entrypoint = readFileSync('entrypoints/inject-helper.content.ts', 'utf8');
+
+    expect(entrypoint).toContain('const mediaCommandHandlers = createMediaCommandHandlers');
+    expect(entrypoint).toContain('input: mediaCommandHandlers.input');
+    expect(entrypoint).toContain('drop: mediaCommandHandlers.drop');
+    expect(entrypoint).not.toMatch(/\bfunction (?:injectIntoInput|injectViaDrop)\b/);
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/page-world/media-commands.test.ts
+++ b/src/page-world/media-commands.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMediaCommandHandlers,
+  type MediaCommandFile,
+  type MediaCommandRuntime,
+  type MediaUploadWaitResult,
+} from './media-commands';
+
+const SOURCE = 'tutti-inject-res-v1';
+const image: MediaCommandFile = {
+  name: 'test.png',
+  type: 'image/png',
+  data: 'AA==',
+};
+const video: MediaCommandFile = {
+  name: 'test.mp4',
+  type: 'video/mp4',
+  data: 'AA==',
+};
+
+function dataTransfer(...files: MediaCommandFile[]): DataTransfer {
+  const transfer = new DataTransfer();
+  for (const file of files) {
+    transfer.items.add(new File(['data'], file.name, { type: file.type }));
+  }
+  return transfer;
+}
+
+function createRuntime(
+  wait: MediaUploadWaitResult = {
+    uploadCount: 1,
+    timedOut: false,
+    acceptedByPreview: false,
+  },
+): MediaCommandRuntime {
+  return {
+    findElement: (selector) => {
+      const el = document.querySelector<HTMLElement>(selector);
+      return el ? { el, matchedPart: selector } : null;
+    },
+    buildDataTransfer: (files) => ({ dt: dataTransfer(...files) }),
+    mediaPreviewScope: (target) => target.parentNode ?? document,
+    countMediaPreviews: vi.fn(() => 2),
+    mediaAcceptedPredicate: vi.fn(() => () => true),
+    mediaRejectionMessage: vi.fn(() => undefined),
+    waitForUploadComplete: vi.fn(async () => wait),
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('page-world media commands', () => {
+  it('injects files and preserves change/input event order', async () => {
+    document.body.innerHTML = '<div role="dialog"><input type="file"></div>';
+    const input = document.querySelector<HTMLInputElement>('input')!;
+    const events: string[] = [];
+    input.addEventListener('change', () => events.push('change'));
+    input.addEventListener('input', () => events.push('input'));
+    const runtime = createRuntime();
+    const handlers = createMediaCommandHandlers(SOURCE, runtime);
+
+    const result = await handlers.input({
+      id: 'input-1',
+      selector: 'input',
+      files: [image],
+      uploadTimeoutMs: 1234,
+    });
+
+    expect(result).toEqual({
+      source: SOURCE,
+      id: 'input-1',
+      ok: true,
+      error: undefined,
+      fileCount: 1,
+      uploadCount: 1,
+      acceptedByPreview: false,
+      uploadTimedOut: false,
+    });
+    expect(events).toEqual(['change', 'input']);
+    expect(runtime.waitForUploadComplete).toHaveBeenCalledWith(1234, {
+      requireMediaAccepted: false,
+      requirePreviewAccepted: false,
+      isMediaPreviewVisible: undefined,
+      getMediaRejectionMessage: undefined,
+    });
+  });
+
+  it('dispatches dragenter/dragover/drop at the target center', async () => {
+    document.body.innerHTML = '<div class="drop"></div>';
+    const target = document.querySelector<HTMLElement>('.drop')!;
+    const getBoundingClientRect = vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+      x: 10,
+      y: 20,
+      left: 10,
+      top: 20,
+      right: 110,
+      bottom: 80,
+      width: 100,
+      height: 60,
+      toJSON: () => ({}),
+    });
+    const events: string[] = [];
+    for (const type of ['dragenter', 'dragover', 'drop']) {
+      target.addEventListener(type, () => events.push(type));
+    }
+    const runtime = createRuntime();
+    const handlers = createMediaCommandHandlers(SOURCE, runtime);
+
+    const result = await handlers.drop({
+      id: 'drop-1',
+      selector: '.drop',
+      files: [image],
+    });
+
+    expect(result).toMatchObject({
+      source: SOURCE,
+      id: 'drop-1',
+      ok: true,
+      fileCount: 1,
+      droppedOn: 'DIV',
+    });
+    expect(getBoundingClientRect).toHaveBeenCalledOnce();
+    expect(events).toEqual(['dragenter', 'dragover', 'drop']);
+  });
+
+  it('requires acceptance and preview evidence for video when requested', async () => {
+    document.body.innerHTML = '<input type="file">';
+    const runtime = createRuntime();
+    const handlers = createMediaCommandHandlers(SOURCE, runtime);
+
+    await handlers.input({
+      id: 'input-video',
+      selector: 'input',
+      files: [video],
+      requireMediaPreview: true,
+    });
+
+    expect(runtime.mediaAcceptedPredicate).toHaveBeenCalledWith(
+      document.querySelector('input'),
+      2,
+    );
+    expect(runtime.waitForUploadComplete).toHaveBeenCalledWith(30000, expect.objectContaining({
+      requireMediaAccepted: true,
+      requirePreviewAccepted: true,
+      isMediaPreviewVisible: expect.any(Function),
+      getMediaRejectionMessage: expect.any(Function),
+    }));
+  });
+
+  it('preserves missing-target and DataTransfer errors', async () => {
+    const runtime = createRuntime();
+    const handlers = createMediaCommandHandlers(SOURCE, runtime);
+    await expect(handlers.input({
+      id: 'missing-input',
+      selector: 'input',
+      files: [image],
+    })).resolves.toEqual({
+      source: SOURCE,
+      id: 'missing-input',
+      ok: false,
+      error: 'file input not found',
+    });
+    await expect(handlers.drop({
+      id: 'missing-drop',
+      selector: '.drop',
+      files: [image],
+    })).resolves.toEqual({
+      source: SOURCE,
+      id: 'missing-drop',
+      ok: false,
+      error: 'drop target not found',
+    });
+
+    document.body.innerHTML = '<input type="file">';
+    runtime.buildDataTransfer = () => ({ error: 'invalid base64' });
+    await expect(handlers.input({
+      id: 'bad-file',
+      selector: 'input',
+      files: [image],
+    })).resolves.toEqual({
+      source: SOURCE,
+      id: 'bad-file',
+      ok: false,
+      error: 'invalid base64',
+    });
+  });
+
+  it('distinguishes preview-accepted timeout from rejection and hard timeout', async () => {
+    document.body.innerHTML = '<input type="file">';
+
+    const accepted = createMediaCommandHandlers(SOURCE, createRuntime({
+      uploadCount: 0,
+      timedOut: true,
+      acceptedByPreview: true,
+    }));
+    await expect(accepted.input({
+      id: 'accepted',
+      selector: 'input',
+      files: [video],
+    })).resolves.toMatchObject({ ok: true, error: undefined, uploadTimedOut: true });
+
+    const rejected = createMediaCommandHandlers(SOURCE, createRuntime({
+      uploadCount: 0,
+      timedOut: false,
+      acceptedByPreview: false,
+      error: 'media rejected',
+    }));
+    await expect(rejected.input({
+      id: 'rejected',
+      selector: 'input',
+      files: [video],
+    })).resolves.toMatchObject({ ok: false, error: 'media rejected' });
+
+    const timedOut = createMediaCommandHandlers(SOURCE, createRuntime({
+      uploadCount: 0,
+      timedOut: true,
+      acceptedByPreview: false,
+    }));
+    await expect(timedOut.input({
+      id: 'timed-out',
+      selector: 'input',
+      files: [video],
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'Timed out while waiting for the media upload or preview',
+    });
+  });
+});

--- a/src/page-world/media-commands.ts
+++ b/src/page-world/media-commands.ts
@@ -1,0 +1,207 @@
+export interface MediaCommandFile {
+  name: string;
+  type: string;
+  data: string;
+}
+
+export interface MediaCommandRequest {
+  id: string;
+  selector: string;
+  files: MediaCommandFile[];
+  uploadTimeoutMs?: number;
+  requireVideoAccepted?: boolean;
+  requireMediaAccepted?: boolean;
+  requireMediaPreview?: boolean;
+}
+
+export interface MediaCommandResponse<Source extends string> {
+  source: Source;
+  id: string;
+  ok: boolean;
+  error?: string;
+  fileCount?: number;
+  droppedOn?: string;
+  uploadCount?: number;
+  acceptedByPreview?: boolean;
+  uploadTimedOut?: boolean;
+}
+
+export interface MediaUploadWaitOptions {
+  requireMediaAccepted?: boolean;
+  requirePreviewAccepted?: boolean;
+  isMediaPreviewVisible?: () => boolean;
+  getMediaRejectionMessage?: () => string | undefined;
+}
+
+export interface MediaUploadWaitResult {
+  uploadCount: number;
+  timedOut: boolean;
+  acceptedByPreview: boolean;
+  error?: string;
+}
+
+export interface MediaCommandRuntime {
+  findElement: (
+    selector: string,
+    options?: { preferVisible?: boolean },
+  ) => { el: HTMLElement; matchedPart: string } | null;
+  buildDataTransfer: (
+    files: MediaCommandFile[],
+  ) => { dt: DataTransfer } | { error: string };
+  mediaPreviewScope: (target: HTMLElement) => ParentNode;
+  countMediaPreviews: (scope: ParentNode) => number;
+  mediaAcceptedPredicate: (
+    target: HTMLElement,
+    beforeCount: number,
+  ) => () => boolean;
+  mediaRejectionMessage: (target: HTMLElement) => string | undefined;
+  waitForUploadComplete: (
+    timeoutMs: number,
+    options: MediaUploadWaitOptions,
+  ) => Promise<MediaUploadWaitResult>;
+}
+
+export function createMediaCommandHandlers<Source extends string>(
+  source: Source,
+  runtime: MediaCommandRuntime,
+): {
+  input: (request: MediaCommandRequest) => Promise<MediaCommandResponse<Source>>;
+  drop: (request: MediaCommandRequest) => Promise<MediaCommandResponse<Source>>;
+} {
+  return {
+    input: async (request) => await handleInputCommand(request, source, runtime),
+    drop: async (request) => await handleDropCommand(request, source, runtime),
+  };
+}
+
+async function handleInputCommand<Source extends string>(
+  request: MediaCommandRequest,
+  source: Source,
+  runtime: MediaCommandRuntime,
+): Promise<MediaCommandResponse<Source>> {
+  const found = runtime.findElement(request.selector, { preferVisible: true });
+  if (!found) {
+    return { source, id: request.id, ok: false, error: 'file input not found' };
+  }
+  const input = found.el as HTMLInputElement;
+  const inDialog = !!input.closest('[role="dialog"]');
+  console.log(
+    `[Tutti inject-helper] inject input matched "${found.matchedPart}" — ` +
+    `inDialog=${inDialog}`,
+  );
+  const built = runtime.buildDataTransfer(request.files);
+  if ('error' in built) {
+    return { source, id: request.id, ok: false, error: built.error };
+  }
+
+  const requireMediaAccepted = requiresMediaAcceptance(request);
+  const beforePreviewCount = runtime.countMediaPreviews(runtime.mediaPreviewScope(input));
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'files')?.set;
+  if (setter) setter.call(input, built.dt.files);
+  else input.files = built.dt.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+
+  const wait = await runtime.waitForUploadComplete(
+    request.uploadTimeoutMs ?? 30000,
+    buildWaitOptions(request, input, beforePreviewCount, requireMediaAccepted, runtime),
+  );
+  const ok = waitSucceeded(wait);
+  return {
+    source,
+    id: request.id,
+    ok,
+    error: waitError(wait, ok),
+    fileCount: input.files?.length ?? 0,
+    uploadCount: wait.uploadCount,
+    acceptedByPreview: wait.acceptedByPreview,
+    uploadTimedOut: wait.timedOut,
+  };
+}
+
+async function handleDropCommand<Source extends string>(
+  request: MediaCommandRequest,
+  source: Source,
+  runtime: MediaCommandRuntime,
+): Promise<MediaCommandResponse<Source>> {
+  const found = runtime.findElement(request.selector);
+  if (!found) {
+    return { source, id: request.id, ok: false, error: 'drop target not found' };
+  }
+  const target = found.el;
+  console.log(`[Tutti inject-helper] drop target matched "${found.matchedPart}"`);
+  const built = runtime.buildDataTransfer(request.files);
+  if ('error' in built) {
+    return { source, id: request.id, ok: false, error: built.error };
+  }
+
+  const requireMediaAccepted = requiresMediaAcceptance(request);
+  const beforePreviewCount = runtime.countMediaPreviews(runtime.mediaPreviewScope(target));
+  const rect = target.getBoundingClientRect();
+  const clientX = rect.left + rect.width / 2;
+  const clientY = rect.top + rect.height / 2;
+  for (const type of ['dragenter', 'dragover', 'drop'] as const) {
+    target.dispatchEvent(new DragEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      dataTransfer: built.dt,
+      clientX,
+      clientY,
+    }));
+  }
+
+  const wait = await runtime.waitForUploadComplete(
+    request.uploadTimeoutMs ?? 30000,
+    buildWaitOptions(request, target, beforePreviewCount, requireMediaAccepted, runtime),
+  );
+  const ok = waitSucceeded(wait);
+  return {
+    source,
+    id: request.id,
+    ok,
+    error: waitError(wait, ok),
+    fileCount: built.dt.files.length,
+    droppedOn: target.tagName,
+    uploadCount: wait.uploadCount,
+    acceptedByPreview: wait.acceptedByPreview,
+    uploadTimedOut: wait.timedOut,
+  };
+}
+
+function requiresMediaAcceptance(request: MediaCommandRequest): boolean {
+  return request.requireMediaAccepted === true ||
+    (
+      request.requireVideoAccepted !== false &&
+      request.files.some((file) => file.type.startsWith('video/'))
+    );
+}
+
+function buildWaitOptions(
+  request: MediaCommandRequest,
+  target: HTMLElement,
+  beforePreviewCount: number,
+  requireMediaAccepted: boolean,
+  runtime: MediaCommandRuntime,
+): MediaUploadWaitOptions {
+  return {
+    requireMediaAccepted,
+    requirePreviewAccepted: request.requireMediaPreview === true,
+    isMediaPreviewVisible: requireMediaAccepted
+      ? runtime.mediaAcceptedPredicate(target, beforePreviewCount)
+      : undefined,
+    getMediaRejectionMessage: requireMediaAccepted
+      ? () => runtime.mediaRejectionMessage(target)
+      : undefined,
+  };
+}
+
+function waitSucceeded(result: MediaUploadWaitResult): boolean {
+  return !result.error && (!result.timedOut || result.acceptedByPreview);
+}
+
+function waitError(result: MediaUploadWaitResult, ok: boolean): string | undefined {
+  return ok
+    ? undefined
+    : (result.error ?? 'Timed out while waiting for the media upload or preview');
+}


### PR DESCRIPTION
Closes #98

Depends on #97.

## Summary
- extract page-world `input` and `drop` media command policy behind one typed runtime
- keep target resolution, DataTransfer construction, upload waiting, preview evidence, and rejection detection as the existing injected primitives
- preserve input setter/change/input ordering, dragenter/dragover/drop ordering, target-center coordinates, timeout defaults, acceptance policy, and response/error shapes
- add deterministic happy-dom/runtime fixtures and an architecture guard

## Verification
- focused media/element/request-dispatch/architecture: 4 files / 38 tests PASS
- `npm run verify:commit`: architecture 15 files / 100 tests; full 97 files / 742 tests; typecheck and production build PASS
- `npm run e2e:smoke:no-build` PASS

## Gate
- [ ] #97 merged and branch rebased on main
- [ ] exact-artifact Surface preview matrix PASS
- [ ] CI PASS
- [ ] evidence recorded before merge

No CWS upload or submission.