### PR TITLE
refactor: extract Tumblr block editor driver

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -17,12 +17,6 @@
  *   4. 待機完了後 window.postMessage({ source: RES_TAG, id, ok, fileCount?, uploadCount? })
  */
 
-import { validateTumblrBodyText } from '../src/utils/tumblr-text';
-import { extractHttpUrls, mergeStandaloneUrlParagraphs } from '../src/utils/text-urls';
-import {
-  findTumblrBodyBlocks,
-  readTumblrBodyTextFromBlocks,
-} from '../src/utils/tumblr-editor';
 import {
   installNetworkObserver,
   type NetworkObserverDiagnostic,
@@ -51,6 +45,7 @@ import {
   injectNativeText,
   resolveTextEditorDriver,
 } from '../src/page-world/editor-drivers';
+import { handleTumblrTextCommand } from '../src/page-world/tumblr-editor-driver';
 
 const REQ_TAG = 'tutti-inject-req-v1';
 const RES_TAG = 'tutti-inject-res-v1';
@@ -904,133 +899,6 @@ export default defineContentScript({
       return `${ownText}${childText}`;
     }
 
-    async function clearEditableBlock(el: HTMLElement): Promise<void> {
-      el.focus();
-      const sel = window.getSelection();
-      if (sel) {
-        try {
-          sel.removeAllRanges();
-          const range = document.createRange();
-          range.selectNodeContents(el);
-          sel.addRange(range);
-        } catch { /* ignore */ }
-      }
-      try {
-        document.execCommand('delete', false);
-      } catch { /* fallback below */ }
-      if ((el.textContent ?? '').trim().length > 0) {
-        el.textContent = '';
-        el.dispatchEvent(new InputEvent('input', {
-          bubbles: true,
-          inputType: 'deleteContentBackward',
-        }));
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
-
-    async function insertTumblrPlainText(selector: string, anchor: HTMLElement, text: string): Promise<void> {
-      const blocks = findTumblrBodyBlocks(selector, { anchor });
-      for (const block of blocks) {
-        await clearEditableBlock(block);
-      }
-      const target = blocks[0] ?? anchor;
-      target.focus();
-      const sel = window.getSelection();
-      if (sel) {
-        try {
-          sel.removeAllRanges();
-          const range = document.createRange();
-          range.selectNodeContents(target);
-          sel.addRange(range);
-        } catch { /* ignore */ }
-      }
-      target.dispatchEvent(new InputEvent('beforeinput', {
-        bubbles: true,
-        cancelable: true,
-        inputType: 'insertText',
-        data: text,
-      }));
-      let inserted = false;
-      try {
-        inserted = document.execCommand('insertText', false, text);
-      } catch { /* fallback below */ }
-      const expectedSnippet = text.slice(0, Math.min(20, text.length)).trim();
-      const visible = () => readTumblrBodyTextFromBlocks(findTumblrBodyBlocks(selector, { anchor: target }));
-      if (!inserted || (expectedSnippet && !visible().includes(expectedSnippet))) {
-        target.textContent = text;
-      }
-      target.dispatchEvent(new InputEvent('input', {
-        bubbles: true,
-        data: text,
-        inputType: 'insertText',
-      }));
-      target.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: text.slice(-1) || 'a' }));
-      await new Promise((r) => setTimeout(r, 250));
-    }
-
-    async function injectTumblrText(req: InjectRequest): Promise<InjectResponse> {
-      const found = findEl(req.selector);
-      if (!found) {
-        return { source: RES_TAG, id: req.id, ok: false, error: 'Tumblr text target not found' };
-      }
-      const originalText = req.text ?? '';
-      const text = mergeStandaloneUrlParagraphs(originalText);
-      const expectedUrls = extractHttpUrls(originalText);
-      const blocks = findTumblrBodyBlocks(req.selector, { anchor: found.el });
-      const target = blocks[0] ?? found.el;
-      console.log(`[Tutti inject-helper] Tumblr text target matched "${found.matchedPart}" (${blocks.length} body blocks)`);
-
-      for (const block of blocks) {
-        await clearEditableBlock(block);
-      }
-      target.focus();
-
-      if (text) {
-        const dt = new DataTransfer();
-        dt.setData('text/plain', text);
-        target.dispatchEvent(new ClipboardEvent('paste', {
-          bubbles: true,
-          cancelable: true,
-          clipboardData: dt,
-        }));
-        const expectedSnippet = text.slice(0, Math.min(20, text.length)).trim();
-        const pasted = await waitFor(
-          () => readTumblrBodyTextFromBlocks(findTumblrBodyBlocks(req.selector, { anchor: target })).includes(expectedSnippet),
-          700,
-        );
-        if (!pasted) {
-          target.textContent = text;
-          target.dispatchEvent(new InputEvent('input', {
-            bubbles: true,
-            data: text,
-            inputType: 'insertText',
-          }));
-          await new Promise((r) => setTimeout(r, 100));
-        }
-      }
-
-      let afterBlocks = findTumblrBodyBlocks(req.selector, { anchor: target });
-      let bodyText = readTumblrBodyTextFromBlocks(afterBlocks);
-      let validation = validateTumblrBodyText(bodyText, text, {
-        allowHashtagStripped: true,
-      });
-      if (!validation.ok && expectedUrls.length > 0) {
-        console.warn(`[Tutti inject-helper] Tumblr paste validation failed with URL text; retrying plain insert (${validation.error ?? 'unknown'})`);
-        await insertTumblrPlainText(req.selector, target, text);
-        afterBlocks = findTumblrBodyBlocks(req.selector, { anchor: target });
-        bodyText = readTumblrBodyTextFromBlocks(afterBlocks);
-        validation = validateTumblrBodyText(bodyText, text, {
-          allowHashtagStripped: true,
-        });
-      }
-      return {
-        source: RES_TAG,
-        id: req.id,
-        ok: validation.ok,
-        error: validation.error,
-      };
-    }
-
     async function readLatestXPostUrl(req: InjectRequest): Promise<InjectResponse> {
       let captured = window.__tuttiXLatestPostId;
       try {
@@ -1070,7 +938,7 @@ export default defineContentScript({
       input: mediaCommandHandlers.input,
       drop: mediaCommandHandlers.drop,
       text: injectText,
-      'tumblr-text': injectTumblrText,
+      'tumblr-text': (request) => handleTumblrTextCommand(request, RES_TAG),
       'tag-list': (request) => handleTagListCommand(request, RES_TAG),
       click: (request) => handleClickCommand(request, RES_TAG),
       'x-post-url': readLatestXPostUrl,

--- a/src/entrypoint-architecture.test.ts
+++ b/src/entrypoint-architecture.test.ts
@@ -161,6 +161,15 @@ describe('entrypoint architecture guard', () => {
     expect(entrypoint).toContain('injectContentEditableText(');
     expect(entrypoint).not.toContain("Object.getOwnPropertyDescriptor(proto, 'value')");
   });
+
+  it('keeps Tumblr block-editor mechanics in its page-world driver', () => {
+    const entrypoint = readFileSync('entrypoints/inject-helper.content.ts', 'utf8');
+
+    expect(entrypoint).toContain('handleTumblrTextCommand(request, RES_TAG)');
+    expect(entrypoint).not.toMatch(
+      /\bfunction (?:injectTumblrText|insertTumblrPlainText|clearEditableBlock)\b/,
+    );
+  });
 });
 
 function categorize(path: string): EntrypointCategory {

--- a/src/page-world/tumblr-editor-driver.test.ts
+++ b/src/page-world/tumblr-editor-driver.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleTumblrTextCommand } from './tumblr-editor-driver';
+
+const SOURCE = 'tutti-inject-res-v1';
+
+function installEditor(): HTMLElement {
+  document.body.innerHTML = `
+    <div role="dialog">
+      <div data-testid="gutenberg-editor">
+        <p class="body" contenteditable="true"></p>
+      </div>
+    </div>
+  `;
+  return document.querySelector<HTMLElement>('.body')!;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('Tumblr block editor driver', () => {
+  it('returns the existing missing-target error', async () => {
+    await expect(handleTumblrTextCommand({
+      id: 'missing',
+      selector: '.body',
+      text: 'hello',
+    }, SOURCE)).resolves.toEqual({
+      source: SOURCE,
+      id: 'missing',
+      ok: false,
+      error: 'Tumblr text target not found',
+    });
+  });
+
+  it('accepts text inserted by the paste handler', async () => {
+    const editor = installEditor();
+    editor.addEventListener('paste', (event) => {
+      editor.textContent = (event as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+
+    const result = await handleTumblrTextCommand({
+      id: 'paste',
+      selector: '.body',
+      text: 'hello Tumblr #tutti',
+    }, SOURCE);
+
+    expect(result).toEqual({ source: SOURCE, id: 'paste', ok: true, error: undefined });
+    expect(editor.textContent).toBe('hello Tumblr #tutti');
+  });
+
+  it('accepts Tumblr moving hashtags out of the body', async () => {
+    const editor = installEditor();
+    editor.addEventListener('paste', () => {
+      editor.textContent = 'hello Tumblr';
+    });
+
+    const result = await handleTumblrTextCommand({
+      id: 'tags',
+      selector: '.body',
+      text: 'hello Tumblr #tutti',
+    }, SOURCE);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('falls back to plain insertion when URL paste validation fails', async () => {
+    const editor = installEditor();
+    const inputs: string[] = [];
+    editor.addEventListener('paste', () => {
+      editor.textContent = 'generated link preview';
+    });
+    editor.addEventListener('input', (event) => {
+      inputs.push((event as InputEvent).inputType);
+    });
+
+    const result = await handleTumblrTextCommand({
+      id: 'url',
+      selector: '.body',
+      text: 'Read this\n\nhttps://tutti.komm64.com/',
+    }, SOURCE);
+
+    expect(result.ok).toBe(true);
+    expect(editor.textContent).toContain('https://tutti.komm64.com/');
+    expect(inputs).toContain('insertText');
+  });
+});

--- a/src/page-world/tumblr-editor-driver.ts
+++ b/src/page-world/tumblr-editor-driver.ts
@@ -1,0 +1,180 @@
+import {
+  findTumblrBodyBlocks,
+  readTumblrBodyTextFromBlocks,
+} from '../utils/tumblr-editor';
+import { validateTumblrBodyText } from '../utils/tumblr-text';
+import { extractHttpUrls, mergeStandaloneUrlParagraphs } from '../utils/text-urls';
+import { findElementBySelectorList } from './element-commands';
+
+export interface TumblrTextCommandRequest {
+  id: string;
+  selector: string;
+  text?: string;
+}
+
+export interface TumblrTextCommandResponse<Source extends string> {
+  source: Source;
+  id: string;
+  ok: boolean;
+  error?: string;
+}
+
+export async function handleTumblrTextCommand<Source extends string>(
+  request: TumblrTextCommandRequest,
+  source: Source,
+): Promise<TumblrTextCommandResponse<Source>> {
+  const found = findElementBySelectorList(request.selector);
+  if (!found) {
+    return { source, id: request.id, ok: false, error: 'Tumblr text target not found' };
+  }
+  const originalText = request.text ?? '';
+  const text = mergeStandaloneUrlParagraphs(originalText);
+  const expectedUrls = extractHttpUrls(originalText);
+  const blocks = findTumblrBodyBlocks(request.selector, { anchor: found.el });
+  const target = blocks[0] ?? found.el;
+  console.log(
+    `[Tutti inject-helper] Tumblr text target matched ` +
+    `"${found.matchedPart}" (${blocks.length} body blocks)`,
+  );
+
+  for (const block of blocks) {
+    await clearEditableBlock(block);
+  }
+  target.focus();
+
+  if (text) {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', text);
+    target.dispatchEvent(new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: dataTransfer,
+    }));
+    const expectedSnippet = text.slice(0, Math.min(20, text.length)).trim();
+    const pasted = await waitFor(
+      () => readTumblrBodyTextFromBlocks(
+        findTumblrBodyBlocks(request.selector, { anchor: target }),
+      ).includes(expectedSnippet),
+      700,
+    );
+    if (!pasted) {
+      target.textContent = text;
+      target.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        data: text,
+        inputType: 'insertText',
+      }));
+      await sleep(100);
+    }
+  }
+
+  let afterBlocks = findTumblrBodyBlocks(request.selector, { anchor: target });
+  let bodyText = readTumblrBodyTextFromBlocks(afterBlocks);
+  let validation = validateTumblrBodyText(bodyText, text, {
+    allowHashtagStripped: true,
+  });
+  if (!validation.ok && expectedUrls.length > 0) {
+    console.warn(
+      `[Tutti inject-helper] Tumblr paste validation failed with URL text; ` +
+      `retrying plain insert (${validation.error ?? 'unknown'})`,
+    );
+    await insertTumblrPlainText(request.selector, target, text);
+    afterBlocks = findTumblrBodyBlocks(request.selector, { anchor: target });
+    bodyText = readTumblrBodyTextFromBlocks(afterBlocks);
+    validation = validateTumblrBodyText(bodyText, text, {
+      allowHashtagStripped: true,
+    });
+  }
+  return {
+    source,
+    id: request.id,
+    ok: validation.ok,
+    error: validation.error,
+  };
+}
+
+async function clearEditableBlock(element: HTMLElement): Promise<void> {
+  element.focus();
+  const selection = window.getSelection();
+  if (selection) {
+    try {
+      selection.removeAllRanges();
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      selection.addRange(range);
+    } catch { /* ignore */ }
+  }
+  try {
+    document.execCommand('delete', false);
+  } catch { /* fallback below */ }
+  if ((element.textContent ?? '').trim().length > 0) {
+    element.textContent = '';
+    element.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'deleteContentBackward',
+    }));
+  }
+  await sleep(50);
+}
+
+async function insertTumblrPlainText(
+  selector: string,
+  anchor: HTMLElement,
+  text: string,
+): Promise<void> {
+  const blocks = findTumblrBodyBlocks(selector, { anchor });
+  for (const block of blocks) {
+    await clearEditableBlock(block);
+  }
+  const target = blocks[0] ?? anchor;
+  target.focus();
+  const selection = window.getSelection();
+  if (selection) {
+    try {
+      selection.removeAllRanges();
+      const range = document.createRange();
+      range.selectNodeContents(target);
+      selection.addRange(range);
+    } catch { /* ignore */ }
+  }
+  target.dispatchEvent(new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    inputType: 'insertText',
+    data: text,
+  }));
+  let inserted = false;
+  try {
+    inserted = document.execCommand('insertText', false, text);
+  } catch { /* fallback below */ }
+  const expectedSnippet = text.slice(0, Math.min(20, text.length)).trim();
+  const visible = () => readTumblrBodyTextFromBlocks(
+    findTumblrBodyBlocks(selector, { anchor: target }),
+  );
+  if (!inserted || (expectedSnippet && !visible().includes(expectedSnippet))) {
+    target.textContent = text;
+  }
+  target.dispatchEvent(new InputEvent('input', {
+    bubbles: true,
+    data: text,
+    inputType: 'insertText',
+  }));
+  target.dispatchEvent(new KeyboardEvent('keyup', {
+    bubbles: true,
+    key: text.slice(-1) || 'a',
+  }));
+  await sleep(250);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(50);
+  }
+  return false;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Depends on #101.

Closes #102.

## Summary
- move Tumblr Gutenberg block discovery, clearing, paste, and URL fallback out of the MAIN-world entrypoint
- preserve existing Tumblr validation and hashtag behavior behind a typed command boundary
- add DOM contract tests and an architecture guard

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] rebase onto merged dependencies
- [ ] build the final exact artifact
- [ ] pass affected Surface real-browser cases on that artifact before merge