### PR TITLE
refactor: extract YouTube Studio URL capture strategy

### DIFF
--- a/src/background/platform-architecture.test.ts
+++ b/src/background/platform-architecture.test.ts
@@ -106,6 +106,16 @@ describe('platform architecture guard', () => {
     expect(capture).not.toContain("platformName === 'x'");
     expect(capture).not.toContain("localStorage.getItem('BSKY_STORAGE')");
   });
+
+  it('keeps YouTube Studio completion in its strategy module', () => {
+    const capture = readFileSync('src/background/post-url-capture.ts', 'utf8');
+
+    expect(capture).toContain("from './post-url-youtube-studio'");
+    expect(capture).not.toMatch(
+      /\bfunction (?:captureYouTubeStudioPostUrlFromTab|captureYouTubeStudioPostUrlInPage)\b/,
+    );
+    expect(capture).not.toContain('reload YouTube Studio before URL capture');
+  });
 });
 
 function productionTypeScriptFiles(root: string): string[] {

--- a/src/background/post-url-capture.test.ts
+++ b/src/background/post-url-capture.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { Window } from 'happy-dom';
 import {
   buildPostUrlCaptureRetryPlan,
   buildPostUrlCaptureScriptArgs,
-  captureYouTubeStudioPostUrlInPage,
 } from './post-url-capture';
 
 describe('post URL capture retry plan', () => {
@@ -77,33 +75,5 @@ describe('post URL capture script arguments', () => {
       undefined,
       Number.NaN,
     )).toEqual(['youtube', 'short title', null, null]);
-  });
-});
-
-describe('YouTube Studio post URL capture', () => {
-  it('finds the matching video card without depending on the localized dashboard heading', async () => {
-    const window = new Window();
-    window.document.body.innerHTML = `
-      <a href="https://studio.youtube.com/video/older-video/edit">Older video</a>
-      <section>
-        <div>Latest video performance</div>
-        <article>
-          <h2 id="title">tutti surface matrix video 2026-07-25T23-42-46</h2>
-          <div>
-            <a href="https://studio.youtube.com/video/new-video-id/analytics/tab-overview">
-              Analytics
-            </a>
-          </div>
-        </article>
-      </section>
-    `;
-
-    await expect(captureYouTubeStudioPostUrlInPage(
-      'tutti surface matrix video 2026-07-25',
-      window.document as unknown as ParentNode,
-    )).resolves.toEqual({
-      url: 'https://www.youtube.com/watch?v=new-video-id',
-      trace: ['matched target title in scoped video card (attempt=0, depth=1)'],
-    });
   });
 });

--- a/src/background/post-url-capture.ts
+++ b/src/background/post-url-capture.ts
@@ -1,13 +1,12 @@
 import type { PlatformId } from '../types/platform';
-import { waitForTabComplete } from './tab-management';
 import {
   captureRenderedProfilePostUrl,
   isRenderedProfileFallbackPlatform,
 } from './post-url-rendered-profile';
-import { retryTransientTabAction } from './tab-action-retry';
 import { captureStoredApiPostUrl } from './post-url-stored-api';
 import { captureMastodonPostViaPublicApi } from './post-url-mastodon-api';
 import { capturePostUrlInPage } from './post-url-in-page';
+import { captureYouTubeStudioPostUrlFromTab } from './post-url-youtube-studio';
 
 export interface CapturePostUrlOptions {
   platform: PlatformId;
@@ -86,46 +85,6 @@ export function buildPostUrlCaptureScriptArgs(
   ];
 }
 
-export async function captureYouTubeStudioPostUrlInPage(
-  targetText: string,
-  root: ParentNode = document,
-): Promise<{ url?: string; trace: string[] }> {
-  const trace: string[] = [];
-  if (!targetText) return { trace };
-
-  const normalize = (value: string | null | undefined): string => (
-    (value ?? '').replace(/\s+/g, ' ').trim()
-  );
-  const titleSelector = 'h1, h2, h3, [id*="title"], ytcp-thumbnail-with-title';
-
-  for (let attempt = 0; attempt < 120; attempt += 1) {
-    const titleNodes = Array.from(root.querySelectorAll<HTMLElement>(titleSelector))
-      .filter((element) => normalize(element.textContent).includes(targetText))
-      .sort((a, b) => normalize(a.textContent).length - normalize(b.textContent).length);
-
-    for (const titleNode of titleNodes) {
-      let scope: Element | null = titleNode;
-      for (let depth = 0; scope && depth < 8; depth += 1, scope = scope.parentElement) {
-        const links = Array.from(scope.querySelectorAll<HTMLAnchorElement>('a[href*="/video/"]'));
-        for (const link of links) {
-          const id = link.href.match(/\/video\/([\w-]+)(?:\/|$)/)?.[1];
-          if (id) {
-            trace.push(`matched target title in scoped video card (attempt=${attempt}, depth=${depth})`);
-            return { url: `https://www.youtube.com/watch?v=${id}`, trace };
-          }
-        }
-      }
-    }
-
-    if (attempt === 0) {
-      trace.push(`target title matches=${titleNodes.length}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-
-  return { trace };
-}
-
 export async function capturePostUrlFromTabWithRetry(
   options: CapturePostUrlOptions,
 ): Promise<string | undefined> {
@@ -181,37 +140,9 @@ export async function capturePostUrlFromTab(options: CapturePostUrlOptions): Pro
     if (platform === 'tumblr') {
       await sleep(1000);
     }
-    if (platform === 'youtube') {
-      dbg('reload Studio dashboard before latest Short lookup');
-      await retryTransientTabAction('reload YouTube Studio before URL capture', () => (
-        browser.tabs.reload(tabId)
-      ));
-      await waitForTabComplete(tabId);
-      await sleep(1000);
-    }
-
     const target = text.replace(/\s+/g, ' ').trim().slice(0, 60);
     if (platform === 'youtube') {
-      const youtubeResults = await browser.scripting.executeScript({
-        target: { tabId },
-        func: captureYouTubeStudioPostUrlInPage,
-        args: [target],
-        world: 'MAIN',
-      });
-      dbg(`scripting result count=${youtubeResults?.length}`);
-      const youtubeResult = youtubeResults?.[0]?.result as {
-        url?: string;
-        trace?: string[];
-      } | null | undefined;
-      for (const line of youtubeResult?.trace?.slice(0, 30) ?? []) {
-        dbg(`  ${line}`);
-      }
-      if (typeof youtubeResult?.url === 'string') {
-        dbg(`URL captured: ${youtubeResult.url}`);
-        return youtubeResult.url;
-      }
-      dbg('URL not found');
-      return undefined;
+      return await captureYouTubeStudioPostUrlFromTab(tabId, target, dbg);
     }
 
     const scriptArgs = buildPostUrlCaptureScriptArgs(

--- a/src/background/post-url-youtube-studio.test.ts
+++ b/src/background/post-url-youtube-studio.test.ts
@@ -1,0 +1,31 @@
+import { Window } from 'happy-dom';
+import { describe, expect, it } from 'vitest';
+import { captureYouTubeStudioPostUrlInPage } from './post-url-youtube-studio';
+
+describe('YouTube Studio post URL capture', () => {
+  it('finds the matching video card without depending on the localized dashboard heading', async () => {
+    const window = new Window();
+    window.document.body.innerHTML = `
+      <a href="https://studio.youtube.com/video/older-video/edit">Older video</a>
+      <section>
+        <div>Latest video performance</div>
+        <article>
+          <h2 id="title">tutti surface matrix video 2026-07-25T23-42-46</h2>
+          <div>
+            <a href="https://studio.youtube.com/video/new-video-id/analytics/tab-overview">
+              Analytics
+            </a>
+          </div>
+        </article>
+      </section>
+    `;
+
+    await expect(captureYouTubeStudioPostUrlInPage(
+      'tutti surface matrix video 2026-07-25',
+      window.document as unknown as ParentNode,
+    )).resolves.toEqual({
+      url: 'https://www.youtube.com/watch?v=new-video-id',
+      trace: ['matched target title in scoped video card (attempt=0, depth=1)'],
+    });
+  });
+});

--- a/src/background/post-url-youtube-studio.ts
+++ b/src/background/post-url-youtube-studio.ts
@@ -1,0 +1,100 @@
+import { retryTransientTabAction } from './tab-action-retry';
+import { waitForTabComplete } from './tab-management';
+
+export interface YouTubeStudioCaptureResult {
+  url?: string;
+  trace: string[];
+}
+
+export async function captureYouTubeStudioPostUrlFromTab(
+  tabId: number,
+  targetText: string,
+  debug: (message: string) => void,
+): Promise<string | undefined> {
+  debug('reload Studio dashboard before latest Short lookup');
+  await retryTransientTabAction('reload YouTube Studio before URL capture', () => (
+    browser.tabs.reload(tabId)
+  ));
+  await waitForTabComplete(tabId);
+  await sleep(1000);
+
+  const results = await browser.scripting.executeScript({
+    target: { tabId },
+    func: captureYouTubeStudioPostUrlInPage,
+    args: [targetText],
+    world: 'MAIN',
+  });
+  debug(`scripting result count=${results?.length}`);
+  const result = results?.[0]?.result as YouTubeStudioCaptureResult | null | undefined;
+  for (const line of result?.trace?.slice(0, 30) ?? []) {
+    debug(`  ${line}`);
+  }
+  if (typeof result?.url === 'string') {
+    debug(`URL captured: ${result.url}`);
+    return result.url;
+  }
+  debug('URL not found');
+  return undefined;
+}
+
+export async function captureYouTubeStudioPostUrlInPage(
+  targetText: string,
+  root: ParentNode = document,
+): Promise<YouTubeStudioCaptureResult> {
+  const trace: string[] = [];
+  if (!targetText) return { trace };
+
+  const normalize = (value: string | null | undefined): string => (
+    (value ?? '').replace(/\s+/g, ' ').trim()
+  );
+  const titleSelector = 'h1, h2, h3, [id*="title"], ytcp-thumbnail-with-title';
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const titleNodes = Array.from(
+      root.querySelectorAll<HTMLElement>(titleSelector),
+    )
+      .filter((element) => normalize(element.textContent).includes(targetText))
+      .sort(
+        (first, second) => (
+          normalize(first.textContent).length - normalize(second.textContent).length
+        ),
+      );
+
+    for (const titleNode of titleNodes) {
+      let scope: Element | null = titleNode;
+      for (
+        let depth = 0;
+        scope && depth < 8;
+        depth += 1, scope = scope.parentElement
+      ) {
+        const links = Array.from(
+          scope.querySelectorAll<HTMLAnchorElement>('a[href*="/video/"]'),
+        );
+        for (const link of links) {
+          const id = link.href.match(/\/video\/([\w-]+)(?:\/|$)/)?.[1];
+          if (id) {
+            trace.push(
+              `matched target title in scoped video card ` +
+              `(attempt=${attempt}, depth=${depth})`,
+            );
+            return {
+              url: `https://www.youtube.com/watch?v=${id}`,
+              trace,
+            };
+          }
+        }
+      }
+    }
+
+    if (attempt === 0) {
+      trace.push(`target title matches=${titleNodes.length}`);
+    }
+    await sleep(500);
+  }
+
+  return { trace };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Depends on #121.
Closes #122.
Parent: #12.

## Summary
- extract Studio dashboard reload and completion wait
- extract closure-free scoped title-card lookup and watch URL construction
- preserve MAIN-world execution, timing, traces, and localized-heading independence
- move the existing DOM characterization test and extend the architecture guard

## Verification
- npm run verify:commit
- npm run e2e:smoke:no-build

## Release gate
- [ ] rebase onto merged dependency
- [ ] build final exact artifact
- [ ] pass Surface YouTube preview and URL-capture case before merge