### PR TITLE
refactor: route Playwright E2E through CDP harness

### DIFF
--- a/scripts/e2e/cdp-harness.mjs
+++ b/scripts/e2e/cdp-harness.mjs
@@ -189,6 +189,12 @@ async function detectExtensionIdOnce(subject) {
     const rawUrl = typeof candidate.url === 'function' ? candidate.url() : candidate.url;
     const extensionId = extensionIdFromUrl(rawUrl);
     if (extensionId) return extensionId;
+    if (/^https?:/.test(String(rawUrl)) && typeof candidate.evaluate === 'function') {
+      const runtimeId = await candidate.evaluate(
+        () => globalThis.chrome?.runtime?.id ?? null,
+      ).catch(() => null);
+      if (runtimeId) return runtimeId;
+    }
   }
   return null;
 }

--- a/scripts/e2e/run.mjs
+++ b/scripts/e2e/run.mjs
@@ -18,6 +18,12 @@ import { chromium } from 'playwright';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
+import {
+  connectPlaywrightCdp,
+  disconnectCdp,
+  resolveCdpEndpoint,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
@@ -34,7 +40,7 @@ const userDataDir = process.env.E2E_USER_DATA_DIR
 // CDP attach mode: 起動中の Chromium に接続する (TikTok 等 session 継続性を見る
 // anti-bot 対策)。事前に Tutti-test-login.bat を `--remote-debugging-port=9222`
 // 付きで起動しておく必要がある。E2E_CDP=http://localhost:9222 で有効化
-const cdpEndpoint = process.env.E2E_CDP;
+const cdpEndpoint = resolveCdpEndpoint({ fallback: '' });
 
 if (!existsSync(extensionDir)) {
   console.error(`[e2e] extension dir not found: ${extensionDir}`);
@@ -56,11 +62,18 @@ async function openCtx(platform) {
   if (cdpEndpoint) {
     // 拡張ありの Chromium に attach する場合、Playwright の target 列挙が
     // 遅いことがあるので timeout を長めに
-    const browser = await chromium.connectOverCDP(cdpEndpoint, { timeout: 90_000 });
+    const browser = await connectPlaywrightCdp({
+      chromium,
+      endpoint: cdpEndpoint,
+      timeoutMs: 90_000,
+    });
     const ctxs = browser.contexts();
     const ctx = ctxs[0];
-    if (!ctx) throw new Error('[e2e] CDP: 既存 context が無い');
-    return { ctx, close: async () => { /* keep browser alive on CDP mode */ } };
+    if (!ctx) {
+      await disconnectCdp(browser);
+      throw new Error('[e2e] CDP: 既存 context が無い');
+    }
+    return { ctx, close: async () => { await disconnectCdp(browser); } };
   }
   const ctx = await chromium.launchPersistentContext(userDataDir, {
     headless: false,
@@ -85,11 +98,10 @@ for (const platform of platforms) {
   }
   console.log(`[e2e] launching Chrome for ${platform}...`);
   const { ctx, close } = await openCtx(platform);
-  const extensionId = process.env.E2E_EXTENSION_ID ?? await detectExtensionId(ctx);
-  console.log(`[e2e] extension id=${extensionId}`);
-
   let result;
   try {
+    const extensionId = await resolveExtensionId(ctx);
+    console.log(`[e2e] extension id=${extensionId}`);
     const mod = await import(`./platforms/${platform}.mjs`);
     result = await mod.run({ ctx, extensionId, debug });
     console.log(`[e2e] ${platform}: ${result.ok ? 'PASS' : 'FAIL'} ${result.note ?? ''}`);
@@ -109,19 +121,3 @@ for (const r of results) {
   if (!r.ok) allOk = false;
 }
 process.exit(allOk ? 0 : 1);
-
-async function detectExtensionId(ctx) {
-  // chrome://extensions/ の DOM から id を取る (Manifest V3)
-  // service worker URL が `chrome-extension://<id>/...` 形式なので、ctx の
-  // serviceWorkers() から id 抽出する方が速くて壊れにくい
-  for (let i = 0; i < 30; i++) {
-    const sws = ctx.serviceWorkers();
-    for (const sw of sws) {
-      const url = sw.url();
-      const m = url.match(/^chrome-extension:\/\/([a-z]+)\//);
-      if (m) return m[1];
-    }
-    await new Promise((r) => setTimeout(r, 200));
-  }
-  throw new Error('failed to detect extension id (service worker not found)');
-}

--- a/scripts/e2e/submit-current-pixiv-form.mjs
+++ b/scripts/e2e/submit-current-pixiv-form.mjs
@@ -1,24 +1,33 @@
 import { chromium } from 'playwright';
+import {
+  connectPlaywrightCdp,
+  disconnectCdp,
+} from './cdp-harness.mjs';
 
-const browser = await chromium.connectOverCDP(process.env.E2E_CDP ?? 'http://localhost:9222');
-const ctx = browser.contexts()[0];
-const page = ctx.pages().find((candidate) => /pixiv\.net\/illustration\/create/.test(candidate.url()));
-if (!page) {
-  console.error('Pixiv create page not found');
-  process.exit(2);
+const browser = await connectPlaywrightCdp({ chromium });
+try {
+  const ctx = browser.contexts()[0];
+  if (!ctx) throw new Error('browser context not found');
+  const page = ctx.pages().find((candidate) => /pixiv\.net\/illustration\/create/.test(candidate.url()));
+  if (!page) {
+    console.error('Pixiv create page not found');
+    process.exitCode = 2;
+  } else {
+    const clicked = await page.evaluate(() => {
+      const buttons = [...document.querySelectorAll('button')]
+        .filter((button) => /^(Post|投稿)$/.test(button.textContent?.trim() ?? ''))
+        .filter((button) => !button.disabled && button.getAttribute('aria-disabled') !== 'true')
+        .filter((button) => !button.className.includes('gtm-work-post-button-in-header-click'));
+      const target = buttons.at(-1);
+      if (!target) return false;
+      target.scrollIntoView({ block: 'center' });
+      target.click();
+      return true;
+    });
+    console.log(`clicked=${clicked}`);
+    await page.waitForTimeout(5000);
+    console.log(`url=${page.url()}`);
+  }
+} finally {
+  await disconnectCdp(browser);
 }
-const clicked = await page.evaluate(() => {
-  const buttons = [...document.querySelectorAll('button')]
-    .filter((button) => /^(Post|投稿)$/.test(button.textContent?.trim() ?? ''))
-    .filter((button) => !button.disabled && button.getAttribute('aria-disabled') !== 'true')
-    .filter((button) => !button.className.includes('gtm-work-post-button-in-header-click'));
-  const target = buttons.at(-1);
-  if (!target) return false;
-  target.scrollIntoView({ block: 'center' });
-  target.click();
-  return true;
-});
-console.log(`clicked=${clicked}`);
-await page.waitForTimeout(5000);
-console.log(`url=${page.url()}`);
-await browser.close();

--- a/scripts/e2e/verify-history-v1.mjs
+++ b/scripts/e2e/verify-history-v1.mjs
@@ -16,6 +16,12 @@ import { chromium } from 'playwright';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
+import {
+  connectPlaywrightCdp,
+  disconnectCdp,
+  resolveCdpEndpoint,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
@@ -24,7 +30,7 @@ const userDataDir = process.env.E2E_USER_DATA_DIR
   ?? resolve(process.env.USERPROFILE ?? process.env.HOME ?? '/tmp', '.tutti-e2e-chrome');
 
 const keepMedia = process.argv.includes('--keep-media');
-const cdpEndpoint = process.env.E2E_CDP;
+const cdpEndpoint = resolveCdpEndpoint({ fallback: '' });
 
 if (!cdpEndpoint && !existsSync(extensionDir)) {
   console.error(`[verify] extension not built: ${extensionDir}`);
@@ -41,7 +47,11 @@ let browser;
 if (cdpEndpoint) {
   // 既に Brave / Chromium が起動済 (--remote-debugging-port=9222) で
   // 拡張が load 済の前提。 ctx を 1 つ取って sw を見つける
-  browser = await chromium.connectOverCDP(cdpEndpoint, { timeout: 30000 });
+  browser = await connectPlaywrightCdp({
+    chromium,
+    endpoint: cdpEndpoint,
+    timeoutMs: 30_000,
+  });
   const ctxs = browser.contexts();
   ctx = ctxs[0];
   if (!ctx) {
@@ -68,37 +78,14 @@ if (cdpEndpoint) {
  * chrome.* API を叩く方が確実。
  */
 async function openExtensionContext() {
-  // 1. 既存の web page から extension id を取る (content script があれば chrome.runtime.id 取得可)
-  let extensionId = null;
-  for (const p of ctx.pages()) {
-    if (!/^https?:/.test(p.url())) continue;
-    try {
-      extensionId = await p.evaluate(() => {
-        // eslint-disable-next-line no-undef
-        return typeof chrome !== 'undefined' && chrome.runtime?.id ? chrome.runtime.id : null;
-      });
-      if (extensionId) break;
-    } catch { /* ignore */ }
-  }
-  // 2. ctx.serviceWorkers() からも試す
-  if (!extensionId) {
-    for (const s of ctx.serviceWorkers()) {
-      const m = s.url().match(/^chrome-extension:\/\/([a-z]+)\//);
-      if (m) { extensionId = m[1]; break; }
-    }
-  }
+  let extensionId = await resolveExtensionId(ctx, { timeoutMs: 1 }).catch(() => null);
   // 3. 最終手段: bsky.app を新規 tab で開いて content script を発火させる
   if (!extensionId) {
     console.log('[verify] opening bsky.app to trigger content script injection...');
     const bootPage = await ctx.newPage();
     await bootPage.goto('https://bsky.app/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await bootPage.waitForTimeout(2000);
-    try {
-      extensionId = await bootPage.evaluate(() => {
-        // eslint-disable-next-line no-undef
-        return typeof chrome !== 'undefined' && chrome.runtime?.id ? chrome.runtime.id : null;
-      });
-    } catch { /* ignore */ }
+    extensionId = await resolveExtensionId(ctx, { timeoutMs: 10_000 }).catch(() => null);
   }
   if (!extensionId) throw new Error('extension id not detected (no content-script tab found)');
   console.log(`[verify] extension id=${extensionId}`);
@@ -264,7 +251,7 @@ if (!audit.ok) {
 if (!cdpEndpoint) {
   await ctx.close();
 } else if (browser) {
-  await browser.close();
+  await disconnectCdp(browser);
 }
 
 if (failures.length) {

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -15,11 +15,17 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { deflateSync } from 'node:zlib';
+import {
+  connectPlaywrightCdp,
+  disconnectCdp,
+  resolveCdpEndpoint,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
 const extensionDir = process.env.E2E_EXT_DIR ?? resolve(repoRoot, '.output', 'chrome-mv3');
-const cdpEndpoint = process.env.E2E_CDP;
+const cdpEndpoint = resolveCdpEndpoint({ fallback: '' });
 const userDataDir = process.env.E2E_USER_DATA_DIR ?? resolve(repoRoot, '.tmp', 'verify-x-thread-profile');
 const isolateXTabs = process.argv.includes('--isolate-x-tabs');
 const skipExtensionReload = process.argv.includes('--skip-extension-reload');
@@ -34,21 +40,8 @@ async function fail(message, detail) {
     console.error(JSON.stringify(detail, null, 2));
   }
   if (!cdpEndpoint && ctx) await ctx.close().catch(() => {});
-  if (browser) await browser.close().catch(() => {});
+  if (browser) await disconnectCdp(browser).catch(() => {});
   process.exit(1);
-}
-
-async function detectExtensionId(ctx) {
-  const fromEnv = process.env.E2E_EXTENSION_ID;
-  if (fromEnv) return fromEnv;
-  for (let i = 0; i < 50; i += 1) {
-    for (const worker of ctx.serviceWorkers()) {
-      const m = worker.url().match(/^chrome-extension:\/\/([a-z]+)\//);
-      if (m?.[1]) return m[1];
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  return null;
 }
 
 function sleep(ms) {
@@ -125,7 +118,11 @@ if (!cdpEndpoint && !existsSync(extensionDir)) {
 }
 
 if (cdpEndpoint) {
-  browser = await chromium.connectOverCDP(cdpEndpoint, { timeout: 30000 });
+  browser = await connectPlaywrightCdp({
+    chromium,
+    endpoint: cdpEndpoint,
+    timeoutMs: 30_000,
+  });
   ctx = browser.contexts()[0];
   if (!ctx) await fail('no browser context found');
 } else {
@@ -140,10 +137,9 @@ if (cdpEndpoint) {
   });
 }
 
-const extensionId = await detectExtensionId(ctx);
-if (!extensionId) {
+const extensionId = await resolveExtensionId(ctx).catch(async () => {
   await fail('extension id not detected. Set E2E_EXTENSION_ID when attaching over CDP.');
-}
+});
 console.log(`[verify-x-thread] extension id=${extensionId}`);
 
 if (!skipExtensionReload && cdpEndpoint) {
@@ -298,4 +294,4 @@ console.log('[verify-x-thread] PASS');
 
 await popup.close().catch(() => {});
 if (!cdpEndpoint) await ctx.close();
-if (browser) await browser.close().catch(() => {});
+if (browser) await disconnectCdp(browser).catch(() => {});

--- a/tests/cdp-harness.test.ts
+++ b/tests/cdp-harness.test.ts
@@ -63,7 +63,7 @@ describe('CDP harness', () => {
     });
   });
 
-  it('discovers extension IDs from configuration, workers, pages, and targets', async () => {
+  it('discovers extension IDs from configuration, workers, pages, targets, and injected runtime', async () => {
     await expect(resolveExtensionId({}, {
       env: { E2E_EXTENSION_ID: 'configuredid' },
       timeoutMs: 1,
@@ -77,6 +77,12 @@ describe('CDP harness', () => {
     await expect(resolveExtensionId({
       targets: () => [{ url: () => 'chrome-extension://targetid/options.html' }],
     }, { env: {}, timeoutMs: 1 })).resolves.toBe('targetid');
+    await expect(resolveExtensionId({
+      pages: () => [{
+        url: () => 'https://x.com/home',
+        evaluate: vi.fn().mockResolvedValue('runtimeid'),
+      }],
+    }, { env: {}, timeoutMs: 1 })).resolves.toBe('runtimeid');
   });
 
   it('rejects extension discovery when no supported target appears', async () => {


### PR DESCRIPTION
Closes #132
Parent: #12 (Phase 9)

## Summary
- migrate four maintained Playwright E2E callers to shared endpoint/attach/disconnect helpers
- replace duplicated extension ID polling with the shared worker/page/runtime discovery contract
- preserve persistent-launch behavior and external CDP browser ownership
- ensure the Pixiv submit helper disconnects even on an early missing-page result

Release-gate scripts are intentionally reserved for the final migration slice.

## Verification
- Node syntax checks for all changed `.mjs` callers
- CDP harness contract tests 11/11 PASS
- `npm run verify:commit` (architecture 15/97; regular 95/723; build PASS)
- `git diff --check`

No production extension code changed and no CWS action was performed.