### PR TITLE
refactor: extract stored API URL capture strategy

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import {
@@ -77,6 +77,16 @@ describe('platform architecture guard', () => {
       violations,
       allowances: PLATFORM_LITERAL_ALLOWANCES,
     });
+  });
+
+  it('keeps stored page-world API URL capture in its strategy module', () => {
+    const capture = readFileSync('src/background/post-url-capture.ts', 'utf8');
+
+    expect(capture).toContain("from './post-url-stored-api'");
+    expect(capture).not.toContain("'tutti:ig-latest-post'");
+    expect(capture).not.toContain("'tutti:mastodon-latest-post'");
+    expect(capture).not.toContain("'tutti:threads-latest-post'");
+    expect(capture).not.toContain("'tutti:tumblr-latest-post'");
   });
 });
 

--- a/src/background/post-url-capture.ts
+++ b/src/background/post-url-capture.ts
@@ -5,8 +5,9 @@ import {
   isRenderedProfileFallbackPlatform,
 } from './post-url-rendered-profile';
 import { getSettings } from '../storage';
-import { normalizeCaptureText, readFreshCapturedPost } from '../utils/post-capture-record';
+import { normalizeCaptureText } from '../utils/post-capture-record';
 import { retryTransientTabAction } from './tab-action-retry';
+import { captureStoredApiPostUrl } from './post-url-stored-api';
 
 export interface CapturePostUrlOptions {
   platform: PlatformId;
@@ -429,59 +430,6 @@ async function resolveExpectedUserForCapture(
   } catch (e) {
     dbg(`expected user storage lookup failed: ${e instanceof Error ? e.message : String(e)}`);
   }
-  return undefined;
-}
-
-async function captureStoredApiPostUrl(
-  platform: PlatformId,
-  tabId: number,
-  text: string,
-  dbg: (message: string) => void,
-  minCapturedAt?: number,
-): Promise<string | undefined> {
-  const key = platform === 'instagram'
-    ? 'tutti:ig-latest-post'
-    : platform === 'mastodon'
-      ? 'tutti:mastodon-latest-post'
-    : platform === 'threads'
-      ? 'tutti:threads-latest-post'
-    : platform === 'tumblr'
-      ? 'tutti:tumblr-latest-post'
-      : undefined;
-  if (!key) return undefined;
-
-  for (let i = 0; i < 30; i += 1) {
-    try {
-      const results = await browser.scripting.executeScript({
-        target: { tabId },
-        func: (storageKey: string) => {
-          try {
-            return localStorage.getItem(storageKey);
-          } catch {
-            return null;
-          }
-        },
-        args: [key],
-        world: 'MAIN',
-      });
-      const raw = results?.[0]?.result;
-      const record = readFreshCapturedPost(typeof raw === 'string' ? raw : null, text, 120_000);
-      if (record && minCapturedAt && record.capturedAt < minCapturedAt) {
-        dbg(`stored API response is stale (capturedAt=${record.capturedAt}, min=${minCapturedAt})`);
-        await sleep(500);
-        continue;
-      }
-      if (record?.url) {
-        dbg(`URL captured via stored API response: ${record.url}`);
-        return record.url;
-      }
-    } catch (e) {
-      dbg(`stored API response read failed: ${e instanceof Error ? e.message : String(e)}`);
-      return undefined;
-    }
-    await sleep(500);
-  }
-  dbg('stored API response URL not found');
   return undefined;
 }
 

--- a/src/background/post-url-stored-api.test.ts
+++ b/src/background/post-url-stored-api.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  captureStoredApiPostUrl,
+  storedApiCaptureKey,
+} from './post-url-stored-api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('stored API post URL capture', () => {
+  it('owns the four page-world capture storage keys', () => {
+    expect(storedApiCaptureKey('instagram')).toBe('tutti:ig-latest-post');
+    expect(storedApiCaptureKey('mastodon')).toBe('tutti:mastodon-latest-post');
+    expect(storedApiCaptureKey('threads')).toBe('tutti:threads-latest-post');
+    expect(storedApiCaptureKey('tumblr')).toBe('tutti:tumblr-latest-post');
+    expect(storedApiCaptureKey('x')).toBeUndefined();
+  });
+
+  it('reads a fresh matching record in the MAIN world', async () => {
+    const executeScript = vi.fn(async () => [{
+      result: JSON.stringify({
+        url: 'https://www.threads.com/@komm64/post/ABC_def_123',
+        capturedAt: Date.now(),
+      }),
+    }]);
+    vi.stubGlobal('browser', { scripting: { executeScript } });
+    const debug = vi.fn();
+
+    await expect(captureStoredApiPostUrl(
+      'threads',
+      42,
+      'hello',
+      debug,
+    )).resolves.toBe('https://www.threads.com/@komm64/post/ABC_def_123');
+
+    expect(executeScript).toHaveBeenCalledWith(expect.objectContaining({
+      target: { tabId: 42 },
+      args: ['tutti:threads-latest-post'],
+      world: 'MAIN',
+    }));
+    expect(debug).toHaveBeenCalledWith(
+      'URL captured via stored API response: ' +
+      'https://www.threads.com/@komm64/post/ABC_def_123',
+    );
+  });
+
+  it('returns immediately for platforms without a stored API strategy', async () => {
+    const executeScript = vi.fn();
+    vi.stubGlobal('browser', { scripting: { executeScript } });
+
+    await expect(captureStoredApiPostUrl(
+      'bluesky',
+      42,
+      'hello',
+      vi.fn(),
+    )).resolves.toBeUndefined();
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+});

--- a/src/background/post-url-stored-api.ts
+++ b/src/background/post-url-stored-api.ts
@@ -1,0 +1,74 @@
+import type { PlatformId } from '../types/platform';
+import { readFreshCapturedPost } from '../utils/post-capture-record';
+
+const STORED_API_CAPTURE_KEYS: Partial<Record<PlatformId, string>> = {
+  instagram: 'tutti:ig-latest-post',
+  mastodon: 'tutti:mastodon-latest-post',
+  threads: 'tutti:threads-latest-post',
+  tumblr: 'tutti:tumblr-latest-post',
+};
+
+export function storedApiCaptureKey(
+  platform: PlatformId,
+): string | undefined {
+  return STORED_API_CAPTURE_KEYS[platform];
+}
+
+export async function captureStoredApiPostUrl(
+  platform: PlatformId,
+  tabId: number,
+  text: string,
+  debug: (message: string) => void,
+  minCapturedAt?: number,
+): Promise<string | undefined> {
+  const key = storedApiCaptureKey(platform);
+  if (!key) return undefined;
+
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const results = await browser.scripting.executeScript({
+        target: { tabId },
+        func: (storageKey: string) => {
+          try {
+            return localStorage.getItem(storageKey);
+          } catch {
+            return null;
+          }
+        },
+        args: [key],
+        world: 'MAIN',
+      });
+      const raw = results?.[0]?.result;
+      const record = readFreshCapturedPost(
+        typeof raw === 'string' ? raw : null,
+        text,
+        120_000,
+      );
+      if (record && minCapturedAt && record.capturedAt < minCapturedAt) {
+        debug(
+          `stored API response is stale ` +
+          `(capturedAt=${record.capturedAt}, min=${minCapturedAt})`,
+        );
+        await sleep(500);
+        continue;
+      }
+      if (record?.url) {
+        debug(`URL captured via stored API response: ${record.url}`);
+        return record.url;
+      }
+    } catch (error) {
+      debug(
+        `stored API response read failed: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    }
+    await sleep(500);
+  }
+  debug('stored API response URL not found');
+  return undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Closes #116.
Parent: #12.

## Summary
- extract stored page-world API URL capture for Instagram, Mastodon, Threads, and Tumblr
- centralize capture storage keys in the strategy
- preserve MAIN-world read, 120s freshness, minCapturedAt rejection, retries, and traces
- add strategy tests and an architecture guard

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] build the final exact artifact
- [ ] pass full Surface preview and affected real URL-capture cases before merge