### PR TITLE
refactor: extract DOM posting attempt policy

### DIFF
--- a/src/background/dom-attempt-policy.test.ts
+++ b/src/background/dom-attempt-policy.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { mastodonAdapter } from '../adapters/mastodon';
+import { threadsAdapter } from '../adapters/threads';
+import type { PlatformAdapter } from '../adapters/types';
+import {
+  buildDomPostAttempts,
+  resolvePreSubmitLoadOptions,
+  shouldOpenActive,
+  shouldRetryPostAttempt,
+  shouldReuseExistingTabForAttempt,
+} from './dom-attempt-policy';
+
+function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
+  return {
+    id: 'threads',
+    name: 'Threads',
+    charLimit: 500,
+    popupOrder: 1,
+    defaultSelected: true,
+    matchUrl: (url) => url.startsWith('https://www.threads.com/'),
+    getComposeUrl: (text) => (
+      `https://www.threads.com/intent/post?text=${encodeURIComponent(text)}`
+    ),
+    prefillsViaUrl: true,
+    imageConstraints: { maxBytesPerImage: 8 * 1024 * 1024, maxImages: 10 },
+    kinds: ['text', 'image'],
+    ...overrides,
+  };
+}
+
+describe('DOM posting attempt policy', () => {
+  it('derives pre-submit load behavior from adapter policy', () => {
+    expect(resolvePreSubmitLoadOptions(mastodonAdapter)).toEqual({
+      loadRetries: 1,
+      relaxedComposeUrlReady: true,
+    });
+    expect(resolvePreSubmitLoadOptions(threadsAdapter)).toBeUndefined();
+  });
+
+  it('builds safe pre-submit fallback attempts for normal SNS posting', () => {
+    expect(buildDomPostAttempts(adapter(), true)).toEqual([
+      { label: 'default' },
+      {
+        label: 'fresh foreground compose',
+        skipApi: true,
+        forceActive: true,
+        reuseExistingTab: false,
+        loadRetries: 1,
+        delayBeforeMs: 750,
+      },
+      {
+        label: 'fresh foreground compose with reload retry',
+        skipApi: true,
+        forceActive: true,
+        reuseExistingTab: false,
+        loadRetries: 2,
+        delayBeforeMs: 1000,
+      },
+    ]);
+  });
+
+  it('keeps foreground-only SNS retries shorter', () => {
+    expect(buildDomPostAttempts(adapter({ requiresForegroundTab: true }), true)).toEqual([
+      { label: 'default' },
+      {
+        label: 'fresh foreground compose',
+        skipApi: true,
+        forceActive: true,
+        reuseExistingTab: false,
+        loadRetries: 1,
+        delayBeforeMs: 750,
+      },
+    ]);
+  });
+
+  it('uses the preview delay and can force the first attempt foreground', () => {
+    expect(buildDomPostAttempts(adapter(), false)[1]).toMatchObject({
+      label: 'fresh foreground compose',
+      delayBeforeMs: 250,
+    });
+    expect(buildDomPostAttempts(adapter(), false, true)[0]).toEqual({
+      label: 'default',
+      forceActive: true,
+    });
+  });
+
+  it('derives foreground policy from post mode and platform requirements', () => {
+    expect(shouldOpenActive(adapter(), false, undefined, true)).toBe(true);
+    expect(shouldOpenActive(adapter(), true, undefined, false)).toBe(false);
+    expect(
+      shouldOpenActive(adapter({ requiresForegroundTab: true }), true, undefined, false),
+    ).toBe(true);
+    expect(shouldOpenActive(adapter(), true, undefined, false, true)).toBe(true);
+  });
+
+  it('reuses only safe background preview tabs unless explicitly overridden', () => {
+    expect(shouldReuseExistingTabForAttempt(adapter(), false)).toBe(true);
+    expect(
+      shouldReuseExistingTabForAttempt(adapter({ requiresForegroundTab: true }), false),
+    ).toBe(false);
+    expect(shouldReuseExistingTabForAttempt(adapter(), false, {}, true)).toBe(false);
+    expect(shouldReuseExistingTabForAttempt(
+      adapter({ requiresForegroundTab: true }),
+      false,
+      { reuseExistingTab: true },
+    )).toBe(true);
+    expect(shouldReuseExistingTabForAttempt(
+      adapter(),
+      false,
+      { reuseExistingTab: false },
+    )).toBe(false);
+  });
+
+  it('stops real-post retries after submit but preserves safe retries', () => {
+    expect(shouldRetryPostAttempt(true, { submitReached: true })).toBe(false);
+    expect(shouldRetryPostAttempt(true, { submitReached: false })).toBe(true);
+    expect(shouldRetryPostAttempt(true)).toBe(true);
+    expect(shouldRetryPostAttempt(false, { submitReached: true })).toBe(true);
+  });
+});

--- a/src/background/dom-attempt-policy.ts
+++ b/src/background/dom-attempt-policy.ts
@@ -1,0 +1,88 @@
+import type { PlatformAdapter } from '../adapters/types';
+import type { PostFlowTrace } from '../messages';
+import { shouldForceInlineThreadPreviewForeground } from './platform-strategies';
+import type { OpenOrFocusTabOptions } from './tab-management';
+
+export interface DomPostAttempt {
+  label: string;
+  skipApi?: boolean;
+  forceActive?: boolean;
+  reuseExistingTab?: boolean;
+  loadRetries?: number;
+  delayBeforeMs?: number;
+}
+
+export function shouldRetryPostAttempt(
+  autoPost: boolean,
+  flow?: Pick<PostFlowTrace, 'submitReached'>,
+): boolean {
+  return !autoPost || flow?.submitReached !== true;
+}
+
+export function resolvePreSubmitLoadOptions(
+  adapter: Pick<PlatformAdapter, 'preSubmitLoad'>,
+): OpenOrFocusTabOptions | undefined {
+  const policy = adapter.preSubmitLoad;
+  if (!policy) return undefined;
+  return {
+    loadRetries: policy.retryCount,
+    relaxedComposeUrlReady: policy.urlReady === 'same-origin-path',
+  };
+}
+
+export function shouldOpenActive(
+  adapter: PlatformAdapter,
+  dryRun: boolean,
+  textChunks?: string[],
+  autoPost = !dryRun,
+  forceForeground = false,
+): boolean {
+  if (forceForeground) return true;
+  if (autoPost) return true;
+  const forceForegroundForThreadPreview =
+    shouldForceInlineThreadPreviewForeground(adapter.id, dryRun, textChunks);
+  return adapter.requiresForegroundTab === true || forceForegroundForThreadPreview;
+}
+
+export function buildDomPostAttempts(
+  adapter: PlatformAdapter,
+  autoPost: boolean,
+  forceForeground = false,
+): DomPostAttempt[] {
+  const dryRun = !autoPost;
+  const attempts: DomPostAttempt[] = [
+    forceForeground ? { label: 'default', forceActive: true } : { label: 'default' },
+    {
+      label: 'fresh foreground compose',
+      skipApi: true,
+      forceActive: true,
+      reuseExistingTab: false,
+      loadRetries: 1,
+      delayBeforeMs: dryRun ? 250 : 750,
+    },
+  ];
+
+  if (!adapter.requiresForegroundTab) {
+    attempts.push({
+      label: 'fresh foreground compose with reload retry',
+      skipApi: true,
+      forceActive: true,
+      reuseExistingTab: false,
+      loadRetries: 2,
+      delayBeforeMs: 1000,
+    });
+  }
+
+  return attempts;
+}
+
+export function shouldReuseExistingTabForAttempt(
+  adapter: Pick<PlatformAdapter, 'requiresForegroundTab'>,
+  autoPost: boolean,
+  attempt: Pick<DomPostAttempt, 'reuseExistingTab'> = {},
+  forceForeground = false,
+): boolean {
+  if (typeof attempt.reuseExistingTab === 'boolean') return attempt.reuseExistingTab;
+  const dryRun = !autoPost;
+  return dryRun && adapter.requiresForegroundTab !== true && !forceForeground;
+}

--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -87,6 +87,15 @@ describe('platform architecture guard', () => {
       /\bfunction (?:buildFinalChunkResult|unconfirmedPostResult|withFlow)\b/,
     );
   });
+
+  it('keeps DOM attempt policy out of the central poster', () => {
+    const poster = readFileSync('src/background/platform-poster.ts', 'utf8');
+
+    expect(poster).toContain("from './dom-attempt-policy'");
+    expect(poster).not.toMatch(
+      /\bfunction (?:buildDomPostAttempts|resolvePreSubmitLoadOptions|shouldOpenActive|shouldRetryPostAttempt|shouldReuseExistingTabForAttempt)\b/,
+    );
+  });
 });
 
 function productionTypeScriptFiles(root: string): string[] {

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -1,17 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { mastodonAdapter } from '../adapters/mastodon';
-import { threadsAdapter } from '../adapters/threads';
 import type { PlatformAdapter } from '../adapters/types';
 import {
   buildVerifyExpectationForChunk,
-  buildDomPostAttempts,
   getComposeUrlForMedia,
   isAmbiguousPostDispatchError,
-  resolvePreSubmitLoadOptions,
   resolveApiPostOutcome,
-  shouldRetryPostAttempt,
-  shouldOpenActive,
-  shouldReuseExistingTabForAttempt,
 } from './platform-poster';
 
 function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
@@ -31,80 +24,6 @@ function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
 }
 
 describe('platform poster helpers', () => {
-  it('derives pre-submit load behavior from adapter policy', () => {
-    expect(resolvePreSubmitLoadOptions(mastodonAdapter)).toEqual({
-      loadRetries: 1,
-      relaxedComposeUrlReady: true,
-    });
-    expect(resolvePreSubmitLoadOptions(threadsAdapter)).toBeUndefined();
-  });
-
-  it('builds safe pre-submit fallback attempts for normal SNS posting', () => {
-    expect(buildDomPostAttempts(adapter(), true)).toEqual([
-      { label: 'default' },
-      {
-        label: 'fresh foreground compose',
-        skipApi: true,
-        forceActive: true,
-        reuseExistingTab: false,
-        loadRetries: 1,
-        delayBeforeMs: 750,
-      },
-      {
-        label: 'fresh foreground compose with reload retry',
-        skipApi: true,
-        forceActive: true,
-        reuseExistingTab: false,
-        loadRetries: 2,
-        delayBeforeMs: 1000,
-      },
-    ]);
-  });
-
-  it('keeps foreground-only SNS retries shorter because the first attempt is already foreground', () => {
-    expect(buildDomPostAttempts(adapter({ requiresForegroundTab: true }), true)).toEqual([
-      { label: 'default' },
-      {
-        label: 'fresh foreground compose',
-        skipApi: true,
-        forceActive: true,
-        reuseExistingTab: false,
-        loadRetries: 1,
-        delayBeforeMs: 750,
-      },
-    ]);
-  });
-
-  it('uses a shorter retry pause for preview because no post can have been submitted', () => {
-    expect(buildDomPostAttempts(adapter(), false)[1]).toMatchObject({
-      label: 'fresh foreground compose',
-      delayBeforeMs: 250,
-    });
-  });
-
-  it('opens all real DOM posting attempts in the foreground', () => {
-    expect(shouldOpenActive(adapter(), false, undefined, true)).toBe(true);
-  });
-
-  it('keeps normal preview attempts in the background unless the platform needs foreground', () => {
-    expect(shouldOpenActive(adapter(), true, undefined, false)).toBe(false);
-    expect(shouldOpenActive(adapter({ requiresForegroundTab: true }), true, undefined, false)).toBe(true);
-    expect(shouldOpenActive(adapter(), true, undefined, false, true)).toBe(true);
-  });
-
-  it('does not reuse existing tabs for foreground-only preview flows', () => {
-    expect(shouldReuseExistingTabForAttempt(adapter(), false)).toBe(true);
-    expect(shouldReuseExistingTabForAttempt(adapter({ requiresForegroundTab: true }), false)).toBe(false);
-    expect(shouldReuseExistingTabForAttempt(adapter(), false, {}, true)).toBe(false);
-  });
-
-  it('can force the first preview attempt into a foreground tab', () => {
-    expect(buildDomPostAttempts(adapter(), false, true)[0]).toMatchObject({
-      label: 'default',
-      forceActive: true,
-    });
-  });
-
   it('uses Tumblr video compose when posting video media', () => {
     const tumblr = adapter({
       id: 'tumblr',
@@ -117,15 +36,6 @@ describe('platform poster helpers', () => {
       data: 'AA==',
     }])).toBe('https://www.tumblr.com/new/video');
     expect(getComposeUrlForMedia(tumblr, 'hello')).toBe('https://www.tumblr.com/new/text');
-  });
-
-  it('honors explicit retry tab reuse overrides', () => {
-    expect(shouldReuseExistingTabForAttempt(adapter({ requiresForegroundTab: true }), false, {
-      reuseExistingTab: true,
-    })).toBe(true);
-    expect(shouldReuseExistingTabForAttempt(adapter(), false, {
-      reuseExistingTab: false,
-    })).toBe(false);
   });
 
   it('expects media only on the first chunk of a split post', () => {
@@ -227,13 +137,6 @@ describe('posting transport safety policy', () => {
         lastCompletedStep: 'api-create-post',
       },
     });
-  });
-
-  it('stops real-post retries after submit but keeps preview and pre-submit retries', () => {
-    expect(shouldRetryPostAttempt(true, { submitReached: true })).toBe(false);
-    expect(shouldRetryPostAttempt(true, { submitReached: false })).toBe(true);
-    expect(shouldRetryPostAttempt(true)).toBe(true);
-    expect(shouldRetryPostAttempt(false, { submitReached: true })).toBe(true);
   });
 
   it('classifies channel-close and timeout failures as ambiguous after dispatch', () => {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -14,7 +14,6 @@ import { t } from '../utils/i18n';
 import {
   closeTabSafely,
   openOrFocusTab,
-  type OpenOrFocusTabOptions,
 } from './tab-management';
 import {
   buildExpectedUrlsForVerification,
@@ -25,7 +24,6 @@ import {
   isVerifySupported,
   resolveComposeUrlForMedia,
   runVerify,
-  shouldForceInlineThreadPreviewForeground,
   shouldUseInlineThread,
   tryApiPath,
 } from './platform-strategies';
@@ -48,19 +46,18 @@ import {
 import type { OpenedTabRegistry } from './opened-tab-registry';
 import { retryTransientTabAction } from './tab-action-retry';
 import type { VerifyExpectation } from '../utils/post-verify';
+import {
+  buildDomPostAttempts,
+  type DomPostAttempt,
+  resolvePreSubmitLoadOptions,
+  shouldOpenActive,
+  shouldRetryPostAttempt,
+  shouldReuseExistingTabForAttempt,
+} from './dom-attempt-policy';
 
 const CHUNK_INTERVAL_MS = 2000;
 
 type Visibility = 'public' | 'unlisted' | 'private' | 'direct';
-
-export interface DomPostAttempt {
-  label: string;
-  skipApi?: boolean;
-  forceActive?: boolean;
-  reuseExistingTab?: boolean;
-  loadRetries?: number;
-  delayBeforeMs?: number;
-}
 
 export interface PlatformPosterOptions {
   openedTabs: Pick<OpenedTabRegistry, 'record' | 'forget'>;
@@ -567,13 +564,6 @@ export function resolveApiPostOutcome(
   });
 }
 
-export function shouldRetryPostAttempt(
-  autoPost: boolean,
-  flow?: Pick<PostFlowTrace, 'submitReached'>,
-): boolean {
-  return !autoPost || flow?.submitReached !== true;
-}
-
 export function isAmbiguousPostDispatchError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   return (
@@ -591,74 +581,6 @@ export function getComposeUrlForMedia(
   images?: readonly ImageAttachment[],
 ): string {
   return resolveComposeUrlForMedia(adapter.id, adapter.getComposeUrl(text), images);
-}
-
-export function resolvePreSubmitLoadOptions(
-  adapter: Pick<PlatformAdapter, 'preSubmitLoad'>,
-): OpenOrFocusTabOptions | undefined {
-  const policy = adapter.preSubmitLoad;
-  if (!policy) return undefined;
-  return {
-    loadRetries: policy.retryCount,
-    relaxedComposeUrlReady: policy.urlReady === 'same-origin-path',
-  };
-}
-
-export function shouldOpenActive(
-  adapter: PlatformAdapter,
-  dryRun: boolean,
-  textChunks?: string[],
-  autoPost = !dryRun,
-  forceForeground = false,
-): boolean {
-  if (forceForeground) return true;
-  if (autoPost) return true;
-  const forceForegroundForThreadPreview =
-    shouldForceInlineThreadPreviewForeground(adapter.id, dryRun, textChunks);
-  return adapter.requiresForegroundTab === true || forceForegroundForThreadPreview;
-}
-
-export function buildDomPostAttempts(
-  adapter: PlatformAdapter,
-  autoPost: boolean,
-  forceForeground = false,
-): DomPostAttempt[] {
-  const dryRun = !autoPost;
-  const attempts: DomPostAttempt[] = [
-    forceForeground ? { label: 'default', forceActive: true } : { label: 'default' },
-    {
-      label: 'fresh foreground compose',
-      skipApi: true,
-      forceActive: true,
-      reuseExistingTab: false,
-      loadRetries: 1,
-      delayBeforeMs: dryRun ? 250 : 750,
-    },
-  ];
-
-  if (!adapter.requiresForegroundTab) {
-    attempts.push({
-      label: 'fresh foreground compose with reload retry',
-      skipApi: true,
-      forceActive: true,
-      reuseExistingTab: false,
-      loadRetries: 2,
-      delayBeforeMs: 1000,
-    });
-  }
-
-  return attempts;
-}
-
-export function shouldReuseExistingTabForAttempt(
-  adapter: Pick<PlatformAdapter, 'requiresForegroundTab'>,
-  autoPost: boolean,
-  attempt: Pick<DomPostAttempt, 'reuseExistingTab'> = {},
-  forceForeground = false,
-): boolean {
-  if (typeof attempt.reuseExistingTab === 'boolean') return attempt.reuseExistingTab;
-  const dryRun = !autoPost;
-  return dryRun && adapter.requiresForegroundTab !== true && !forceForeground;
 }
 
 async function attachVerifyResult(


### PR DESCRIPTION
Depends on #107.
Closes #108.
Parent: #12.

## Summary
- extract DOM attempt ordering and retry delays
- extract active-tab, tab-reuse, and pre-submit load policy
- keep submitReached as the hard boundary that stops real-post retries
- move characterization tests and guard the central poster boundary

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] rebase onto merged dependency
- [ ] build the final exact artifact
- [ ] pass the full Surface preview matrix on that artifact before merge