### PR TITLE
refactor: route Puppeteer E2E through CDP harness

### DIFF
--- a/scripts/e2e/cdp-attach-instagram.mjs
+++ b/scripts/e2e/cdp-attach-instagram.mjs
@@ -12,21 +12,17 @@
  */
 
 import puppeteer from 'puppeteer-core';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  loadE2eFixture,
+  resolveCdpEndpoint,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
-async function discoverWsEndpoint() {
-  const res = await fetch('http://localhost:9222/json/version').catch(() => null);
-  if (!res || !res.ok) {
-    throw new Error('IG CDP: localhost:9222 に Chromium が見つからない');
-  }
-  const data = await res.json();
-  return data.webSocketDebuggerUrl;
-}
-
-const ws = await discoverWsEndpoint();
-console.log(`[ig-cdp] connecting to ${ws}`);
-const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null });
+const cdpEndpoint = resolveCdpEndpoint();
+console.log(`[ig-cdp] connecting to ${cdpEndpoint}`);
+const browser = await connectPuppeteerCdp({ puppeteer, endpoint: cdpEndpoint });
 
 let pages = await browser.pages();
 let igPages = pages.filter((p) => /instagram\.com/.test(p.url()));
@@ -73,7 +69,7 @@ await new Promise((r) => setTimeout(r, 500));
 // 拡張 ID を CDP の page list から拾う (extension SW がアイドルでも、page list の
 // faviconUrl 等から chrome-extension:// URL があれば取れる)。
 // Tutti は load 済前提。SW が sleep してたら popup を navigate して wake する。
-let extId = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const extId = await resolveExtensionId(browser);
 async function findSw() {
   return browser.targets().find((t) =>
     t.type() === 'service_worker' && t.url().includes(`chrome-extension://${extId}/`),
@@ -103,14 +99,14 @@ if (!swTarget) {
 }
 if (!swTarget) {
   console.error('[ig-cdp] FAIL: Tutti 拡張 SW を wake できなかった (Tutti が load されてない可能性)');
-  browser.disconnect();
+  await disconnectCdp(browser);
   process.exit(2);
 }
 const worker = await swTarget.worker();
 console.log(`[ig-cdp] attached to SW: ${swTarget.url()}`);
 
-const imagePath = resolve(process.cwd(), 'scripts/e2e/fixtures/test-image.jpg');
-const imgB64 = readFileSync(imagePath).toString('base64');
+const imageFixture = await loadE2eFixture('test-image.jpg', 'image/jpeg', { required: true });
+const imgB64 = imageFixture.data;
 const text = `tutti ig diag ${new Date().toISOString()}`;
 const autoPost = process.env.IG_AUTOPOST === '1';
 
@@ -228,5 +224,5 @@ for (const s of snapshots) {
 console.log(`\n[ig-cdp] console log (last 30 of ${consoleLog.length}):`);
 for (const c of consoleLog.slice(-30)) console.log(`  ${c}`);
 
-browser.disconnect();
+await disconnectCdp(browser);
 process.exit(sendResult.ok ? 0 : 1);

--- a/scripts/e2e/cdp-attach-tiktok.mjs
+++ b/scripts/e2e/cdp-attach-tiktok.mjs
@@ -21,26 +21,20 @@
  *
  * Playwright の `chromium.connectOverCDP` は拡張持ち Chromium に attach すると
  * 内部の target 列挙で hang する (Surface 実機 2026-05-13 で確認、Timeout 90s)。
- * puppeteer-core の `puppeteer.connect` は即座に attach 成功するので採用。
+ * puppeteer-core の CDP attach は即座に成功するため、共通 harness 経由で採用。
  */
 
 import puppeteer from 'puppeteer-core';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  loadE2eFixture,
+  resolveCdpEndpoint,
+} from './cdp-harness.mjs';
 
-// CDP endpoint の自動検出 (HTTP /json/version からWS URLを引く)
-async function discoverWsEndpoint() {
-  const res = await fetch('http://localhost:9222/json/version').catch(() => null);
-  if (!res || !res.ok) {
-    throw new Error('TikTok CDP smoke: localhost:9222 に Chromium が見つからない (Tutti-test-login.bat 起動済?)');
-  }
-  const data = await res.json();
-  return data.webSocketDebuggerUrl;
-}
-
-const ws = process.env.E2E_CDP_WS ?? await discoverWsEndpoint();
-console.log(`[tiktok-cdp] connecting to ${ws}`);
-const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null });
+const cdpEndpoint = resolveCdpEndpoint();
+console.log(`[tiktok-cdp] connecting to ${cdpEndpoint}`);
+const browser = await connectPuppeteerCdp({ puppeteer, endpoint: cdpEndpoint });
 
 let pages = await browser.pages();
 let ttPage = pages.find((p) => /tiktok\.com\/tiktokstudio\/upload/.test(p.url()))
@@ -53,7 +47,7 @@ await new Promise((r) => setTimeout(r, 8000));
 const fi = await ttPage.evaluate(() => !!document.querySelector('input[type="file"][accept*="video"]'));
 if (!fi) {
   console.error('[tiktok-cdp] FAIL: TikTok Studio file input が見つからない (未ログイン / UI 変更?)');
-  browser.disconnect();
+  await disconnectCdp(browser);
   process.exit(2);
 }
 
@@ -62,13 +56,13 @@ const swTarget = browser.targets().find((t) =>
 );
 if (!swTarget) {
   console.error('[tiktok-cdp] FAIL: Tutti 拡張 SW が見つからない (拡張 load 済?)');
-  browser.disconnect();
+  await disconnectCdp(browser);
   process.exit(3);
 }
 const worker = await swTarget.worker();
 
-const videoPath = resolve(process.cwd(), 'scripts/e2e/fixtures/test-video.mp4');
-const videoB64 = readFileSync(videoPath).toString('base64');
+const videoFixture = await loadE2eFixture('test-video.mp4', 'video/mp4', { required: true });
+const videoB64 = videoFixture.data;
 const text = `tutti e2e tiktok cdp ${new Date().toISOString()}`;
 
 console.log(`[tiktok-cdp] sending POST_TO_PLATFORM (autoPost=false / preview)`);
@@ -87,5 +81,5 @@ const result = await worker.evaluate(async ({ text, videoB64 }) => {
 }, { text, videoB64 });
 
 console.log(`[tiktok-cdp] RESULT: ${JSON.stringify(result)}`);
-browser.disconnect();
+await disconnectCdp(browser);
 process.exit(result.ok ? 0 : 1);

--- a/scripts/e2e/enable-ext.mjs
+++ b/scripts/e2e/enable-ext.mjs
@@ -1,6 +1,7 @@
 import puppeteer from 'puppeteer-core';
-const ws = (await (await fetch('http://localhost:9222/json/version')).json()).webSocketDebuggerUrl;
-const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null });
+import { connectPuppeteerCdp, disconnectCdp } from './cdp-harness.mjs';
+
+const browser = await connectPuppeteerCdp({ puppeteer });
 const p = await browser.newPage();
 await p.goto('chrome://extensions/', { timeout: 10000 });
 await new Promise((r) => setTimeout(r, 2000));
@@ -57,4 +58,4 @@ const final = await p.evaluate(() => {
 });
 console.log(`[enable-ext] final: ${JSON.stringify(final, null, 2)}`);
 await p.close().catch(() => {});
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/open-pixiv-ig.mjs
+++ b/scripts/e2e/open-pixiv-ig.mjs
@@ -1,5 +1,7 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', defaultViewport: null, protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp } from './cdp-harness.mjs';
+
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 60_000 });
 
 for (const url of ['https://www.pixiv.net/', 'https://www.instagram.com/']) {
   const page = await browser.newPage();
@@ -8,4 +10,4 @@ for (const url of ['https://www.pixiv.net/', 'https://www.instagram.com/']) {
   await new Promise((r) => setTimeout(r, 3000));
 }
 
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/show-tutti-sidepanel.mjs
+++ b/scripts/e2e/show-tutti-sidepanel.mjs
@@ -1,14 +1,13 @@
 import puppeteer from 'puppeteer-core';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
-const browser = await puppeteer.connect({
-  browserURL: 'http://localhost:9222',
-  protocolTimeout: 60000,
-});
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 60_000 });
 const pages = await browser.pages();
-const extensionId = process.env.E2E_EXTENSION_ID ?? pages
-  .map((page) => page.url().match(/^chrome-extension:\/\/([a-z]+)\//)?.[1])
-  .find(Boolean);
-if (!extensionId) throw new Error('Tutti extension id not found');
+const extensionId = await resolveExtensionId(browser);
 
 let page = pages.find((candidate) =>
   candidate.url() === `chrome-extension://${extensionId}/sidepanel.html`);
@@ -25,4 +24,4 @@ await page.evaluate(async () => {
 });
 await page.bringToFront();
 console.log(`[show] Tutti sidepanel page opened (${extensionId}), displayMode=auto`);
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/switch-ig-to-professional.mjs
+++ b/scripts/e2e/switch-ig-to-professional.mjs
@@ -9,10 +9,9 @@
  * を試みる。失敗したら何 step まで進んだかを log して human-in-loop 対応。
  */
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './cdp-harness.mjs';
 
-const res = await fetch('http://localhost:9222/json/version');
-const ws = (await res.json()).webSocketDebuggerUrl;
-const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null });
+const browser = await connectPuppeteerCdp({ puppeteer });
 
 const pages = await browser.pages();
 let ig = pages.find((p) => /instagram\.com/.test(p.url()));
@@ -115,4 +114,4 @@ for (const url of candidates) {
   }
 }
 
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/test-multichunk-bugs.mjs
+++ b/scripts/e2e/test-multichunk-bugs.mjs
@@ -20,25 +20,20 @@
  */
 
 import puppeteer from 'puppeteer-core';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  loadE2eFixture,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
 const AUTOPOST = process.env.AUTOPOST === '1';
 const PLATFORM_FILTER = process.env.PLATFORM ?? ''; // 'x', 'bluesky', 'instagram', or empty for all
 
-async function discoverWsEndpoint() {
-  const res = await fetch('http://localhost:9222/json/version').catch(() => null);
-  if (!res || !res.ok) throw new Error('CDP localhost:9222 に接続できない');
-  const data = await res.json();
-  return data.webSocketDebuggerUrl;
-}
-
-const ws = await discoverWsEndpoint();
 console.log(`[cdp] connecting`);
-const browser = await puppeteer.connect({ browserWSEndpoint: ws, defaultViewport: null });
+const browser = await connectPuppeteerCdp({ puppeteer });
 
-// 拡張 ID は Tutti が unpacked load される際に固定 (mv3 manifest key 由来)
-const extId = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const extId = await resolveExtensionId(browser);
 
 async function findSw() {
   return browser.targets().find((t) =>
@@ -68,7 +63,7 @@ async function wakeSw() {
 const swTarget = await wakeSw();
 if (!swTarget) {
   console.error('[cdp] FAIL: Tutti SW を wake できなかった');
-  browser.disconnect();
+  await disconnectCdp(browser);
   process.exit(2);
 }
 const worker = await swTarget.worker();
@@ -87,8 +82,8 @@ await new Promise((r) => setTimeout(r, 1000));
 console.log(`[cdp] popup page opened: ${popupPage.url()}`);
 
 // fixture image (8KB JPEG)
-const imgPath = resolve(process.cwd(), 'scripts/e2e/fixtures/test-image.jpg');
-const imgB64 = readFileSync(imgPath).toString('base64');
+const imageFixture = await loadE2eFixture('test-image.jpg', 'image/jpeg', { required: true });
+const imgB64 = imageFixture.data;
 console.log(`[fixture] image: ${imgB64.length} chars b64 (~${Math.round(imgB64.length * 0.75)} bytes)`);
 
 const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -201,5 +196,5 @@ for (const r of results) {
   if (url) console.log(`  url: ${url}`);
 }
 
-browser.disconnect();
+await disconnectCdp(browser);
 process.exit(0);

--- a/scripts/e2e/verify-bsky-thread.mjs
+++ b/scripts/e2e/verify-bsky-thread.mjs
@@ -1,9 +1,7 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({
-  browserURL: 'http://localhost:9222',
-  defaultViewport: null,
-  protocolTimeout: 60000,
-});
+import { connectPuppeteerCdp, disconnectCdp } from './cdp-harness.mjs';
+
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 60_000 });
 const pages = await browser.pages();
 const bskyPage = pages.find((p) => /bsky\.app/.test(p.url())) || await browser.newPage();
 await bskyPage.bringToFront();
@@ -27,4 +25,4 @@ const detail = await bskyPage.evaluate(() => {
 console.log(JSON.stringify(detail, null, 2));
 
 await bskyPage.screenshot({ path: 'C:/Users/komm64/Projects/tutti/scripts/e2e/bsky-thread-shot.png', fullPage: true });
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/verify-pixiv-ig-detection.mjs
+++ b/scripts/e2e/verify-pixiv-ig-detection.mjs
@@ -1,7 +1,13 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', defaultViewport: null, protocolTimeout: 60000 });
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 60_000 });
+
+const EXT_ID = await resolveExtensionId(browser);
 let sw = browser.targets().find((t) => t.type() === 'service_worker' && t.url().includes(EXT_ID));
 if (!sw) {
   const p = await browser.newPage();
@@ -47,4 +53,4 @@ const lastSeen = await popupPage.evaluate(async () => {
 });
 console.log('lastSeenUsers:', JSON.stringify(lastSeen, null, 2));
 await popupPage.close().catch(() => {});
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/verify-tags-all.mjs
+++ b/scripts/e2e/verify-tags-all.mjs
@@ -9,18 +9,18 @@
  * Usage: PLATFORM=tumblr|deviantart|youtube node scripts/e2e/verify-tags-all.mjs
  */
 import puppeteer from 'puppeteer-core';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  loadE2eFixture,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
 
 const PLATFORM = (process.env.PLATFORM || 'tumblr').trim();
 const TEST_TEXT = 'Tutti verify #cats #photography #beautiful #goldenhour\n\nLook at this scene!';
 
-const browser = await puppeteer.connect({
-  browserURL: 'http://localhost:9222',
-  defaultViewport: null,
-  protocolTimeout: 180000,
-});
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 180_000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 let sw = browser.targets().find((t) => t.type() === 'service_worker' && t.url().includes(EXT_ID));
 if (!sw) {
@@ -69,7 +69,8 @@ page.on('console', (m) => {
   if (/Tutti|tutti/i.test(t)) logs.push(`[${m.type()}] ${t}`);
 });
 
-const imgB64 = readFileSync(resolve(process.cwd(), 'scripts/e2e/fixtures/test-image.jpg')).toString('base64');
+const imageFixture = await loadE2eFixture('test-image.jpg', 'image/jpeg', { required: true });
+const imgB64 = imageFixture.data;
 console.log(`[${PLATFORM}] sending dry-run with text=${TEST_TEXT.slice(0, 50)}...`);
 const result = await worker.evaluate(async ({ text, imgB64, platform }) => {
   const urls = {
@@ -128,4 +129,4 @@ console.log(JSON.stringify(tagState, null, 2));
 console.log(`\n=== ${logs.length} Tutti console logs ===`);
 for (const l of logs) console.log(l);
 
-browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/verify-yt-clear-stale.mjs
+++ b/scripts/e2e/verify-yt-clear-stale.mjs
@@ -4,8 +4,14 @@
  * REFRESH_USER 後に lastSeenUsers から youtube key が消えてること。
  */
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', defaultViewport: null, protocolTimeout: 60000 });
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
+import {
+  connectPuppeteerCdp,
+  disconnectCdp,
+  resolveExtensionId,
+} from './cdp-harness.mjs';
+
+const browser = await connectPuppeteerCdp({ puppeteer, timeoutMs: 60_000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 let sw = browser.targets().find((t) => t.type() === 'service_worker' && t.url().includes(EXT_ID));
 if (!sw) {
@@ -51,4 +57,4 @@ console.log('\nyoutube key:', after?.youtube ?? '(cleared / absent)');
 await popupPage2.close().catch(() => {});
 
 await popupPage.close().catch(() => {});
-browser.disconnect();
+await disconnectCdp(browser);


### PR DESCRIPTION
Closes #134
Parent: #12 (Phase 9)

## Summary
- route eleven maintained Puppeteer E2E scripts under `scripts/e2e/` through the shared attach/disconnect harness
- remove duplicated `/json/version` WebSocket discovery
- replace fixed extension IDs with shared worker/page/runtime discovery
- route image/video fixture reads through the bounded shared fixture loader
- preserve all existing auto-post opt-ins and default preview behavior

## Verification
- Node syntax checks for all eleven changed callers
- no direct Puppeteer connect/disconnect, `/json/version`, fixed extension ID, or manual fixture read remains in this group
- harness contract tests 11/11 PASS
- `npm run verify:commit` (architecture 15/97; regular 95/723; build PASS)

No production extension code or CWS state changed.