### PR TITLE
refactor: introduce page-world editor drivers

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -46,6 +46,11 @@ import {
   handleTagListCommand,
 } from '../src/page-world/element-commands';
 import { createMediaCommandHandlers } from '../src/page-world/media-commands';
+import {
+  injectContentEditableText,
+  injectNativeText,
+  resolveTextEditorDriver,
+} from '../src/page-world/editor-drivers';
 
 const REQ_TAG = 'tutti-inject-req-v1';
 const RES_TAG = 'tutti-inject-res-v1';
@@ -545,6 +550,7 @@ export default defineContentScript({
       const text = req.text ?? '';
       let frameworkTextVerified = false;
       let requiresStableFrameworkText = false;
+      const editorDriver = resolveTextEditorDriver(el);
       console.log(`[Tutti inject-helper] text target matched "${found.matchedPart}" (${el.tagName})`);
 
       // v0.4.59: 空文字 inject は no-op で成功扱い (画像のみ投稿の正常 path)。
@@ -557,14 +563,8 @@ export default defineContentScript({
 
       el.focus();
 
-      if (el instanceof HTMLTextAreaElement || el instanceof HTMLInputElement) {
-        // textarea / input: native value setter + input event
-        const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
-        const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
-        if (setter) setter.call(el, text);
-        else (el as HTMLTextAreaElement).value = text;
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-        el.dispatchEvent(new Event('change', { bubbles: true }));
+      if (editorDriver === 'native') {
+        injectNativeText(el as HTMLInputElement | HTMLTextAreaElement, text);
       } else {
         // contenteditable (Draft.js / Lexical / TipTap / ProseMirror):
         // 経路 (v0.4.66〜):
@@ -581,11 +581,7 @@ export default defineContentScript({
           window.__tuttiIgPendingCaption = text;
           console.log('[Tutti inject-helper] IG pending caption set (len=' + text.length + ')');
         }
-        const isLexical =
-          !!el.closest('[data-lexical-editor]') ||
-          el.matches('[data-lexical-editor]');
-
-        if (isLexical) {
+        if (editorDriver === 'lexical') {
           // IG 特有の workaround: Share click 時の `/api/v1/media/configure/`
           // への fetch で body の `caption=` が空のまま送られる問題 (Lexical state
           // を更新しても IG の submit state には伝わらない silent failure)。
@@ -797,10 +793,7 @@ export default defineContentScript({
             }
             await new Promise((r) => setTimeout(r, 800));
           }
-        } else if (
-          el.matches('.public-DraftEditor-content') ||
-          !!el.closest('.DraftEditor-root')
-        ) {
+        } else if (editorDriver === 'draft') {
           // Draft.js (TikTok Studio): upload 後に filename 由来の初期 caption
           // が入る variant がある。DOM だけ消して paste すると controlled
           // state 側の旧値へ追記されるため、editor selection を全置換する。
@@ -870,45 +863,7 @@ export default defineContentScript({
           el.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: text.slice(-1) || 'a' }));
           await new Promise((r) => setTimeout(r, 800));
         } else {
-          // 非 Lexical (TipTap / ProseMirror 等): paste event 経由
-          const existing = (el.textContent ?? '').trim();
-          if (existing.length > 0) {
-            const sel = window.getSelection();
-            if (sel) {
-              sel.selectAllChildren(el);
-              sel.deleteFromDocument();
-            }
-            if ((el.textContent ?? '').trim().length > 0) {
-              try {
-                document.execCommand('selectAll', false);
-                document.execCommand('delete', false);
-              } catch { /* ignore */ }
-            }
-          }
-          const dt = new DataTransfer();
-          dt.setData('text/plain', text);
-          const pasteEv = new ClipboardEvent('paste', {
-            bubbles: true,
-            cancelable: true,
-            clipboardData: dt,
-          });
-          el.dispatchEvent(pasteEv);
-
-          const matchSnippet = text.slice(0, Math.min(16, text.length));
-          const visibleNow = (): string =>
-            (el as HTMLElement).innerText ?? el.textContent ?? '';
-          const pasted = await waitFor(
-            () => matchSnippet === '' || visibleNow().includes(matchSnippet),
-            600,
-          );
-
-          if (!pasted) {
-            el.textContent = text;
-            el.dispatchEvent(new InputEvent('input', {
-              bubbles: true, data: text, inputType: 'insertText',
-            }));
-            await new Promise((r) => setTimeout(r, 80));
-          }
+          await injectContentEditableText(el, text, { waitFor });
         }
       }
 

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -152,6 +152,15 @@ describe('entrypoint architecture guard', () => {
     expect(entrypoint).toContain('drop: mediaCommandHandlers.drop');
     expect(entrypoint).not.toMatch(/\bfunction (?:injectIntoInput|injectViaDrop)\b/);
   });
+
+  it('keeps native and generic contenteditable mechanics in editor drivers', () => {
+    const entrypoint = readFileSync('entrypoints/inject-helper.content.ts', 'utf8');
+
+    expect(entrypoint).toContain('const editorDriver = resolveTextEditorDriver(el)');
+    expect(entrypoint).toContain('injectNativeText(');
+    expect(entrypoint).toContain('injectContentEditableText(');
+    expect(entrypoint).not.toContain("Object.getOwnPropertyDescriptor(proto, 'value')");
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/page-world/editor-drivers.test.ts
+++ b/src/page-world/editor-drivers.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  injectContentEditableText,
+  injectNativeText,
+  resolveTextEditorDriver,
+} from './editor-drivers';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('page-world editor drivers', () => {
+  it('selects native, Lexical, Draft.js, and generic contenteditable drivers', () => {
+    document.body.innerHTML = `
+      <input id="input">
+      <textarea id="textarea"></textarea>
+      <div data-lexical-editor><div id="lexical" contenteditable="true"></div></div>
+      <div class="DraftEditor-root"><div id="draft" contenteditable="true"></div></div>
+      <div id="generic" contenteditable="true"></div>
+    `;
+
+    expect(resolveTextEditorDriver(document.querySelector('#input')!)).toBe('native');
+    expect(resolveTextEditorDriver(document.querySelector('#textarea')!)).toBe('native');
+    expect(resolveTextEditorDriver(document.querySelector('#lexical')!)).toBe('lexical');
+    expect(resolveTextEditorDriver(document.querySelector('#draft')!)).toBe('draft');
+    expect(resolveTextEditorDriver(document.querySelector('#generic')!)).toBe('contenteditable');
+  });
+
+  it.each(['input', 'textarea'])(
+    'uses the native value setter and input/change order for %s',
+    (tag) => {
+      document.body.innerHTML = `<${tag}></${tag}>`;
+      const element = document.querySelector<HTMLInputElement | HTMLTextAreaElement>(tag)!;
+      const events: string[] = [];
+      element.addEventListener('input', () => events.push('input'));
+      element.addEventListener('change', () => events.push('change'));
+
+      injectNativeText(element, 'hello 😀');
+
+      expect(element.value).toBe('hello 😀');
+      expect(events).toEqual(['input', 'change']);
+    },
+  );
+
+  it('accepts framework paste handling without firing the fallback input event', async () => {
+    document.body.innerHTML = '<div contenteditable="true"></div>';
+    const element = document.querySelector<HTMLElement>('div')!;
+    const input = vi.fn();
+    element.addEventListener('input', input);
+    element.addEventListener('paste', (event) => {
+      element.textContent = (event as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+
+    await injectContentEditableText(element, 'pasted text');
+
+    expect(element.textContent).toBe('pasted text');
+    expect(input).not.toHaveBeenCalled();
+  });
+
+  it('replaces existing content and falls back to textContent plus input', async () => {
+    document.body.innerHTML = '<div contenteditable="true">stale text</div>';
+    const element = document.querySelector<HTMLElement>('div')!;
+    const inputTypes: Array<string | undefined> = [];
+    element.addEventListener('input', (event) => {
+      inputTypes.push((event as InputEvent).inputType);
+    });
+
+    await injectContentEditableText(element, 'replacement', {
+      waitFor: async () => false,
+      sleep: async () => {},
+    });
+
+    expect(element.textContent).toBe('replacement');
+    expect(inputTypes).toEqual(['insertText']);
+  });
+});

--- a/src/page-world/editor-drivers.ts
+++ b/src/page-world/editor-drivers.ts
@@ -1,0 +1,102 @@
+export type TextEditorDriverKind =
+  | 'native'
+  | 'lexical'
+  | 'draft'
+  | 'contenteditable';
+
+interface ContentEditableDriverOptions {
+  sleep?: (ms: number) => Promise<void>;
+  waitFor?: (predicate: () => boolean, timeoutMs: number) => Promise<boolean>;
+}
+
+export function resolveTextEditorDriver(element: HTMLElement): TextEditorDriverKind {
+  if (element instanceof HTMLTextAreaElement || element instanceof HTMLInputElement) {
+    return 'native';
+  }
+  if (
+    element.matches('[data-lexical-editor]') ||
+    !!element.closest('[data-lexical-editor]')
+  ) {
+    return 'lexical';
+  }
+  if (
+    element.matches('.public-DraftEditor-content') ||
+    !!element.closest('.DraftEditor-root')
+  ) {
+    return 'draft';
+  }
+  return 'contenteditable';
+}
+
+export function injectNativeText(
+  element: HTMLInputElement | HTMLTextAreaElement,
+  text: string,
+): void {
+  const prototype = element instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+  if (setter) setter.call(element, text);
+  else element.value = text;
+  element.dispatchEvent(new Event('input', { bubbles: true }));
+  element.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+export async function injectContentEditableText(
+  element: HTMLElement,
+  text: string,
+  options: ContentEditableDriverOptions = {},
+): Promise<void> {
+  const existing = (element.textContent ?? '').trim();
+  if (existing.length > 0) {
+    const selection = window.getSelection();
+    if (selection) {
+      selection.selectAllChildren(element);
+      selection.deleteFromDocument();
+    }
+    if ((element.textContent ?? '').trim().length > 0) {
+      try {
+        document.execCommand('selectAll', false);
+        document.execCommand('delete', false);
+      } catch { /* ignore */ }
+    }
+  }
+
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/plain', text);
+  element.dispatchEvent(new ClipboardEvent('paste', {
+    bubbles: true,
+    cancelable: true,
+    clipboardData: dataTransfer,
+  }));
+
+  const matchSnippet = text.slice(0, Math.min(16, text.length));
+  const visibleNow = (): string => element.innerText ?? element.textContent ?? '';
+  const waitFor = options.waitFor ?? defaultWaitFor;
+  const pasted = await waitFor(
+    () => matchSnippet === '' || visibleNow().includes(matchSnippet),
+    600,
+  );
+  if (pasted) return;
+
+  element.textContent = text;
+  element.dispatchEvent(new InputEvent('input', {
+    bubbles: true,
+    data: text,
+    inputType: 'insertText',
+  }));
+  await (options.sleep ?? defaultSleep)(80);
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function defaultWaitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await defaultSleep(50);
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #100

Depends on #99.

## Summary
- introduce deterministic editor-driver classification for native, Lexical, Draft.js, and generic contenteditable targets
- extract native input/textarea setter + input/change behavior
- extract generic contenteditable paste + textContent/input fallback behavior
- leave Lexical, Draft.js, and Tumblr-block mechanics unchanged for dedicated follow-up slices
- preserve empty-text, Instagram pending-caption, and final verification behavior
- add happy-dom fixtures and an architecture guard

## Verification
- focused editor/media/element/request-dispatch/architecture: 5 files / 44 tests PASS
- `npm run verify:commit`: architecture 15 files / 101 tests; full 98 files / 748 tests; typecheck and production build PASS
- `npm run e2e:smoke:no-build` PASS

## Gate
- [ ] #99 merged and branch rebased on main
- [ ] exact-artifact Surface preview matrix PASS
- [ ] CI PASS
- [ ] evidence recorded before merge

No CWS upload or submission.