### PR TITLE
refactor: unify content-flow finalization

### DIFF
--- a/src/utils/flow-architecture.test.ts
+++ b/src/utils/flow-architecture.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('content flow architecture', () => {
+  it('keeps submit finalization shared by simple and multi-step flows', () => {
+    const postFlow = readFileSync('src/utils/post-flow.ts', 'utf8');
+    const stepRunner = readFileSync('src/utils/step-runner.ts', 'utf8');
+
+    for (const source of [postFlow, stepRunner]) {
+      expect(source).toContain("from './flow-finalization'");
+      expect(source).toContain('waitForSubmitButton(');
+      expect(source).toContain('highlightPreviewButton(');
+      expect(source).toContain('finalizeFlow(');
+      expect(source).not.toMatch(/\bmarkPostSubmissionStarted\b/);
+    }
+    expect(postFlow).not.toMatch(/\bfunction maybeConfirmDialog\b/);
+    expect(stepRunner).not.toContain("from './post-flow'");
+  });
+});

--- a/src/utils/flow-finalization.test.ts
+++ b/src/utils/flow-finalization.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  finalizeFlow,
+  findFlowButton,
+  highlightPreviewButton,
+  maybeConfirmDialog,
+  waitForSubmitButton,
+} from './flow-finalization';
+
+function button(options: {
+  disabled?: boolean;
+  label?: string;
+  onClick?: () => void;
+} = {}): HTMLElement {
+  return {
+    textContent: options.label ?? '',
+    getAttribute: vi.fn(() => null),
+    disabled: options.disabled ?? false,
+    click: options.onClick ?? vi.fn(),
+    style: { outline: '' },
+  } as unknown as HTMLElement;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('flow button resolution', () => {
+  it('preserves finder, selector-list, then text priority', () => {
+    const finderButton = button();
+    const selectorButton = button();
+    vi.stubGlobal('document', {
+      querySelector: vi.fn(() => selectorButton),
+      querySelectorAll: vi.fn(() => [selectorButton]),
+    });
+
+    expect(findFlowButton({
+      finder: () => finderButton,
+      selector: '.submit',
+      texts: ['Post'],
+    })).toBe(finderButton);
+  });
+
+  it('can choose an enabled later selector match while retaining the first fallback', () => {
+    const disabledButton = button({ disabled: true });
+    const enabledButton = button();
+    vi.stubGlobal('document', {
+      querySelectorAll: vi.fn((selector: string) => (
+        selector === '.primary' ? [disabledButton] : [enabledButton]
+      )),
+    });
+
+    expect(findFlowButton({
+      selector: '.primary, .secondary',
+    }, {
+      preferEnabledSelectorMatch: true,
+    })).toBe(enabledButton);
+  });
+
+  it('returns the last disabled candidate when submit waiting times out', async () => {
+    const disabledButton = button({ disabled: true });
+
+    const result = await waitForSubmitButton({
+      finder: () => disabledButton,
+    }, 10);
+
+    expect(result).toEqual({
+      button: null,
+      lastFound: disabledButton,
+    });
+  });
+});
+
+describe('flow finalization', () => {
+  it('highlights previews without clicking and restores the outline', async () => {
+    vi.useFakeTimers();
+    const previewButton = button();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    highlightPreviewButton(previewButton, 'preview');
+    expect(previewButton.style.outline).toBe('3px dashed #f59e0b');
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(previewButton.style.outline).toBe('');
+  });
+
+  it('runs custom click, confirmation, and post-processing in order', async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const submitButton = button();
+    const confirmButton = button({
+      label: 'Post anyway',
+      onClick: () => events.push('confirm'),
+    });
+    const dialog = {
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => [confirmButton]),
+    } as unknown as HTMLElement;
+    vi.stubGlobal('document', {
+      querySelectorAll: vi.fn((selector: string) => (
+        selector === '[role="dialog"]' ? [dialog] : []
+      )),
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = finalizeFlow({
+      button: submitButton,
+      click: () => {
+        events.push('submit');
+      },
+      confirmDialogButtonTexts: ['Post anyway'],
+      confirmDialogGraceMs: 10,
+      afterClickDelayMs: 25,
+    });
+    await vi.runAllTimersAsync();
+    await result;
+
+    expect(events).toEqual(['submit', 'confirm']);
+  });
+});
+
+describe('confirmation dialog compatibility', () => {
+  it('ignores existing compose dialogs and excludes the clicked submit button', async () => {
+    const submitButton = button({ label: 'Post' });
+    const confirmButton = button({ label: 'Post without tags' });
+    const composeDialog = {
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => [submitButton]),
+    } as unknown as HTMLElement;
+    const confirmDialog = {
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => [confirmButton]),
+    } as unknown as HTMLElement;
+    vi.stubGlobal('document', {
+      body: {},
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn((selector: string) => (
+        selector === '[role="dialog"]' ? [composeDialog, confirmDialog] : []
+      )),
+    });
+    vi.stubGlobal('MutationObserver', undefined);
+
+    await expect(maybeConfirmDialog(['Post without tags'], 10, {
+      ignoredDialogs: [composeDialog],
+      excludedButtons: [submitButton],
+    })).resolves.toBe(true);
+
+    expect(confirmButton.click).toHaveBeenCalledOnce();
+    expect(submitButton.click).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/flow-finalization.ts
+++ b/src/utils/flow-finalization.ts
@@ -1,0 +1,217 @@
+import {
+  elementTextMatches,
+  findClickableByText,
+  sleep,
+  waitForCondition,
+} from './dom';
+import {
+  markPostStepCompleted,
+  markPostStepFailed,
+  markPostStepStarted,
+  markPostSubmissionStarted,
+} from './post-submission-state';
+
+const CONFIRM_DIALOG_SELECTORS = [
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '.modal-root__container',
+  '.components-modal__frame',
+  'ytcp-dialog',
+  'tp-yt-paper-dialog',
+];
+
+export interface FlowButtonSpec {
+  selector?: string;
+  texts?: string[];
+  finder?: () => HTMLElement | null;
+}
+
+export interface FindFlowButtonOptions {
+  preferEnabledSelectorMatch?: boolean;
+}
+
+export interface WaitForSubmitButtonOptions extends FindFlowButtonOptions {
+  allowDisabled?: boolean;
+  intervalMs?: number;
+}
+
+export interface SubmitButtonResolution {
+  button: HTMLElement | null;
+  lastFound: HTMLElement | null;
+}
+
+export interface ConfirmDialogOptions {
+  ignoredDialogs?: readonly HTMLElement[];
+  excludedButtons?: readonly HTMLElement[];
+  composeInputSelector?: string;
+}
+
+export interface FinalizeFlowOptions {
+  button: HTMLElement;
+  click?: () => Promise<void> | void;
+  confirmDialogButtonTexts?: string[];
+  confirmDialogGraceMs?: number;
+  confirmDialogOptions?: ConfirmDialogOptions;
+  afterClickDelayMs?: number;
+}
+
+export function isFlowButtonDisabled(button: HTMLElement): boolean {
+  return button.getAttribute('aria-disabled') === 'true' ||
+    (button as HTMLButtonElement).disabled;
+}
+
+export function findFlowButton(
+  spec: FlowButtonSpec,
+  options: FindFlowButtonOptions = {},
+): HTMLElement | null {
+  if (spec.finder) return spec.finder();
+  if (spec.selector) {
+    let firstSelectorMatch: HTMLElement | null = null;
+    for (const part of splitSelectorList(spec.selector)) {
+      const matches = options.preferEnabledSelectorMatch
+        ? document.querySelectorAll<HTMLElement>(part)
+        : [document.querySelector<HTMLElement>(part)].filter(
+          (element): element is HTMLElement => element !== null,
+        );
+      for (const element of matches) {
+        firstSelectorMatch ??= element;
+        if (
+          !options.preferEnabledSelectorMatch ||
+          !isFlowButtonDisabled(element)
+        ) {
+          return element;
+        }
+      }
+    }
+    if (firstSelectorMatch) return firstSelectorMatch;
+  }
+  if (spec.texts && spec.texts.length > 0) {
+    return findClickableByText(spec.texts);
+  }
+  return null;
+}
+
+export async function waitForSubmitButton(
+  spec: FlowButtonSpec,
+  timeoutMs: number,
+  options: WaitForSubmitButtonOptions = {},
+): Promise<SubmitButtonResolution> {
+  markPostStepStarted('wait-submit');
+  let lastFound: HTMLElement | null = null;
+  const button = await waitForCondition<HTMLElement>(() => {
+    const candidate = findFlowButton(spec, options);
+    if (!candidate) return null;
+    lastFound = candidate;
+    if (!isFlowButtonDisabled(candidate) || options.allowDisabled) {
+      return candidate;
+    }
+    return null;
+  }, {
+    timeoutMs,
+    intervalMs: options.intervalMs ?? 150,
+  });
+  if (button) {
+    markPostStepCompleted('wait-submit');
+  } else {
+    markPostStepFailed('wait-submit');
+  }
+  return { button, lastFound };
+}
+
+export function highlightPreviewButton(button: HTMLElement, message: string): void {
+  console.log(message, button);
+  const originalOutline = button.style.outline;
+  button.style.outline = '3px dashed #f59e0b';
+  setTimeout(() => {
+    button.style.outline = originalOutline;
+  }, 5000);
+}
+
+export async function finalizeFlow(options: FinalizeFlowOptions): Promise<void> {
+  markPostSubmissionStarted();
+  if (options.click) {
+    await options.click();
+  } else {
+    options.button.click();
+  }
+
+  if (
+    options.confirmDialogButtonTexts &&
+    options.confirmDialogButtonTexts.length > 0
+  ) {
+    markPostStepStarted('complete-confirmation');
+    await maybeConfirmDialog(
+      options.confirmDialogButtonTexts,
+      options.confirmDialogGraceMs,
+      options.confirmDialogOptions,
+    );
+    markPostStepCompleted('complete-confirmation');
+  }
+
+  markPostStepStarted('post-processing');
+  await sleep(options.afterClickDelayMs ?? 250);
+  markPostStepCompleted('post-processing');
+}
+
+export async function maybeConfirmDialog(
+  texts: string[],
+  graceMs = 800,
+  options: ConfirmDialogOptions = {},
+): Promise<boolean> {
+  const start = Date.now();
+  const ignoredDialogs = new Set(options.ignoredDialogs ?? []);
+  const excludedButtons = new Set(options.excludedButtons ?? []);
+  let lastSeenDialog: HTMLElement | null = null;
+  let lastSeenButtonTexts: string[] = [];
+  const confirmed = await waitForCondition<boolean>(() => {
+    for (const dialog of collectConfirmDialogs()) {
+      if (ignoredDialogs.has(dialog)) continue;
+      if (
+        options.composeInputSelector &&
+        dialog.querySelector(options.composeInputSelector)
+      ) {
+        continue;
+      }
+      lastSeenDialog = dialog;
+      const buttons = Array.from(
+        dialog.querySelectorAll<HTMLButtonElement>(
+          'button, ytcp-button[role="button"], [role="button"]',
+        ),
+      ).filter((button) => !excludedButtons.has(button));
+      lastSeenButtonTexts = buttons
+        .map((button) => (button.textContent ?? '').trim())
+        .filter((text) => text.length > 0);
+      for (const wanted of texts) {
+        const target = buttons.find((button) => elementTextMatches(button, [wanted]));
+        if (target && !target.disabled) {
+          console.log(`[Tutti] confirm dialog: clicking "${wanted}"`);
+          target.click();
+          return true;
+        }
+      }
+    }
+    if (!lastSeenDialog && Date.now() - start >= graceMs) return true;
+    return null;
+  }, { timeoutMs: 8000, intervalMs: 150 });
+
+  if (lastSeenDialog && lastSeenButtonTexts.length > 0) {
+    console.warn(
+      `[Tutti] confirm dialog detected but no button matched. ` +
+      `Tried: [${texts.join(', ')}]. ` +
+      `Saw: [${lastSeenButtonTexts.join(', ')}]`,
+    );
+  }
+  return confirmed === true;
+}
+
+export function collectConfirmDialogs(): HTMLElement[] {
+  const dialogs: HTMLElement[] = [];
+  for (const selector of CONFIRM_DIALOG_SELECTORS) {
+    dialogs.push(...Array.from(document.querySelectorAll<HTMLElement>(selector)));
+  }
+  return dialogs.filter((dialog, index, all) => all.indexOf(dialog) === index);
+}
+
+function splitSelectorList(selector: string): string[] {
+  return selector.split(',').map((part) => part.trim()).filter(Boolean);
+}

--- a/src/utils/post-flow.ts
+++ b/src/utils/post-flow.ts
@@ -1,40 +1,30 @@
 import type { ImageAttachment } from '../messages';
 import {
-  elementTextMatches,
-  findClickableByText,
   sleep,
   waitForCondition,
   waitForElement,
 } from './dom';
+import {
+  collectConfirmDialogs,
+  finalizeFlow,
+  findFlowButton,
+  highlightPreviewButton,
+  isFlowButtonDisabled,
+  waitForSubmitButton,
+} from './flow-finalization';
 import { dropImages, injectImages, injectTextIntoElement } from './image';
 import { t } from './i18n';
 import {
   markPostStepCompleted,
   markPostStepStarted,
-  markPostSubmissionStarted,
 } from './post-submission-state';
 
 const VIDEO_POST_BUTTON_TIMEOUT_MS = 120_000;
-const CONFIRM_DIALOG_SELECTORS = [
-  '[role="dialog"]',
-  '[role="alertdialog"]',
-  '.modal-root__container', // Mastodon
-  '.components-modal__frame', // Gutenberg / Tumblr
-  'ytcp-dialog', // YouTube Studio custom dialog (role="dialog" も付くが念のため)
-  'tp-yt-paper-dialog', // YouTube Studio polymer dialog
-];
 
-export interface ConfirmDialogOptions {
-  /**
-   * Compose 本体も role=dialog の SNS があるため、post click 前から存在していた
-   * dialog は確認 dialog として扱わない。
-   */
-  ignoredDialogs?: readonly HTMLElement[];
-  /** click した元の submit button を confirmation 候補から除外する。 */
-  excludedButtons?: readonly HTMLElement[];
-  /** Compose 本体 dialog を除外するための入力欄 selector。 */
-  composeInputSelector?: string;
-}
+export {
+  maybeConfirmDialog,
+  type ConfirmDialogOptions,
+} from './flow-finalization';
 
 export interface PostFlowOptions {
   /** URL pre-fill 方式なら true、DOM injection が必要なら false */
@@ -217,21 +207,13 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
     if (prefillsViaUrl && !sawComposeInput) {
       sawComposeInput = !!findComposeInput(textareaSelector);
     }
-    if (postButtonFinder) return postButtonFinder();
-    if (postButtonSelector) {
-      let firstSelectorMatch: HTMLElement | null = null;
-      for (const part of postButtonSelector.split(',').map((s) => s.trim()).filter(Boolean)) {
-        for (const el of document.querySelectorAll<HTMLElement>(part)) {
-          firstSelectorMatch ??= el;
-          if (!isDisabled(el)) return el;
-        }
-      }
-      if (firstSelectorMatch) return firstSelectorMatch;
-    }
-    if (postButtonTexts && postButtonTexts.length > 0) {
-      return findClickableByText(postButtonTexts);
-    }
-    return null;
+    return findFlowButton({
+      finder: postButtonFinder,
+      selector: postButtonSelector,
+      texts: postButtonTexts,
+    }, {
+      preferEnabledSelectorMatch: true,
+    });
   };
 
   // ボタンの「存在 + enabled」を **両方満たす** まで loop で待つ。
@@ -241,24 +223,16 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
   // 動画ありの場合は upload 完了に時間が掛かるので timeout を多めに延長
   // (caller が postButtonTimeoutMs に明示値を渡していなければ default 15s、
   //  動画 attachment があれば 120s に bump)。
-  const isDisabled = (b: HTMLElement) =>
-    b.getAttribute('aria-disabled') === 'true' || (b as HTMLButtonElement).disabled;
   const hasVideo = (images ?? []).some((m) => m.type.startsWith('video/'));
   const effectiveTimeoutMs = resolvePostButtonTimeoutMs(postButtonTimeoutMs, hasVideo);
   const acceptsDisabledPreviewButton = dryRun && allowDisabledPostButtonInPreview === true;
 
-  markPostStepStarted('wait-submit');
-  let lastFound: HTMLElement | null = null;
-  const button = await waitForCondition<HTMLElement>(() => {
-    const candidate = findButton();
-    if (candidate) {
-      lastFound = candidate;
-      if (!isDisabled(candidate) || acceptsDisabledPreviewButton) {
-        return candidate;
-      }
-    }
-    return null;
-  }, { timeoutMs: effectiveTimeoutMs, intervalMs: 300 });
+  const { button, lastFound } = await waitForSubmitButton({
+    finder: findButton,
+  }, effectiveTimeoutMs, {
+    allowDisabled: acceptsDisabledPreviewButton,
+    intervalMs: 300,
+  });
   if (!button) {
     if (!lastFound) {
       if (prefillsViaUrl && textareaSelector && !sawComposeInput) {
@@ -272,36 +246,31 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
       t('runtimePostButtonDisabled'),
     );
   }
-  markPostStepCompleted('wait-submit');
 
   if (dryRun) {
-    const disabledNote = isDisabled(button) ? ' (disabled accepted for preview)' : ' and enabled';
-    console.log(`[Tutti] dry-run: post button found${disabledNote}, skipping click`, button);
-    // 視覚的にハイライトして検証しやすく
-    const orig = button.style.outline;
-    button.style.outline = '3px dashed #f59e0b';
-    setTimeout(() => { button!.style.outline = orig; }, 5000);
+    const disabledNote = isFlowButtonDisabled(button)
+      ? ' (disabled accepted for preview)'
+      : ' and enabled';
+    highlightPreviewButton(
+      button,
+      `[Tutti] dry-run: post button found${disabledNote}, skipping click`,
+    );
     return;
   }
 
   const preClickDialogs = collectConfirmDialogs();
-  markPostSubmissionStarted();
-  if (clickPostButton) await clickPostButton();
-  else button.click();
-
-  if (confirmDialogButtonTexts && confirmDialogButtonTexts.length > 0) {
-    markPostStepStarted('complete-confirmation');
-    await maybeConfirmDialog(confirmDialogButtonTexts, confirmDialogGraceMs, {
+  await finalizeFlow({
+    button,
+    click: clickPostButton,
+    confirmDialogButtonTexts,
+    confirmDialogGraceMs,
+    confirmDialogOptions: {
       ignoredDialogs: preClickDialogs,
       excludedButtons: [button],
       composeInputSelector: textareaSelector,
-    });
-    markPostStepCompleted('complete-confirmation');
-  }
-
-  markPostStepStarted('post-processing');
-  await sleep(afterClickDelayMs);
-  markPostStepCompleted('post-processing');
+    },
+    afterClickDelayMs,
+  });
 }
 
 async function attachMedia(
@@ -364,67 +333,4 @@ export function resolvePostButtonTimeoutMs(postButtonTimeoutMs: number, hasVideo
 
 function findComposeInput(selector: string | undefined): HTMLElement | null {
   return selector ? document.querySelector<HTMLElement>(selector) : null;
-}
-
-/**
- * 投稿ボタン押下後に出る確認ダイアログのボタンを自動クリックする。
- * モーダル系の標準的なコンテナ内に限って探索する(本体の "Post" 等と被らないように)。
- * v0.5.11〜 deadline は 8s に延長 (YouTube の "still checking" dialog が出るまで
- *   server-side validation の round trip があり、 3s では取りこぼすケースを確認)。
- *
- * step-runner.ts の finalize からも再利用するため export してある。
- */
-export async function maybeConfirmDialog(
-  texts: string[],
-  graceMs = 800,
-  options: ConfirmDialogOptions = {},
-): Promise<boolean> {
-  const start = Date.now();
-  const ignoredDialogs = new Set(options.ignoredDialogs ?? []);
-  const excludedButtons = new Set(options.excludedButtons ?? []);
-  let lastSeenDialog: HTMLElement | null = null;
-  let lastSeenButtonTexts: string[] = [];
-  const confirmed = await waitForCondition<boolean>(() => {
-    for (const dialog of collectConfirmDialogs()) {
-      if (ignoredDialogs.has(dialog)) continue;
-      if (options.composeInputSelector && dialog.querySelector(options.composeInputSelector)) continue;
-      lastSeenDialog = dialog;
-      // ダイアログ内の button のうち、テキストが完全一致するもの(部分一致だと "Post anyway" が "Post" に弾かれる)
-      const buttons = (Array.from(
-        dialog.querySelectorAll<HTMLButtonElement>('button, ytcp-button[role="button"], [role="button"]'),
-      ) as HTMLElement[]).filter((button) => !excludedButtons.has(button));
-      lastSeenButtonTexts = buttons.map((b) => (b.textContent ?? '').trim()).filter((t) => t.length > 0);
-      for (const wanted of texts) {
-        const target = buttons.find((b) => elementTextMatches(b, [wanted]));
-        if (target && !(target as HTMLButtonElement).disabled) {
-          console.log(`[Tutti] confirm dialog: clicking "${wanted}"`);
-          target.click();
-          return true;
-        }
-      }
-    }
-    // 通常ケースでは確認 dialog は出ない。短い grace 後に先へ進み、
-    // dialog を一度でも見た場合だけ disabled → enabled の変化を最大 8s 待つ。
-    if (!lastSeenDialog && Date.now() - start >= graceMs) return true;
-    return null;
-  }, { timeoutMs: 8000, intervalMs: 150 });
-  // dialog が居て texts が全部空振りした場合: auto-triage の手掛かりとして
-  // 観測した button text を warn log に残す (CWS / users 側で再現したときに
-  // diagnostics で button text が分かるようになる)
-  if (lastSeenDialog && lastSeenButtonTexts.length > 0) {
-    console.warn(
-      `[Tutti] confirm dialog detected but no button matched. ` +
-      `Tried: [${texts.join(', ')}]. ` +
-      `Saw: [${lastSeenButtonTexts.join(', ')}]`,
-    );
-  }
-  return confirmed === true;
-}
-
-function collectConfirmDialogs(): HTMLElement[] {
-  const dialogs: HTMLElement[] = [];
-  for (const sel of CONFIRM_DIALOG_SELECTORS) {
-    dialogs.push(...Array.from(document.querySelectorAll<HTMLElement>(sel)));
-  }
-  return dialogs.filter((dialog, index, all) => all.indexOf(dialog) === index);
 }

--- a/src/utils/step-runner.ts
+++ b/src/utils/step-runner.ts
@@ -28,14 +28,19 @@
  *   - selector / texts / finder の優先順序は executePostFlow と同じ (finder > selector > texts)。
  *   - 単体テストは「dry-run で全 step が走り finalize は click されない」を最低限カバー。
  */
-import { findClickableByText, sleep, waitForCondition, waitForElement } from './dom';
-import { maybeConfirmDialog } from './post-flow';
+import { sleep, waitForCondition, waitForElement } from './dom';
+import {
+  finalizeFlow,
+  findFlowButton,
+  highlightPreviewButton,
+  isFlowButtonDisabled,
+  waitForSubmitButton,
+} from './flow-finalization';
 import { t } from './i18n';
 import {
   markPostStepCompleted,
   markPostStepFailed,
   markPostStepStarted,
-  markPostSubmissionStarted,
 } from './post-submission-state';
 
 /**
@@ -172,41 +177,31 @@ export async function executeMultiStepFlow(options: MultiStepFlowOptions): Promi
     }
   }
 
-  markPostStepStarted('wait-submit');
-  let finalizeBtn = await waitForStepButton(finalize, finalize.timeoutMs ?? 8000);
-  if (!finalizeBtn && dryRun && finalize.allowDisabledInPreview === true) {
-    const candidate = findStepButton(finalize);
-    if (candidate) {
-      finalizeBtn = candidate;
-      console.log('[Tutti] dry-run: disabled finalize button found, skipping click', finalizeBtn);
-    }
-  }
+  const { button: finalizeBtn } = await waitForSubmitButton(
+    finalize,
+    finalize.timeoutMs ?? 8000,
+    {
+      allowDisabled: dryRun && finalize.allowDisabledInPreview === true,
+    },
+  );
   if (!finalizeBtn) {
-    markPostStepFailed('wait-submit');
     throw new Error(t('runtimeFinalPostButtonMissing'));
   }
-  markPostStepCompleted('wait-submit');
 
   if (dryRun) {
-    console.log('[Tutti] dry-run: finalize button found and enabled, skipping click', finalizeBtn);
-    const orig = finalizeBtn.style.outline;
-    finalizeBtn.style.outline = '3px dashed #f59e0b';
-    setTimeout(() => { finalizeBtn.style.outline = orig; }, 5000);
+    const message = isFlowButtonDisabled(finalizeBtn)
+      ? '[Tutti] dry-run: disabled finalize button found, skipping click'
+      : '[Tutti] dry-run: finalize button found and enabled, skipping click';
+    highlightPreviewButton(finalizeBtn, message);
     return;
   }
 
-  markPostSubmissionStarted();
-  finalizeBtn.click();
-
-  if (finalize.confirmDialogButtonTexts && finalize.confirmDialogButtonTexts.length > 0) {
-    markPostStepStarted('complete-confirmation');
-    await maybeConfirmDialog(finalize.confirmDialogButtonTexts, finalize.confirmDialogGraceMs);
-    markPostStepCompleted('complete-confirmation');
-  }
-
-  markPostStepStarted('post-processing');
-  await sleep(finalize.afterClickDelayMs ?? 250);
-  markPostStepCompleted('post-processing');
+  await finalizeFlow({
+    button: finalizeBtn,
+    confirmDialogButtonTexts: finalize.confirmDialogButtonTexts,
+    confirmDialogGraceMs: finalize.confirmDialogGraceMs,
+    afterClickDelayMs: finalize.afterClickDelayMs,
+  });
 }
 
 /**
@@ -233,17 +228,7 @@ function dumpVisibleDialogButtons(): string {
  * step 内 action から advance を手動でトリガーしたい場合にも使える。
  */
 export function findStepButton(opts: AdvanceSpec): HTMLElement | null {
-  if (opts.finder) return opts.finder();
-  if (opts.selector) {
-    for (const part of opts.selector.split(',').map((s) => s.trim()).filter(Boolean)) {
-      const el = document.querySelector<HTMLElement>(part);
-      if (el) return el;
-    }
-  }
-  if (opts.texts && opts.texts.length > 0) {
-    return findClickableByText(opts.texts);
-  }
-  return null;
+  return findFlowButton(opts);
 }
 
 /**
@@ -256,11 +241,7 @@ export async function waitForStepButton(
 ): Promise<HTMLElement | null> {
   return await waitForCondition<HTMLElement>(() => {
     const btn = findStepButton(opts);
-    if (
-      btn &&
-      btn.getAttribute('aria-disabled') !== 'true' &&
-      !(btn as HTMLButtonElement).disabled
-    ) {
+    if (btn && !isFlowButtonDisabled(btn)) {
       return btn;
     }
     return null;

--- a/vitest.architecture.config.ts
+++ b/vitest.architecture.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       'src/entrypoint-architecture.test.ts',
       'src/messages/messages-architecture.test.ts',
       'src/storage/storage-architecture.test.ts',
+      'src/utils/flow-architecture.test.ts',
       'src/utils/no-hardcoded-japanese.test.ts',
       'src/utils/selector-feed.test.ts',
     ],


### PR DESCRIPTION
Closes #104.
Parent: #12.

## Summary
- share submit-button lookup and enabled-state waiting between simple and wizard flows
- share preview highlighting, submission start, confirmation dialogs, post-processing delay, and trace transitions
- preserve the post-flow compatibility re-export and runner-specific errors
- guard both runners against reintroducing local finalization logic

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build
- simple and wizard smoke lanes PASS

## Release gate
- [ ] build the final exact artifact
- [ ] pass the full Surface preview matrix on that artifact before merge