### PR TITLE
refactor: extract Mastodon URL capture strategy

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -88,6 +88,15 @@ describe('platform architecture guard', () => {
     expect(capture).not.toContain("'tutti:threads-latest-post'");
     expect(capture).not.toContain("'tutti:tumblr-latest-post'");
   });
+
+  it('keeps Mastodon public API URL capture in its strategy module', () => {
+    const capture = readFileSync('src/background/post-url-capture.ts', 'utf8');
+
+    expect(capture).toContain("from './post-url-mastodon-api'");
+    expect(capture).not.toMatch(
+      /\bfunction (?:captureMastodonPostViaPublicApi|fetchMastodonAccountId|inferMastodonInstance|resolveMastodonIdentity|stripHtml)\b/,
+    );
+  });
 });
 
 function productionTypeScriptFiles(root: string): string[] {

--- a/src/background/post-url-capture.ts
+++ b/src/background/post-url-capture.ts
@@ -4,10 +4,9 @@ import {
   captureRenderedProfilePostUrl,
   isRenderedProfileFallbackPlatform,
 } from './post-url-rendered-profile';
-import { getSettings } from '../storage';
-import { normalizeCaptureText } from '../utils/post-capture-record';
 import { retryTransientTabAction } from './tab-action-retry';
 import { captureStoredApiPostUrl } from './post-url-stored-api';
+import { captureMastodonPostViaPublicApi } from './post-url-mastodon-api';
 
 export interface CapturePostUrlOptions {
   platform: PlatformId;
@@ -431,113 +430,6 @@ async function resolveExpectedUserForCapture(
     dbg(`expected user storage lookup failed: ${e instanceof Error ? e.message : String(e)}`);
   }
   return undefined;
-}
-
-async function captureMastodonPostViaPublicApi(
-  tabId: number,
-  text: string,
-  expectedUser: string | undefined,
-  dbg: (message: string) => void,
-): Promise<string | undefined> {
-  const target = normalizeCaptureText(text).slice(0, 60);
-  if (!target) return undefined;
-
-  const identity = await resolveMastodonIdentity(tabId, expectedUser);
-  if (!identity.acct) {
-    dbg('Mastodon public API fallback skipped: account unknown');
-    return undefined;
-  }
-
-  const accountId = await fetchMastodonAccountId(identity.instance, identity.acct, dbg);
-  if (!accountId) return undefined;
-
-  for (let i = 0; i < 12; i += 1) {
-    if (i > 0) await sleep(1000);
-    try {
-      const statusesUrl = `${identity.instance}/api/v1/accounts/${encodeURIComponent(accountId)}/statuses?limit=10&exclude_replies=false&exclude_reblogs=true`;
-      const res = await fetch(statusesUrl, { cache: 'no-store' });
-      dbg(`Mastodon public API statuses attempt ${i}: ${res.status}`);
-      if (!res.ok) continue;
-      const statuses = await res.json() as Array<{ url?: string | null; uri?: string; content?: string }>;
-      for (const status of statuses) {
-        const body = normalizeCaptureText(stripHtml(status.content ?? ''));
-        dbg(`  cmp "${body.slice(0, 30)}" vs "${target.slice(0, 30)}"`);
-        if (!body.startsWith(target)) continue;
-        const url = status.url || status.uri;
-        if (url) {
-          dbg(`URL captured via Mastodon public API: ${url}`);
-          return url;
-        }
-      }
-    } catch (e) {
-      dbg(`Mastodon public API statuses failed: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
-  return undefined;
-}
-
-async function resolveMastodonIdentity(
-  tabId: number,
-  expectedUser: string | undefined,
-): Promise<{ instance: string; acct?: string }> {
-  let instance = await inferMastodonInstance(tabId);
-  const raw = expectedUser?.trim().replace(/^@/, '') ?? '';
-  if (!raw) return { instance };
-
-  const federated = raw.match(/^([^@]+)@([^@]+)$/);
-  if (federated?.[1] && federated?.[2]) {
-    instance = `https://${federated[2]}`;
-    return { instance, acct: federated[1] };
-  }
-
-  return { instance, acct: raw };
-}
-
-async function inferMastodonInstance(tabId: number): Promise<string> {
-  try {
-    const tab = await browser.tabs.get(tabId);
-    if (tab.url) {
-      const url = new URL(tab.url);
-      if (url.protocol === 'https:') return url.origin;
-    }
-  } catch { /* fall through to settings */ }
-
-  try {
-    return (await getSettings()).mastodonInstance;
-  } catch {
-    return 'https://mastodon.social';
-  }
-}
-
-async function fetchMastodonAccountId(
-  instance: string,
-  acct: string,
-  dbg: (message: string) => void,
-): Promise<string | undefined> {
-  try {
-    const lookupUrl = `${instance}/api/v1/accounts/lookup?acct=${encodeURIComponent(acct)}`;
-    const res = await fetch(lookupUrl, { cache: 'no-store' });
-    dbg(`Mastodon public API lookup: ${res.status}`);
-    if (!res.ok) return undefined;
-    const data = await res.json() as { id?: string };
-    return data.id;
-  } catch (e) {
-    dbg(`Mastodon public API lookup failed: ${e instanceof Error ? e.message : String(e)}`);
-    return undefined;
-  }
-}
-
-function stripHtml(value: string): string {
-  return value
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"');
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/background/post-url-mastodon-api.test.ts
+++ b/src/background/post-url-mastodon-api.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureMastodonPostViaPublicApi } from './post-url-mastodon-api';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Mastodon public API post URL capture', () => {
+  it('resolves the local account and matches normalized status text', async () => {
+    vi.stubGlobal('browser', {
+      tabs: {
+        get: vi.fn(async () => ({
+          url: 'https://social.example/home',
+        })),
+      },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ id: 'account-42' }),
+        { status: 200 },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify([{
+          url: 'https://social.example/@alice/123',
+          content: '<p>Hello &amp; welcome<br>from Tutti</p>',
+        }]),
+        { status: 200 },
+      ));
+    vi.stubGlobal('fetch', fetchMock);
+    const debug = vi.fn();
+
+    await expect(captureMastodonPostViaPublicApi(
+      42,
+      'Hello & welcome from Tutti',
+      '@alice',
+      debug,
+    )).resolves.toBe('https://social.example/@alice/123');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://social.example/api/v1/accounts/lookup?acct=alice',
+      { cache: 'no-store' },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://social.example/api/v1/accounts/account-42/' +
+      'statuses?limit=10&exclude_replies=false&exclude_reblogs=true',
+      { cache: 'no-store' },
+    );
+  });
+
+  it('uses the federated account domain instead of the compose tab instance', async () => {
+    vi.stubGlobal('browser', {
+      tabs: {
+        get: vi.fn(async () => ({
+          url: 'https://local.example/home',
+        })),
+      },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ id: 'remote-42' }),
+        { status: 200 },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify([{
+          uri: 'https://remote.example/users/alice/statuses/456',
+          content: '<p>Federated hello</p>',
+        }]),
+        { status: 200 },
+      ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(captureMastodonPostViaPublicApi(
+      42,
+      'Federated hello',
+      '@alice@remote.example',
+      vi.fn(),
+    )).resolves.toBe('https://remote.example/users/alice/statuses/456');
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://remote.example/api/v1/accounts/lookup?acct=alice',
+    );
+  });
+});

--- a/src/background/post-url-mastodon-api.ts
+++ b/src/background/post-url-mastodon-api.ts
@@ -1,0 +1,130 @@
+import { getSettings } from '../storage';
+import { normalizeCaptureText } from '../utils/post-capture-record';
+
+export async function captureMastodonPostViaPublicApi(
+  tabId: number,
+  text: string,
+  expectedUser: string | undefined,
+  debug: (message: string) => void,
+): Promise<string | undefined> {
+  const target = normalizeCaptureText(text).slice(0, 60);
+  if (!target) return undefined;
+
+  const identity = await resolveMastodonIdentity(tabId, expectedUser);
+  if (!identity.acct) {
+    debug('Mastodon public API fallback skipped: account unknown');
+    return undefined;
+  }
+
+  const accountId = await fetchMastodonAccountId(
+    identity.instance,
+    identity.acct,
+    debug,
+  );
+  if (!accountId) return undefined;
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    if (attempt > 0) await sleep(1000);
+    try {
+      const statusesUrl =
+        `${identity.instance}/api/v1/accounts/${encodeURIComponent(accountId)}` +
+        '/statuses?limit=10&exclude_replies=false&exclude_reblogs=true';
+      const response = await fetch(statusesUrl, { cache: 'no-store' });
+      debug(`Mastodon public API statuses attempt ${attempt}: ${response.status}`);
+      if (!response.ok) continue;
+      const statuses = await response.json() as Array<{
+        url?: string | null;
+        uri?: string;
+        content?: string;
+      }>;
+      for (const status of statuses) {
+        const body = normalizeCaptureText(stripHtml(status.content ?? ''));
+        debug(`  cmp "${body.slice(0, 30)}" vs "${target.slice(0, 30)}"`);
+        if (!body.startsWith(target)) continue;
+        const url = status.url || status.uri;
+        if (url) {
+          debug(`URL captured via Mastodon public API: ${url}`);
+          return url;
+        }
+      }
+    } catch (error) {
+      debug(
+        `Mastodon public API statuses failed: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return undefined;
+}
+
+async function resolveMastodonIdentity(
+  tabId: number,
+  expectedUser: string | undefined,
+): Promise<{ instance: string; acct?: string }> {
+  let instance = await inferMastodonInstance(tabId);
+  const raw = expectedUser?.trim().replace(/^@/, '') ?? '';
+  if (!raw) return { instance };
+
+  const federated = raw.match(/^([^@]+)@([^@]+)$/);
+  if (federated?.[1] && federated?.[2]) {
+    instance = `https://${federated[2]}`;
+    return { instance, acct: federated[1] };
+  }
+
+  return { instance, acct: raw };
+}
+
+async function inferMastodonInstance(tabId: number): Promise<string> {
+  try {
+    const tab = await browser.tabs.get(tabId);
+    if (tab.url) {
+      const url = new URL(tab.url);
+      if (url.protocol === 'https:') return url.origin;
+    }
+  } catch { /* fall through to settings */ }
+
+  try {
+    return (await getSettings()).mastodonInstance;
+  } catch {
+    return 'https://mastodon.social';
+  }
+}
+
+async function fetchMastodonAccountId(
+  instance: string,
+  acct: string,
+  debug: (message: string) => void,
+): Promise<string | undefined> {
+  try {
+    const lookupUrl =
+      `${instance}/api/v1/accounts/lookup?acct=${encodeURIComponent(acct)}`;
+    const response = await fetch(lookupUrl, { cache: 'no-store' });
+    debug(`Mastodon public API lookup: ${response.status}`);
+    if (!response.ok) return undefined;
+    const data = await response.json() as { id?: string };
+    return data.id;
+  } catch (error) {
+    debug(
+      `Mastodon public API lookup failed: ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Depends on #117.
Closes #118.
Parent: #12.

## Summary
- extract Mastodon identity resolution and public account/status lookup
- preserve local and federated account routing, settings fallback, polling, HTML normalization, URI fallback, and traces
- add focused strategy tests and extend the capture architecture guard

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] rebase onto merged dependency
- [ ] build final exact artifact
- [ ] pass full Surface preview and Mastodon real URL-capture before merge