### PR TITLE
Fix X inline threads to submit in one action

### DIFF
--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -361,3 +361,4 @@ console.log('[verify-x-thread] PASS');
 await popup.close().catch(() => {});
 if (!cdpEndpoint) await ctx.close();
 if (browser) await disconnectCdp(browser).catch(() => {});
+process.exit(0);

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -219,8 +219,11 @@ const homeState = await xHome.evaluate(() => ({
   title: document.title,
 }));
 console.log('[verify-x-thread] home state:', JSON.stringify(homeState));
+if (homeState.hasLoginLink) {
+  await fail('The X verification profile is signed out.', homeState);
+}
 if (!homeState.hasTextarea) {
-  await fail('X home composer was not found. The verification profile is probably signed out.', homeState);
+  console.log('[verify-x-thread] home inline composer is absent; continuing with the production /compose/post route');
 }
 
 const text = [

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -61,6 +61,24 @@ function installXClickProbe() {
   }, true);
 }
 
+function attachDialogHandlers(context) {
+  const attached = new WeakSet();
+  const attach = (page) => {
+    if (!page || attached.has(page)) return;
+    attached.add(page);
+    page.on('dialog', async (dialog) => {
+      try {
+        await dialog.dismiss();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[verify-x-thread] ignored dialog after page detach: ${message}`);
+      }
+    });
+  };
+  for (const page of context.pages()) attach(page);
+  context.on('page', attach);
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -158,6 +176,7 @@ if (cdpEndpoint) {
   });
 }
 
+attachDialogHandlers(ctx);
 await ctx.exposeBinding('__tuttiE2ERecordXClick', ({ page }, marker) => {
   xClickEvents.push({
     marker: String(marker),

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -79,6 +79,32 @@ function attachDialogHandlers(context) {
   context.on('page', attach);
 }
 
+async function verifyPublishedInlineThread(context, postUrl) {
+  const page = await context.newPage();
+  try {
+    await page.goto(postUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForFunction(() => {
+      const texts = [...document.querySelectorAll('article')]
+        .map((article) => article.textContent ?? '');
+      return texts.some((value) => value.includes('(1/2)') && value.includes('Tutti X existing-home')) &&
+        texts.some((value) => value.includes('(2/2)') && value.includes('bravo'));
+    }, undefined, { timeout: 30000 });
+    const articles = await page.evaluate(() => (
+      [...document.querySelectorAll('article')].slice(0, 6)
+        .map((article) => (article.textContent ?? '').replace(/\s+/g, ' ').slice(0, 400))
+    ));
+    return { ok: true, url: page.url(), articles };
+  } catch (error) {
+    return {
+      ok: false,
+      url: page.url() || postUrl,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -296,14 +322,17 @@ if (postMode) {
   if (xResult.confirmed !== true || !xResult.url || xResult.flow?.submitReached !== true) {
     await fail('real X inline thread was not confirmed with a captured URL', xResult);
   }
-  if (clickSummary.addPost < 1) {
-    await fail('X inline thread did not use the Add post action', clickSummary);
-  }
   if (clickSummary.postAll !== 1) {
     await fail('X inline thread must click Post all exactly once', clickSummary);
   }
   if (clickSummary.singlePost !== 0) {
     await fail('X inline thread used the obsolete per-post submit action', clickSummary);
+  }
+
+  const published = await verifyPublishedInlineThread(ctx, xResult.url);
+  console.log('[verify-x-thread] published thread:', JSON.stringify(published, null, 2));
+  if (!published.ok) {
+    await fail('published X URL does not contain both inline thread posts', published);
   }
 
   console.log(`[verify-x-thread] published URL: ${xResult.url}`);

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -7,6 +7,7 @@
  *
  * Usage:
  *   node scripts/e2e/verify-x-thread-existing-home.mjs
+ *   node scripts/e2e/verify-x-thread-existing-home.mjs --post
  *   E2E_CDP=http://localhost:9222 E2E_EXTENSION_ID=<id> node scripts/e2e/verify-x-thread-existing-home.mjs --isolate-x-tabs
  */
 
@@ -30,6 +31,8 @@ const userDataDir = process.env.E2E_USER_DATA_DIR ?? resolve(repoRoot, '.tmp', '
 const isolateXTabs = process.argv.includes('--isolate-x-tabs');
 const skipExtensionReload = process.argv.includes('--skip-extension-reload');
 const includeImage = process.argv.includes('--image') || process.argv.includes('--with-image');
+const postMode = process.argv.includes('--post');
+const xClickEvents = [];
 
 let browser;
 let ctx;
@@ -42,6 +45,20 @@ async function fail(message, detail) {
   if (!cdpEndpoint && ctx) await ctx.close().catch(() => {});
   if (browser) await disconnectCdp(browser).catch(() => {});
   process.exit(1);
+}
+
+function installXClickProbe() {
+  if (globalThis.__tuttiE2EXClickProbeInstalled) return;
+  globalThis.__tuttiE2EXClickProbeInstalled = true;
+  document.addEventListener('click', (event) => {
+    const target = event.target instanceof Element
+      ? event.target.closest('[data-tutti-click-marker]')
+      : null;
+    const marker = target?.getAttribute('data-tutti-click-marker');
+    if (marker?.startsWith('tutti-x-')) {
+      void globalThis.__tuttiE2ERecordXClick?.(marker);
+    }
+  }, true);
 }
 
 function sleep(ms) {
@@ -112,7 +129,11 @@ async function openExtensionPage(path, attempts = 8) {
   await fail(`could not open extension page ${path}`, lastError?.message ?? String(lastError));
 }
 
-console.log(`[verify-x-thread] mode=${cdpEndpoint ? `CDP ${cdpEndpoint}` : `launch ${userDataDir}`} image=${includeImage ? 'yes' : 'no'}`);
+console.log(
+  `[verify-x-thread] mode=${postMode ? 'post' : 'preview'} ` +
+  `browser=${cdpEndpoint ? `CDP ${cdpEndpoint}` : `launch ${userDataDir}`} ` +
+  `image=${includeImage ? 'yes' : 'no'}`,
+);
 if (!cdpEndpoint && !existsSync(extensionDir)) {
   await fail(`extension build not found: ${extensionDir}`);
 }
@@ -136,6 +157,16 @@ if (cdpEndpoint) {
     ],
   });
 }
+
+await ctx.exposeBinding('__tuttiE2ERecordXClick', ({ page }, marker) => {
+  xClickEvents.push({
+    marker: String(marker),
+    url: page.url(),
+    capturedAt: new Date().toISOString(),
+  });
+});
+await ctx.addInitScript(installXClickProbe);
+await Promise.all(ctx.pages().map((page) => page.evaluate(installXClickProbe).catch(() => {})));
 
 const extensionId = await resolveExtensionId(ctx).catch(async () => {
   await fail('extension id not detected. Set E2E_EXTENSION_ID when attaching over CDP.');
@@ -169,11 +200,11 @@ await popup.waitForTimeout(1000);
 const version = await popup.evaluate(() => chrome.runtime.getManifest().version);
 console.log(`[verify-x-thread] version=${version}`);
 
-await popup.evaluate(async () => {
+await popup.evaluate(async (autoPost) => {
   const stored = (await chrome.storage.sync.get('settings')).settings ?? {};
-  await chrome.storage.sync.set({ settings: { ...stored, autoPost: false } });
-});
-console.log('[verify-x-thread] autoPost=false');
+  await chrome.storage.sync.set({ settings: { ...stored, autoPost } });
+}, postMode);
+console.log(`[verify-x-thread] autoPost=${postMode}`);
 
 let xHome = ctx.pages().find((page) => /^https:\/\/(x|twitter)\.com\//.test(page.url()));
 if (!xHome) xHome = await ctx.newPage();
@@ -227,6 +258,38 @@ console.log('[verify-x-thread] POST_REQUEST response:', JSON.stringify(postResp)
 const xResult = postResp?.results?.find?.((r) => r.platform === 'x');
 if (!xResult?.success) {
   await fail('POST_REQUEST did not report X success', postResp);
+}
+
+if (postMode) {
+  await popup.waitForTimeout(1500);
+  const markers = xClickEvents.map(({ marker }) => marker);
+  const clickSummary = {
+    addPost: markers.filter((marker) => marker.startsWith('tutti-x-add-post-')).length,
+    postAll: markers.filter((marker) => marker.startsWith('tutti-x-post-all-')).length,
+    singlePost: markers.filter((marker) => /^tutti-x-post-\d/.test(marker)).length,
+    events: xClickEvents,
+  };
+  console.log('[verify-x-thread] click summary:', JSON.stringify(clickSummary, null, 2));
+
+  if (xResult.confirmed !== true || !xResult.url || xResult.flow?.submitReached !== true) {
+    await fail('real X inline thread was not confirmed with a captured URL', xResult);
+  }
+  if (clickSummary.addPost < 1) {
+    await fail('X inline thread did not use the Add post action', clickSummary);
+  }
+  if (clickSummary.postAll !== 1) {
+    await fail('X inline thread must click Post all exactly once', clickSummary);
+  }
+  if (clickSummary.singlePost !== 0) {
+    await fail('X inline thread used the obsolete per-post submit action', clickSummary);
+  }
+
+  console.log(`[verify-x-thread] published URL: ${xResult.url}`);
+  console.log('[verify-x-thread] PASS');
+  await popup.close().catch(() => {});
+  if (!cdpEndpoint) await ctx.close();
+  if (browser) await disconnectCdp(browser).catch(() => {});
+  process.exit(0);
 }
 
 await xHome.waitForTimeout(3000);

--- a/src/background/platform-poster-inline-thread.test.ts
+++ b/src/background/platform-poster-inline-thread.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PostResultMessage, PostToPlatformMessage } from '../messages';
+
+const mocks = vi.hoisted(() => ({
+  openOrFocusTab: vi.fn(),
+  sendPostMessageWhenReady: vi.fn(),
+}));
+
+vi.mock('./tab-management', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./tab-management')>();
+  return {
+    ...actual,
+    openOrFocusTab: mocks.openOrFocusTab,
+  };
+});
+
+vi.mock('./content-dispatch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./content-dispatch')>();
+  return {
+    ...actual,
+    sendPostMessageWhenReady: mocks.sendPostMessageWhenReady,
+  };
+});
+
+vi.mock('../storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../storage')>();
+  return {
+    ...actual,
+    getLastSeenUsers: vi.fn(async () => ({})),
+  };
+});
+
+import { createPlatformPoster } from './platform-poster';
+
+describe('X inline thread orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.openOrFocusTab.mockResolvedValue({
+      tab: {
+        id: 42,
+        url: 'https://x.com/compose/post',
+        status: 'complete',
+      },
+      wasCreated: true,
+    });
+    mocks.sendPostMessageWhenReady.mockResolvedValue({
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      url: 'https://x.com/alice/status/123456789',
+    } satisfies PostResultMessage);
+
+    Object.assign((globalThis as typeof globalThis & { browser: Record<string, unknown> }).browser, {
+      tabs: {
+        get: vi.fn(async () => ({
+          id: 42,
+          url: 'https://x.com/compose/post',
+          status: 'complete',
+        })),
+      },
+    });
+  });
+
+  it('dispatches all real-post chunks to one compose request', async () => {
+    const poster = createPlatformPoster({
+      openedTabs: {
+        record: vi.fn(),
+        forget: vi.fn(),
+      },
+    });
+    const text = Array.from({ length: 120 }, (_, index) => `word${index}`).join(' ');
+
+    const result = await poster.postToPlatform('x', text, undefined, undefined, undefined, true);
+
+    expect(result).toMatchObject({
+      platform: 'x',
+      success: true,
+      confirmed: true,
+      url: 'https://x.com/alice/status/123456789',
+    });
+    expect(mocks.openOrFocusTab).toHaveBeenCalledTimes(1);
+    expect(mocks.sendPostMessageWhenReady).toHaveBeenCalledTimes(1);
+
+    const [, message] = mocks.sendPostMessageWhenReady.mock.calls[0] as [
+      number,
+      PostToPlatformMessage,
+    ];
+    expect(message.platform).toBe('x');
+    expect(message.dryRun).toBe(false);
+    expect(message.textChunks?.length).toBeGreaterThan(1);
+    expect(message.text).toBe(message.textChunks?.[0]);
+    expect(message.textChunks?.join('')).toContain('word119');
+  });
+});

--- a/src/background/platform-strategies.test.ts
+++ b/src/background/platform-strategies.test.ts
@@ -25,15 +25,13 @@ describe('background platform strategy registry', () => {
   it('derives continuation support and URLs from strategy membership', () => {
     expect(Object.entries(backgroundPlatformStrategies)
       .filter(([, strategy]) => strategy.continuationUrl)
-      .map(([platform]) => platform)).toEqual(['x', 'threads', 'mastodon']);
-    expect(continuationNeedsReplyUrl('x')).toBe(true);
+      .map(([platform]) => platform)).toEqual(['threads', 'mastodon']);
+    expect(continuationNeedsReplyUrl('x')).toBe(false);
     expect(continuationNeedsReplyUrl('mastodon')).toBe(true);
     expect(continuationNeedsReplyUrl('threads')).toBe(true);
     expect(continuationNeedsReplyUrl('bluesky')).toBe(false);
 
-    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/alice/status/123456')).toBe(
-      'https://x.com/intent/post?in_reply_to=123456',
-    );
+    expect(buildReplyOverrideUrl('x', 1, 'https://x.com/alice/status/123456')).toBeUndefined();
     expect(buildReplyOverrideUrl('mastodon', 1, 'https://mastodon.social/@alice/123')).toBe(
       'https://mastodon.social/@alice/123',
     );
@@ -48,7 +46,7 @@ describe('background platform strategy registry', () => {
   it('derives inline thread and API reply continuation policy from strategies', () => {
     expect(shouldUseInlineThread('bluesky', true)).toBe(true);
     expect(shouldUseInlineThread('x', false)).toBe(true);
-    expect(shouldUseInlineThread('x', true)).toBe(false);
+    expect(shouldUseInlineThread('x', true)).toBe(true);
     expect(shouldUseInlineThread('threads', false)).toBe(false);
 
     expect(canUseApiWithReplyUrl('mastodon', 'https://mastodon.social/@alice/123')).toBe(true);

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -72,12 +72,10 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   x: {
     parsePostId: ({ pathname }) => pathname.match(/\/status(?:es)?\/(\d+)/)?.[1] ?? null,
     inlineThread: {
-      shouldUse: (autoPost) => !autoPost,
+      // X の複数投稿は preview / 本投稿とも compose 上で全件を組み立て、
+      // 最後に "Post all" を 1 回だけ実行する。
+      shouldUse: () => true,
       forceForegroundPreview: true,
-    },
-    continuationUrl: (previousPostUrl) => {
-      const statusId = previousPostUrl.match(/\/status\/(\d+)/)?.[1];
-      return statusId ? `https://x.com/intent/post?in_reply_to=${statusId}` : undefined;
     },
     verifyPost: verifyXPost,
     capturePostUrl: capturePostUrlWithGenericFlow,


### PR DESCRIPTION
## Summary
- enable X inline thread composition for both preview and real posting
- remove the obsolete X `in_reply_to` continuation route
- add orchestration coverage proving a real multi-chunk X request dispatches once with all `textChunks`

## Verification
- focused X contracts PASS on the rebased branch
- `npm run verify:commit` PASS
- CI `verify`: PASS / merge state CLEAN
- final integration source (#143): architecture 17/114; full 111 files / 801 tests; production build PASS

## Exact-artifact Surface gate
- final integration commit: `b73f1a2d82d5e0c25fcc71803aa1751d9ce8aabd`
- extension `0.5.49`, id `heffmapbljoonmjghklgjhmfnldaeome`
- ZIP SHA-256: `F46C824255973F183BEAC9549BAE257FDE57C73BF123F21DC0009B77F4379D06`
- `background.js` SHA-256: `1A240027BB05AA3CABA70680085C37FB122B91180D9CF8A7CFA94DF1A8DD0C20`; staged Surface hashes matched
- non-Threads full preview matrix: 20 iterations / 140 results PASS; failures 0, timeouts 0, unsafe submits 0, URLs 0
- exact X real inline thread: PASS
  - published: https://x.com/ren_fujimoto/status/2081885643748331823
  - `success=true`, `confirmed=true`, `submitReached=true`
  - one `Post all` click; zero obsolete per-post submit clicks
  - published page contains both `(1/2)` and `(2/2)` posts
- Threads remains independently unavailable because the logged-in Surface profile receives HTTP 429 from the Threads intent endpoint; this X-only change does not alter Threads
- no CWS upload or submission

Closes #124