### PR TITLE
refactor: extract posting transport service

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -90,8 +90,9 @@ describe('platform architecture guard', () => {
 
   it('keeps DOM attempt policy out of the central poster', () => {
     const poster = readFileSync('src/background/platform-poster.ts', 'utf8');
+    const transport = readFileSync('src/background/posting-transport.ts', 'utf8');
 
-    expect(poster).toContain("from './dom-attempt-policy'");
+    expect(transport).toContain("from './dom-attempt-policy'");
     expect(poster).not.toMatch(
       /\bfunction (?:buildDomPostAttempts|resolvePreSubmitLoadOptions|shouldOpenActive|shouldRetryPostAttempt|shouldReuseExistingTabForAttempt)\b/,
     );
@@ -104,6 +105,17 @@ describe('platform architecture guard', () => {
     expect(poster).not.toMatch(
       /\bfunction (?:attachVerifyResult|buildVerifyExpectationForChunk|captureUrl|ensurePostUrl|maybeAutoOpenPostUrl|recoverFromAmbiguousDispatchFailure)\b/,
     );
+  });
+
+  it('keeps single-chunk API and DOM effects in PostingTransport', () => {
+    const poster = readFileSync('src/background/platform-poster.ts', 'utf8');
+
+    expect(poster).toContain("from './posting-transport'");
+    expect(poster).not.toMatch(
+      /\bfunction (?:closeOwnedAttemptTab|getComposeUrlForMedia|postSingleChunk|postSingleChunkWithRetry|resolveApiPostOutcome)\b/,
+    );
+    expect(poster).not.toContain('sendPostMessageWhenReady');
+    expect(poster).not.toContain('tryApiPath');
   });
 });
 

--- a/src/background/platform-poster.test.ts
+++ b/src/background/platform-poster.test.ts
@@ -3,7 +3,7 @@ import type { PlatformAdapter } from '../adapters/types';
 import {
   getComposeUrlForMedia,
   resolveApiPostOutcome,
-} from './platform-poster';
+} from './posting-transport';
 
 function adapter(overrides: Partial<PlatformAdapter> = {}): PlatformAdapter {
   return {

--- a/src/background/platform-poster.ts
+++ b/src/background/platform-poster.ts
@@ -1,83 +1,53 @@
+import type { PlatformAdapter } from '../adapters/types';
 import type {
   ImageAttachment,
   PlatformId,
-  PostFlowTrace,
   PostResultMessage,
-  PostToPlatformMessage,
 } from '../messages';
-import type { PlatformAdapter } from '../adapters/types';
-import type { ApiPostResult } from '../api/types';
-import { getLastSeenUsers } from '../storage';
-import { splitTextForPlatform } from '../utils/platform-text';
-import { log } from '../utils/logger';
 import { t } from '../utils/i18n';
-import {
-  closeTabSafely,
-  openOrFocusTab,
-} from './tab-management';
-import {
-  buildReplyOverrideUrl,
-  canUseApiWithReplyUrl,
-  continuationNeedsReplyUrl,
-  isVerifySupported,
-  resolveComposeUrlForMedia,
-  shouldUseInlineThread,
-  tryApiPath,
-} from './platform-strategies';
-import {
-  buildLoginRedirectErrorForUrl,
-  buildMissingReceiverLoginError,
-  isMissingReceiverError,
-  sendPostMessageWhenReady,
-} from './content-dispatch';
+import { log } from '../utils/logger';
+import { splitTextForPlatform } from '../utils/platform-text';
 import { resolveAdapter } from './adapter-resolver';
-import { prepareMediaForPlatform } from './platform-media';
-import { maybeResizeImagesForPlatform } from './media-preprocess';
-import {
-  buildFinalChunkResult,
-  downgradeHardVerifyFailures,
-  toPreviewResult,
-  unconfirmedPostResult,
-  withFlow,
-} from './post-result-policy';
 import type { OpenedTabRegistry } from './opened-tab-registry';
-import {
-  buildDomPostAttempts,
-  type DomPostAttempt,
-  resolvePreSubmitLoadOptions,
-  shouldOpenActive,
-  shouldRetryPostAttempt,
-  shouldReuseExistingTabForAttempt,
-} from './dom-attempt-policy';
 import {
   attachVerifyResult,
   createPostConfirmation,
   maybeAutoOpenPostUrl,
 } from './post-confirmation';
+import {
+  buildReplyOverrideUrl,
+  continuationNeedsReplyUrl,
+  isVerifySupported,
+  shouldUseInlineThread,
+} from './platform-strategies';
+import { prepareMediaForPlatform } from './platform-media';
+import {
+  buildFinalChunkResult,
+  downgradeHardVerifyFailures,
+  toPreviewResult,
+  unconfirmedPostResult,
+} from './post-result-policy';
+import {
+  createPostingTransport,
+  PostFlowError,
+  type PostToPlatformOptions,
+  type Visibility,
+} from './posting-transport';
 
 const CHUNK_INTERVAL_MS = 2000;
-
-type Visibility = 'public' | 'unlisted' | 'private' | 'direct';
 
 export interface PlatformPosterOptions {
   openedTabs: Pick<OpenedTabRegistry, 'record' | 'forget'>;
   appendBackgroundLog?: (message: string) => void;
 }
 
-export interface PostToPlatformOptions {
-  forceForeground?: boolean;
-}
-
-class PostFlowError extends Error {
-  constructor(message: string, readonly flow?: PostFlowTrace) {
-    super(message);
-    this.name = 'PostFlowError';
-  }
-}
-
 export function createPlatformPoster(options: PlatformPosterOptions) {
   const confirmation = createPostConfirmation({
     appendBackgroundLog: options.appendBackgroundLog,
+  });
+  const transport = createPostingTransport({
+    openedTabs: options.openedTabs,
+    confirmation,
   });
 
   async function postToPlatform(
@@ -104,24 +74,33 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
       };
     }
 
-    const media = await prepareMediaForPlatform(adapter, platform, images, autoPost);
+    const media = await prepareMediaForPlatform(
+      adapter,
+      platform,
+      images,
+      autoPost,
+    );
     if (!media.ok) return media.result;
     images = media.images;
 
     const chunks = splitTextForPlatform(adapter.id, text, adapter.charLimit);
-
     if (shouldUseInlineThread(adapter.id, autoPost) && chunks.length > 1) {
       return await postSingleChunkInlineThread(adapter, chunks, images, autoPost);
     }
 
-    let prevPostUrl: string | undefined;
+    let previousPostUrl: string | undefined;
     let allConfirmed = true;
     let finalChunkFlow: PostResultMessage['flow'];
-    for (let i = 0; i < chunks.length; i++) {
-      if (i > 0) await sleep(CHUNK_INTERVAL_MS);
-      const chunkImages = i === 0 ? images : undefined;
-      const replyToUrl = i > 0 ? prevPostUrl : undefined;
-      if (autoPost && i > 0 && continuationNeedsReplyUrl(adapter.id) && !replyToUrl) {
+    for (let index = 0; index < chunks.length; index++) {
+      if (index > 0) await sleep(CHUNK_INTERVAL_MS);
+      const chunkImages = index === 0 ? images : undefined;
+      const replyToUrl = index > 0 ? previousPostUrl : undefined;
+      if (
+        autoPost &&
+        index > 0 &&
+        continuationNeedsReplyUrl(adapter.id) &&
+        !replyToUrl
+      ) {
         return unconfirmedPostResult(adapter.id, {
           mode: 'post',
           submitReached: true,
@@ -129,12 +108,16 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
           lastCompletedStep: finalChunkFlow?.lastCompletedStep,
         });
       }
-      const overrideUrl = buildReplyOverrideUrl(adapter.id, i, prevPostUrl);
+      const overrideUrl = buildReplyOverrideUrl(
+        adapter.id,
+        index,
+        previousPostUrl,
+      );
 
       try {
-        const result = await postSingleChunkWithRetry(
+        const result = await transport.postSingleChunkWithRetry(
           adapter,
-          chunks[i]!,
+          chunks[index]!,
           chunkImages,
           undefined,
           overrideUrl,
@@ -144,21 +127,25 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
           replyToUrl,
           postOptions,
         );
-
         if (!result.success) {
           return {
             ...result,
             error: chunks.length > 1
-              ? t('runtimeChunkContext', i + 1, chunks.length, result.error ?? t('runtimePostUncertain'))
+              ? t(
+                  'runtimeChunkContext',
+                  index + 1,
+                  chunks.length,
+                  result.error ?? t('runtimePostUncertain'),
+                )
               : result.error,
           };
         }
-        if (result.url) prevPostUrl = result.url;
+        if (result.url) previousPostUrl = result.url;
         if (!result.confirmed && !result.url) allConfirmed = false;
         finalChunkFlow = result.flow;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        const flow = err instanceof PostFlowError ? err.flow : undefined;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const flow = error instanceof PostFlowError ? error.flow : undefined;
         return {
           type: 'POST_RESULT',
           platform,
@@ -169,23 +156,39 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
             lastCompletedStep: flow?.lastCompletedStep,
             failedStep: flow?.failedStep ?? 'pre-submit-attempt',
           },
-          error: chunks.length > 1 ? t('runtimeChunkFailed', i + 1, chunks.length, msg) : msg,
+          error: chunks.length > 1
+            ? t('runtimeChunkFailed', index + 1, chunks.length, message)
+            : message,
         };
       }
     }
 
-    const finalResultBase = buildFinalChunkResult(platform, autoPost, allConfirmed, prevPostUrl, finalChunkFlow);
-    let finalResult = autoPost ? finalResultBase : toPreviewResult(finalResultBase);
+    const finalResultBase = buildFinalChunkResult(
+      platform,
+      autoPost,
+      allConfirmed,
+      previousPostUrl,
+      finalChunkFlow,
+    );
+    let finalResult = autoPost
+      ? finalResultBase
+      : toPreviewResult(finalResultBase);
 
-    if (autoPost && prevPostUrl && isVerifySupported(platform)) {
-      await attachVerifyResult(finalResult, platform, prevPostUrl, chunks, text, images);
+    if (autoPost && previousPostUrl && isVerifySupported(platform)) {
+      await attachVerifyResult(
+        finalResult,
+        platform,
+        previousPostUrl,
+        chunks,
+        text,
+        images,
+      );
       finalResult = downgradeHardVerifyFailures(finalResult);
     }
 
-    if (autoPost && prevPostUrl) {
-      void maybeAutoOpenPostUrl(prevPostUrl, finalResult.verify);
+    if (autoPost && previousPostUrl) {
+      void maybeAutoOpenPostUrl(previousPostUrl, finalResult.verify);
     }
-
     return finalResult;
   }
 
@@ -195,312 +198,23 @@ export function createPlatformPoster(options: PlatformPosterOptions) {
     images?: ImageAttachment[],
     autoPost = true,
   ): Promise<PostResultMessage> {
-    log.info(`${adapter.id}: inline thread compose で ${chunks.length} chunks を 1 つの compose に並べる`);
-    return await postSingleChunkWithRetry(adapter, chunks[0]!, images, chunks, undefined, undefined, undefined, autoPost);
-  }
-
-  async function postSingleChunkWithRetry(
-    adapter: PlatformAdapter,
-    text: string,
-    rawImages?: ImageAttachment[],
-    textChunks?: string[],
-    overrideUrl?: string,
-    cw?: string,
-    visibility?: Visibility,
-    autoPost = true,
-    replyToUrl?: string,
-    postOptions: PostToPlatformOptions = {},
-  ): Promise<PostResultMessage> {
-    const attempts = buildDomPostAttempts(adapter, autoPost, postOptions.forceForeground === true);
-    let lastError: unknown;
-    for (let i = 0; i < attempts.length; i += 1) {
-      const attempt = attempts[i]!;
-      if (attempt.delayBeforeMs) await sleep(attempt.delayBeforeMs);
-      try {
-        return await postSingleChunk(
-          adapter,
-          text,
-          rawImages,
-          textChunks,
-          overrideUrl,
-          cw,
-          visibility,
-          autoPost,
-          attempt,
-          replyToUrl,
-          postOptions,
-        );
-      } catch (err) {
-        lastError = err;
-        const flow = err instanceof PostFlowError ? err.flow : undefined;
-        if (!shouldRetryPostAttempt(autoPost, flow)) {
-          const message = err instanceof Error ? err.message : String(err);
-          log.warn(
-            `${adapter.id}: post action may have started during "${attempt.label}"; ` +
-            'stopping automatic retries',
-          );
-          return {
-            type: 'POST_RESULT',
-            platform: adapter.id,
-            success: false,
-            uncertain: true,
-            userAction: 'check-post-before-retry',
-            flow: {
-              mode: 'post',
-              ...flow,
-              submitReached: true,
-              failedStep: flow?.failedStep ?? 'post-dispatch',
-            },
-            error: message,
-          };
-        }
-        if (i >= attempts.length - 1) throw err;
-        const next = attempts[i + 1]!;
-        log.warn(
-          `${adapter.id}: pre-submit attempt "${attempt.label}" failed before the post action; ` +
-          `retrying with "${next.label}": ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-    throw lastError instanceof Error ? lastError : new Error(String(lastError ?? t('runtimeUnknownError')));
-  }
-
-  async function postSingleChunk(
-    adapter: PlatformAdapter,
-    text: string,
-    rawImages?: ImageAttachment[],
-    textChunks?: string[],
-    overrideUrl?: string,
-    cw?: string,
-    visibility?: Visibility,
-    autoPost = true,
-    attempt: DomPostAttempt = { label: 'default' },
-    replyToUrl?: string,
-    postOptions: PostToPlatformOptions = {},
-  ): Promise<PostResultMessage> {
-    const images = rawImages ? await maybeResizeImagesForPlatform(adapter, rawImages) : undefined;
-    const baseFlow: Partial<PostFlowTrace> = {
-      mode: autoPost ? 'post' : 'preview',
-      attempt: attempt.label,
-      submitReached: false,
-      lastCompletedStep: 'preflight',
-    };
-
-    if (
-      autoPost
-      && (!overrideUrl || canUseApiWithReplyUrl(adapter.id, replyToUrl))
-      && !textChunks
-      && !attempt.skipApi
-    ) {
-      const apiResult = await tryApiPath(adapter.id, text, images, cw, visibility, replyToUrl);
-      const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, baseFlow);
-      if (apiOutcome) {
-        if (apiOutcome.success) {
-          log.info(`${adapter.id} via API ✓ ${apiOutcome.url ?? ''}`);
-        } else if (apiOutcome.uncertain) {
-          const detail = apiResult === 'no-credentials'
-            ? t('runtimeUnknownError')
-            : apiResult.error ?? t('runtimeUnknownError');
-          log.warn(`${adapter.id} via API: post result uncertain - ${detail}`);
-        } else {
-          log.warn(
-            `${adapter.id} via API failed; keeping this request on the selected API transport: ` +
-            `${apiOutcome.error ?? t('runtimeUnknownError')}`,
-          );
-        }
-        return apiOutcome;
-      }
-    }
-
-    const dryRun = !autoPost;
-    const forceForeground = postOptions.forceForeground === true;
-    const active = forceForeground || attempt.forceActive === true ||
-      shouldOpenActive(adapter, dryRun, textChunks, autoPost);
-    const reuseExistingTab = shouldReuseExistingTabForAttempt(adapter, autoPost, attempt, forceForeground);
-    const openOptions = resolvePreSubmitLoadOptions(adapter);
-    const { tab, wasCreated } = await openOrFocusTab(
-      overrideUrl ?? getComposeUrlForMedia(adapter, text, images),
-      adapter.matchUrl,
-      active,
-      {
-        ...openOptions,
-        loadRetries: Math.max(openOptions?.loadRetries ?? 0, attempt.loadRetries ?? 0),
-        // Real posts must start from a clean compose surface.
-        // Reusing broad domain matches (for example instagram.com/ or x.com/compose/post)
-        // can collide with preview drafts left open by the previous request.
-        // Foreground-only upload wizards are stateful enough that preview also needs
-        // a clean compose surface between repeated runs.
-        reuseExistingTab,
-      },
+    log.info(
+      `${adapter.id}: inline thread compose で ` +
+      `${chunks.length} chunks を 1 つの compose に並べる`,
     );
-    if (typeof tab.id !== 'number') {
-      throw new Error(t('runtimeSnsTabOpenFailed'));
-    }
-    const ownedTabId = wasCreated && !dryRun ? tab.id : undefined;
-    if (typeof ownedTabId === 'number') options.openedTabs.record(adapter.id, ownedTabId);
-    let response: PostResultMessage | undefined;
-
-    try {
-      const currentTab = await browser.tabs.get(tab.id).catch(() => tab);
-      const tabUrlBefore = currentTab.url ?? currentTab.pendingUrl;
-      const loginRedirectError = buildLoginRedirectErrorForUrl(currentTab.url ?? currentTab.pendingUrl ?? '');
-      if (loginRedirectError) {
-        return withFlow({
-          type: 'POST_RESULT',
-          platform: adapter.id,
-          success: false,
-          userAction: 'sign-in',
-          error: loginRedirectError,
-        }, {
-          ...baseFlow,
-          tabUrlBefore,
-          failedStep: 'verify-login',
-        });
-      }
-
-      const lastSeenUsers = await getLastSeenUsers();
-      const expectedUser = lastSeenUsers[adapter.id] ?? undefined;
-      const message: PostToPlatformMessage = {
-        type: 'POST_TO_PLATFORM',
-        platform: adapter.id,
-        text,
-        textChunks,
-        images,
-        dryRun,
-        expectedUser,
-        cw,
-        visibility,
-      };
-
-      const dispatchStartedAt = Date.now();
-      try {
-        response = await sendPostMessageWhenReady(tab.id, message);
-      } catch (err) {
-        if (isMissingReceiverError(err)) {
-          const loginError = await buildMissingReceiverLoginError(tab.id, adapter.id);
-          if (loginError) {
-            return {
-              type: 'POST_RESULT',
-              platform: adapter.id,
-              success: false,
-              userAction: 'sign-in',
-              flow: {
-                ...baseFlow,
-                tabUrlBefore,
-                failedStep: 'verify-login',
-                submitReached: false,
-              },
-              error: loginError,
-            };
-          }
-        }
-        const recovered = await confirmation.recoverFromAmbiguousDispatchFailure(
-          err,
-          adapter.id,
-          tab.id,
-          text,
-          expectedUser,
-          dryRun,
-          dispatchStartedAt,
-        );
-        if (recovered) return withFlow(recovered, { ...baseFlow, tabUrlBefore });
-        throw err;
-      }
-
-      if (!response) {
-        throw new Error(t('runtimeSnsPageNoResponse'));
-      }
-      response = withFlow(response, { ...baseFlow, tabUrlBefore });
-      if (!response.success) {
-        if (response.uncertain) return response;
-        throw new PostFlowError(response.error ?? t('runtimePostFailed'), response.flow);
-      }
-      if (dryRun) return toPreviewResult(response);
-
-      const withUrl = await confirmation.ensurePostUrl(
-        response,
-        adapter.id,
-        tab.id,
-        text,
-        expectedUser,
-      );
-      if (withUrl.url) return { ...withUrl, confirmed: true };
-      return unconfirmedPostResult(adapter.id, {
-        ...withUrl.flow,
-        tabUrlBefore,
-        failedStep: withUrl.flow?.failedStep ?? 'capture-url',
-        submitReached: withUrl.flow?.submitReached ?? true,
-      });
-    } catch (err) {
-      if (typeof ownedTabId === 'number' && response?.flow?.submitReached !== true) {
-        await closeOwnedAttemptTab(adapter.id, ownedTabId, attempt.label);
-      }
-      throw err;
-    }
-  }
-
-  async function closeOwnedAttemptTab(
-    platform: PlatformId,
-    tabId: number,
-    attemptLabel: string,
-  ): Promise<void> {
-    log.info(`${platform}: closing failed pre-submit attempt tab (${attemptLabel}, tabId=${tabId}) before retry`);
-    options.openedTabs.forget(platform, tabId);
-    await closeTabSafely(tabId);
+    return await transport.postSingleChunkWithRetry(
+      adapter,
+      chunks[0]!,
+      images,
+      chunks,
+      undefined,
+      undefined,
+      undefined,
+      autoPost,
+    );
   }
 
   return { postToPlatform };
-}
-
-export function resolveApiPostOutcome(
-  platform: PlatformId,
-  apiResult: ApiPostResult | 'no-credentials',
-  baseFlow: Partial<PostFlowTrace> = {},
-): PostResultMessage | null {
-  if (apiResult === 'no-credentials') return null;
-  const flow = {
-    ...baseFlow,
-    attempt: 'api',
-  };
-  if (apiResult.success && apiResult.postUrl) {
-    return withFlow({
-      type: 'POST_RESULT',
-      platform,
-      success: true,
-      confirmed: true,
-      url: apiResult.postUrl,
-    }, {
-      ...flow,
-      submitReached: true,
-      lastCompletedStep: 'api-create-post',
-    });
-  }
-  if (apiResult.success || apiResult.uncertain) {
-    return unconfirmedPostResult(platform, {
-      ...flow,
-      submitReached: true,
-      lastCompletedStep: 'api-create-post',
-      failedStep: 'capture-url',
-    });
-  }
-  return withFlow({
-    type: 'POST_RESULT',
-    platform,
-    success: false,
-    error: apiResult.error ?? t('runtimeUnknownError'),
-  }, {
-    ...flow,
-    submitReached: false,
-    failedStep: 'api-post',
-  });
-}
-
-export function getComposeUrlForMedia(
-  adapter: PlatformAdapter,
-  text: string,
-  images?: readonly ImageAttachment[],
-): string {
-  return resolveComposeUrlForMedia(adapter.id, adapter.getComposeUrl(text), images);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/background/post-confirmation.ts
+++ b/src/background/post-confirmation.ts
@@ -125,6 +125,8 @@ export function createPostConfirmation(options: PostConfirmationOptions = {}) {
   };
 }
 
+export type PostConfirmation = ReturnType<typeof createPostConfirmation>;
+
 export async function attachVerifyResult(
   result: PostResultMessage,
   platform: PlatformId,

--- a/src/background/posting-transport.ts
+++ b/src/background/posting-transport.ts
@@ -1,0 +1,409 @@
+import type { PlatformAdapter } from '../adapters/types';
+import type { ApiPostResult } from '../api/types';
+import type {
+  ImageAttachment,
+  PlatformId,
+  PostFlowTrace,
+  PostResultMessage,
+  PostToPlatformMessage,
+} from '../messages';
+import { getLastSeenUsers } from '../storage';
+import { t } from '../utils/i18n';
+import { log } from '../utils/logger';
+import {
+  buildLoginRedirectErrorForUrl,
+  buildMissingReceiverLoginError,
+  isMissingReceiverError,
+  sendPostMessageWhenReady,
+} from './content-dispatch';
+import {
+  buildDomPostAttempts,
+  type DomPostAttempt,
+  resolvePreSubmitLoadOptions,
+  shouldOpenActive,
+  shouldRetryPostAttempt,
+  shouldReuseExistingTabForAttempt,
+} from './dom-attempt-policy';
+import { maybeResizeImagesForPlatform } from './media-preprocess';
+import type { OpenedTabRegistry } from './opened-tab-registry';
+import type { PostConfirmation } from './post-confirmation';
+import {
+  canUseApiWithReplyUrl,
+  resolveComposeUrlForMedia,
+  tryApiPath,
+} from './platform-strategies';
+import {
+  toPreviewResult,
+  unconfirmedPostResult,
+  withFlow,
+} from './post-result-policy';
+import { closeTabSafely, openOrFocusTab } from './tab-management';
+
+export type Visibility = 'public' | 'unlisted' | 'private' | 'direct';
+
+export interface PostToPlatformOptions {
+  forceForeground?: boolean;
+}
+
+export interface PostingTransportOptions {
+  openedTabs: Pick<OpenedTabRegistry, 'record' | 'forget'>;
+  confirmation: Pick<
+    PostConfirmation,
+    'ensurePostUrl' | 'recoverFromAmbiguousDispatchFailure'
+  >;
+}
+
+export class PostFlowError extends Error {
+  constructor(message: string, readonly flow?: PostFlowTrace) {
+    super(message);
+    this.name = 'PostFlowError';
+  }
+}
+
+export function createPostingTransport(options: PostingTransportOptions) {
+  async function postSingleChunkWithRetry(
+    adapter: PlatformAdapter,
+    text: string,
+    rawImages?: ImageAttachment[],
+    textChunks?: string[],
+    overrideUrl?: string,
+    cw?: string,
+    visibility?: Visibility,
+    autoPost = true,
+    replyToUrl?: string,
+    postOptions: PostToPlatformOptions = {},
+  ): Promise<PostResultMessage> {
+    const attempts = buildDomPostAttempts(
+      adapter,
+      autoPost,
+      postOptions.forceForeground === true,
+    );
+    let lastError: unknown;
+    for (let index = 0; index < attempts.length; index += 1) {
+      const attempt = attempts[index]!;
+      if (attempt.delayBeforeMs) await sleep(attempt.delayBeforeMs);
+      try {
+        return await postSingleChunk(
+          adapter,
+          text,
+          rawImages,
+          textChunks,
+          overrideUrl,
+          cw,
+          visibility,
+          autoPost,
+          attempt,
+          replyToUrl,
+          postOptions,
+        );
+      } catch (error) {
+        lastError = error;
+        const flow = error instanceof PostFlowError ? error.flow : undefined;
+        if (!shouldRetryPostAttempt(autoPost, flow)) {
+          const message = error instanceof Error ? error.message : String(error);
+          log.warn(
+            `${adapter.id}: post action may have started during "${attempt.label}"; ` +
+            'stopping automatic retries',
+          );
+          return {
+            type: 'POST_RESULT',
+            platform: adapter.id,
+            success: false,
+            uncertain: true,
+            userAction: 'check-post-before-retry',
+            flow: {
+              mode: 'post',
+              ...flow,
+              submitReached: true,
+              failedStep: flow?.failedStep ?? 'post-dispatch',
+            },
+            error: message,
+          };
+        }
+        if (index >= attempts.length - 1) throw error;
+        const next = attempts[index + 1]!;
+        log.warn(
+          `${adapter.id}: pre-submit attempt "${attempt.label}" failed before the post action; ` +
+          `retrying with "${next.label}": ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(String(lastError ?? t('runtimeUnknownError')));
+  }
+
+  async function postSingleChunk(
+    adapter: PlatformAdapter,
+    text: string,
+    rawImages?: ImageAttachment[],
+    textChunks?: string[],
+    overrideUrl?: string,
+    cw?: string,
+    visibility?: Visibility,
+    autoPost = true,
+    attempt: DomPostAttempt = { label: 'default' },
+    replyToUrl?: string,
+    postOptions: PostToPlatformOptions = {},
+  ): Promise<PostResultMessage> {
+    const images = rawImages
+      ? await maybeResizeImagesForPlatform(adapter, rawImages)
+      : undefined;
+    const baseFlow: Partial<PostFlowTrace> = {
+      mode: autoPost ? 'post' : 'preview',
+      attempt: attempt.label,
+      submitReached: false,
+      lastCompletedStep: 'preflight',
+    };
+
+    if (
+      autoPost &&
+      (!overrideUrl || canUseApiWithReplyUrl(adapter.id, replyToUrl)) &&
+      !textChunks &&
+      !attempt.skipApi
+    ) {
+      const apiResult = await tryApiPath(
+        adapter.id,
+        text,
+        images,
+        cw,
+        visibility,
+        replyToUrl,
+      );
+      const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, baseFlow);
+      if (apiOutcome) {
+        if (apiOutcome.success) {
+          log.info(`${adapter.id} via API ✓ ${apiOutcome.url ?? ''}`);
+        } else if (apiOutcome.uncertain) {
+          const detail = apiResult === 'no-credentials'
+            ? t('runtimeUnknownError')
+            : apiResult.error ?? t('runtimeUnknownError');
+          log.warn(`${adapter.id} via API: post result uncertain - ${detail}`);
+        } else {
+          log.warn(
+            `${adapter.id} via API failed; keeping this request on the selected API transport: ` +
+            `${apiOutcome.error ?? t('runtimeUnknownError')}`,
+          );
+        }
+        return apiOutcome;
+      }
+    }
+
+    const dryRun = !autoPost;
+    const forceForeground = postOptions.forceForeground === true;
+    const active = forceForeground || attempt.forceActive === true ||
+      shouldOpenActive(adapter, dryRun, textChunks, autoPost);
+    const reuseExistingTab = shouldReuseExistingTabForAttempt(
+      adapter,
+      autoPost,
+      attempt,
+      forceForeground,
+    );
+    const openOptions = resolvePreSubmitLoadOptions(adapter);
+    const { tab, wasCreated } = await openOrFocusTab(
+      overrideUrl ?? getComposeUrlForMedia(adapter, text, images),
+      adapter.matchUrl,
+      active,
+      {
+        ...openOptions,
+        loadRetries: Math.max(
+          openOptions?.loadRetries ?? 0,
+          attempt.loadRetries ?? 0,
+        ),
+        reuseExistingTab,
+      },
+    );
+    if (typeof tab.id !== 'number') {
+      throw new Error(t('runtimeSnsTabOpenFailed'));
+    }
+    const ownedTabId = wasCreated && !dryRun ? tab.id : undefined;
+    if (typeof ownedTabId === 'number') {
+      options.openedTabs.record(adapter.id, ownedTabId);
+    }
+    let response: PostResultMessage | undefined;
+
+    try {
+      const currentTab = await browser.tabs.get(tab.id).catch(() => tab);
+      const tabUrlBefore = currentTab.url ?? currentTab.pendingUrl;
+      const loginRedirectError = buildLoginRedirectErrorForUrl(
+        currentTab.url ?? currentTab.pendingUrl ?? '',
+      );
+      if (loginRedirectError) {
+        return withFlow({
+          type: 'POST_RESULT',
+          platform: adapter.id,
+          success: false,
+          userAction: 'sign-in',
+          error: loginRedirectError,
+        }, {
+          ...baseFlow,
+          tabUrlBefore,
+          failedStep: 'verify-login',
+        });
+      }
+
+      const lastSeenUsers = await getLastSeenUsers();
+      const expectedUser = lastSeenUsers[adapter.id] ?? undefined;
+      const message: PostToPlatformMessage = {
+        type: 'POST_TO_PLATFORM',
+        platform: adapter.id,
+        text,
+        textChunks,
+        images,
+        dryRun,
+        expectedUser,
+        cw,
+        visibility,
+      };
+
+      const dispatchStartedAt = Date.now();
+      try {
+        response = await sendPostMessageWhenReady(tab.id, message);
+      } catch (error) {
+        if (isMissingReceiverError(error)) {
+          const loginError = await buildMissingReceiverLoginError(tab.id, adapter.id);
+          if (loginError) {
+            return {
+              type: 'POST_RESULT',
+              platform: adapter.id,
+              success: false,
+              userAction: 'sign-in',
+              flow: {
+                ...baseFlow,
+                tabUrlBefore,
+                failedStep: 'verify-login',
+                submitReached: false,
+              },
+              error: loginError,
+            };
+          }
+        }
+        const recovered = await options.confirmation
+          .recoverFromAmbiguousDispatchFailure(
+            error,
+            adapter.id,
+            tab.id,
+            text,
+            expectedUser,
+            dryRun,
+            dispatchStartedAt,
+          );
+        if (recovered) {
+          return withFlow(recovered, { ...baseFlow, tabUrlBefore });
+        }
+        throw error;
+      }
+
+      if (!response) {
+        throw new Error(t('runtimeSnsPageNoResponse'));
+      }
+      response = withFlow(response, { ...baseFlow, tabUrlBefore });
+      if (!response.success) {
+        if (response.uncertain) return response;
+        throw new PostFlowError(
+          response.error ?? t('runtimePostFailed'),
+          response.flow,
+        );
+      }
+      if (dryRun) return toPreviewResult(response);
+
+      const withUrl = await options.confirmation.ensurePostUrl(
+        response,
+        adapter.id,
+        tab.id,
+        text,
+        expectedUser,
+      );
+      if (withUrl.url) return { ...withUrl, confirmed: true };
+      return unconfirmedPostResult(adapter.id, {
+        ...withUrl.flow,
+        tabUrlBefore,
+        failedStep: withUrl.flow?.failedStep ?? 'capture-url',
+        submitReached: withUrl.flow?.submitReached ?? true,
+      });
+    } catch (error) {
+      if (
+        typeof ownedTabId === 'number' &&
+        response?.flow?.submitReached !== true
+      ) {
+        await closeOwnedAttemptTab(adapter.id, ownedTabId, attempt.label);
+      }
+      throw error;
+    }
+  }
+
+  async function closeOwnedAttemptTab(
+    platform: PlatformId,
+    tabId: number,
+    attemptLabel: string,
+  ): Promise<void> {
+    log.info(
+      `${platform}: closing failed pre-submit attempt tab ` +
+      `(${attemptLabel}, tabId=${tabId}) before retry`,
+    );
+    options.openedTabs.forget(platform, tabId);
+    await closeTabSafely(tabId);
+  }
+
+  return { postSingleChunkWithRetry };
+}
+
+export function resolveApiPostOutcome(
+  platform: PlatformId,
+  apiResult: ApiPostResult | 'no-credentials',
+  baseFlow: Partial<PostFlowTrace> = {},
+): PostResultMessage | null {
+  if (apiResult === 'no-credentials') return null;
+  const flow = {
+    ...baseFlow,
+    attempt: 'api',
+  };
+  if (apiResult.success && apiResult.postUrl) {
+    return withFlow({
+      type: 'POST_RESULT',
+      platform,
+      success: true,
+      confirmed: true,
+      url: apiResult.postUrl,
+    }, {
+      ...flow,
+      submitReached: true,
+      lastCompletedStep: 'api-create-post',
+    });
+  }
+  if (apiResult.success || apiResult.uncertain) {
+    return unconfirmedPostResult(platform, {
+      ...flow,
+      submitReached: true,
+      lastCompletedStep: 'api-create-post',
+      failedStep: 'capture-url',
+    });
+  }
+  return withFlow({
+    type: 'POST_RESULT',
+    platform,
+    success: false,
+    error: apiResult.error ?? t('runtimeUnknownError'),
+  }, {
+    ...flow,
+    submitReached: false,
+    failedStep: 'api-post',
+  });
+}
+
+export function getComposeUrlForMedia(
+  adapter: PlatformAdapter,
+  text: string,
+  images?: readonly ImageAttachment[],
+): string {
+  return resolveComposeUrlForMedia(
+    adapter.id,
+    adapter.getComposeUrl(text),
+    images,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Depends on #111.
Closes #112.
Parent: #12.

## Summary
- extract single-chunk API/DOM transport selection and compose dispatch
- extract safe pre-submit retries and owned-attempt tab cleanup
- retain PostConfirmation and DomAttemptPolicy as explicit dependencies
- preserve no transport fallback after API selection and submitReached retry stop
- guard platform-poster as chunk/thread orchestration only

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build
- transport boundary integration tests PASS

## Release gate
- [ ] rebase onto merged dependency
- [ ] build the final exact artifact
- [ ] pass full Surface preview and affected real posting cases before merge