### PR TITLE
refactor: centralize post result construction

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import {
@@ -77,6 +77,15 @@ describe('platform architecture guard', () => {
       violations,
       allowances: PLATFORM_LITERAL_ALLOWANCES,
     });
+  });
+
+  it('keeps post result construction out of the central poster', () => {
+    const poster = readFileSync('src/background/platform-poster.ts', 'utf8');
+
+    expect(poster).toContain("from './post-result-policy'");
+    expect(poster).not.toMatch(
+      /\bfunction (?:buildFinalChunkResult|unconfirmedPostResult|withFlow)\b/,
+    );
   });
 });
 

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -4,7 +4,6 @@ import { threadsAdapter } from '../adapters/threads';
 import type { PlatformAdapter } from '../adapters/types';
 import {
   buildVerifyExpectationForChunk,
-  buildFinalChunkResult,
   buildDomPostAttempts,
   getComposeUrlForMedia,
   isAmbiguousPostDispatchError,
@@ -127,32 +126,6 @@ describe('platform poster helpers', () => {
     expect(shouldReuseExistingTabForAttempt(adapter(), false, {
       reuseExistingTab: false,
     })).toBe(false);
-  });
-
-  it('preserves the final chunk flow trace on aggregated preview results', () => {
-    const result = buildFinalChunkResult('x', false, true, undefined, {
-      mode: 'preview',
-      attempt: 'default',
-      submitReached: false,
-      lastCompletedStep: 'wait-submit',
-    });
-
-    expect(result.flow).toMatchObject({
-      mode: 'preview',
-      attempt: 'default',
-      submitReached: false,
-      lastCompletedStep: 'wait-submit',
-    });
-  });
-
-  it('adds a fallback flow trace when a successful chunk omitted it', () => {
-    const result = buildFinalChunkResult('x', false, true);
-
-    expect(result.flow).toMatchObject({
-      mode: 'preview',
-      submitReached: false,
-      lastCompletedStep: 'preview-flow',
-    });
   });
 
   it('expects media only on the first chunk of a split post', () => {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -38,7 +38,13 @@ import {
 import { resolveAdapter } from './adapter-resolver';
 import { prepareMediaForPlatform } from './platform-media';
 import { maybeResizeImagesForPlatform } from './media-preprocess';
-import { downgradeHardVerifyFailures, toPreviewResult } from './post-result-policy';
+import {
+  buildFinalChunkResult,
+  downgradeHardVerifyFailures,
+  toPreviewResult,
+  unconfirmedPostResult,
+  withFlow,
+} from './post-result-policy';
 import type { OpenedTabRegistry } from './opened-tab-registry';
 import { retryTransientTabAction } from './tab-action-retry';
 import type { VerifyExpectation } from '../utils/post-verify';
@@ -655,30 +661,6 @@ export function shouldReuseExistingTabForAttempt(
   return dryRun && adapter.requiresForegroundTab !== true && !forceForeground;
 }
 
-export function buildFinalChunkResult(
-  platform: PlatformId,
-  autoPost: boolean,
-  allConfirmed: boolean,
-  postUrl?: string,
-  flow?: PostResultMessage['flow'],
-): PostResultMessage {
-  const mode = autoPost ? 'post' : 'preview';
-  const lastCompletedStep = flow?.lastCompletedStep ?? (autoPost ? 'post-flow' : 'preview-flow');
-  return {
-    type: 'POST_RESULT',
-    platform,
-    success: true,
-    confirmed: allConfirmed,
-    url: postUrl,
-    flow: {
-      ...flow,
-      mode: flow?.mode ?? mode,
-      submitReached: flow?.submitReached ?? autoPost,
-      lastCompletedStep,
-    },
-  };
-}
-
 async function attachVerifyResult(
   result: PostResultMessage,
   platform: PlatformId,
@@ -748,36 +730,6 @@ async function maybeAutoOpenPostUrl(
   } catch (e) {
     log.warn(`auto-open failed: ${e instanceof Error ? e.message : String(e)}`);
   }
-}
-
-function unconfirmedPostResult(platform: PlatformId, flow: Partial<PostFlowTrace> = {}): PostResultMessage {
-  return {
-    type: 'POST_RESULT',
-    platform,
-    success: false,
-    uncertain: true,
-    userAction: 'check-post-before-retry',
-    flow: {
-      submitReached: true,
-      ...flow,
-    },
-    error: t('runtimePostUncertain'),
-  };
-}
-
-function withFlow(result: PostResultMessage, flow: Partial<PostFlowTrace>): PostResultMessage {
-  return {
-    ...result,
-    flow: {
-      submitReached: result.flow?.submitReached ?? flow.submitReached ?? false,
-      ...flow,
-      ...result.flow,
-      urlCaptureTrace: result.flow?.urlCaptureTrace ?? flow.urlCaptureTrace,
-      submissionStartedAt: result.flow?.submissionStartedAt ?? flow.submissionStartedAt,
-      tabUrlBefore: result.flow?.tabUrlBefore ?? flow.tabUrlBefore,
-      tabUrlAfter: result.flow?.tabUrlAfter ?? flow.tabUrlAfter,
-    },
-  };
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/background/post-result-policy.test.ts
+++ b/src/background/post-result-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { PostResultMessage } from '../messages';
 import {
+  buildFinalChunkResult,
   downgradeHardVerifyFailures,
   hasDurablePostEvidence,
   normalizePostEvidence,
@@ -8,9 +9,80 @@ import {
   realPostResults,
   shouldRunPostCompletionSideEffects,
   toPreviewResult,
+  unconfirmedPostResult,
+  withFlow,
 } from './post-result-policy';
 
 describe('post result policy', () => {
+  it('preserves the final chunk flow trace on aggregated preview results', () => {
+    const result = buildFinalChunkResult('x', false, true, undefined, {
+      mode: 'preview',
+      attempt: 'default',
+      submitReached: false,
+      lastCompletedStep: 'wait-submit',
+    });
+
+    expect(result.flow).toMatchObject({
+      mode: 'preview',
+      attempt: 'default',
+      submitReached: false,
+      lastCompletedStep: 'wait-submit',
+    });
+  });
+
+  it('adds a fallback flow trace when a successful chunk omitted it', () => {
+    const result = buildFinalChunkResult('x', false, true);
+
+    expect(result.flow).toMatchObject({
+      mode: 'preview',
+      submitReached: false,
+      lastCompletedStep: 'preview-flow',
+    });
+  });
+
+  it('constructs uncertain results with the durable retry-safety contract', () => {
+    expect(unconfirmedPostResult('tumblr', {
+      mode: 'post',
+      failedStep: 'capture-url',
+    })).toMatchObject({
+      platform: 'tumblr',
+      success: false,
+      uncertain: true,
+      userAction: 'check-post-before-retry',
+      flow: {
+        mode: 'post',
+        submitReached: true,
+        failedStep: 'capture-url',
+      },
+    });
+  });
+
+  it('merges flow context without replacing response-owned evidence', () => {
+    expect(withFlow({
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      flow: {
+        submitReached: true,
+        submissionStartedAt: 20,
+        urlCaptureTrace: ['response'],
+      },
+    }, {
+      mode: 'post',
+      submitReached: false,
+      submissionStartedAt: 10,
+      urlCaptureTrace: ['base'],
+      tabUrlBefore: 'https://x.com/compose/post',
+    }).flow).toEqual({
+      mode: 'post',
+      submitReached: true,
+      submissionStartedAt: 20,
+      urlCaptureTrace: ['response'],
+      tabUrlBefore: 'https://x.com/compose/post',
+      tabUrlAfter: undefined,
+    });
+  });
+
   it('marks preview results and strips post evidence', () => {
     const result = toPreviewResult({
       type: 'POST_RESULT',

--- a/src/background/post-result-policy.ts
+++ b/src/background/post-result-policy.ts
@@ -1,4 +1,8 @@
-import type { PostResultMessage } from '../messages';
+import type {
+  PlatformId,
+  PostFlowTrace,
+  PostResultMessage,
+} from '../messages';
 import { t } from '../utils/i18n';
 
 export function toPreviewResult(result: PostResultMessage): PostResultMessage {
@@ -60,6 +64,67 @@ export function downgradeHardVerifyFailures(result: PostResultMessage): PostResu
       failedStep: result.flow?.failedStep ?? hardIssue.kind,
     },
     error: hardIssue.message,
+  };
+}
+
+export function buildFinalChunkResult(
+  platform: PlatformId,
+  autoPost: boolean,
+  allConfirmed: boolean,
+  postUrl?: string,
+  flow?: PostResultMessage['flow'],
+): PostResultMessage {
+  const mode = autoPost ? 'post' : 'preview';
+  const lastCompletedStep = flow?.lastCompletedStep ??
+    (autoPost ? 'post-flow' : 'preview-flow');
+  return {
+    type: 'POST_RESULT',
+    platform,
+    success: true,
+    confirmed: allConfirmed,
+    url: postUrl,
+    flow: {
+      ...flow,
+      mode: flow?.mode ?? mode,
+      submitReached: flow?.submitReached ?? autoPost,
+      lastCompletedStep,
+    },
+  };
+}
+
+export function unconfirmedPostResult(
+  platform: PlatformId,
+  flow: Partial<PostFlowTrace> = {},
+): PostResultMessage {
+  return {
+    type: 'POST_RESULT',
+    platform,
+    success: false,
+    uncertain: true,
+    userAction: 'check-post-before-retry',
+    flow: {
+      submitReached: true,
+      ...flow,
+    },
+    error: t('runtimePostUncertain'),
+  };
+}
+
+export function withFlow(
+  result: PostResultMessage,
+  flow: Partial<PostFlowTrace>,
+): PostResultMessage {
+  return {
+    ...result,
+    flow: {
+      submitReached: result.flow?.submitReached ?? flow.submitReached ?? false,
+      ...flow,
+      ...result.flow,
+      urlCaptureTrace: result.flow?.urlCaptureTrace ?? flow.urlCaptureTrace,
+      submissionStartedAt: result.flow?.submissionStartedAt ?? flow.submissionStartedAt,
+      tabUrlBefore: result.flow?.tabUrlBefore ?? flow.tabUrlBefore,
+      tabUrlAfter: result.flow?.tabUrlAfter ?? flow.tabUrlAfter,
+    },
   };
 }
 


### PR DESCRIPTION
Closes #106.
Parent: #12.

## Summary
- move final chunk, uncertain result, and flow merge construction into ResultPolicy
- preserve field precedence, preview/post defaults, retry-safety result, and localized error
- relocate and extend characterization tests
- guard platform-poster against reclaiming result construction

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] build the final exact artifact
- [ ] pass the full Surface preview matrix on that artifact before merge