### PR TITLE
refactor: route root E2E through CDP harness

### DIFF
--- a/scripts/check-blog-anchors.mjs
+++ b/scripts/check-blog-anchors.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 const pages = await browser.pages();
 const page = pages.find((p) => /tumblr\.com/.test(p.url())) ?? pages[0];
 console.log('URL:', page.url());
@@ -22,4 +23,4 @@ const info = await page.evaluate(() => {
   };
 });
 console.log(JSON.stringify(info, null, 2));
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/e2e/cdp-harness.d.mts
+++ b/scripts/e2e/cdp-harness.d.mts
@@ -21,7 +21,11 @@ export function connectPuppeteerCdp(options?: {
   puppeteer?: { connect(options: Record<string, unknown>): Promise<unknown> };
   endpoint?: string;
   timeoutMs?: number;
+  browserURL?: string;
+  browserWSEndpoint?: string;
+  protocolTimeout?: number;
   defaultViewport?: null | { width: number; height: number };
+  [option: string]: unknown;
 }): Promise<unknown>;
 
 export function disconnectCdp(browser: unknown): Promise<void>;

--- a/scripts/e2e/cdp-harness.mjs
+++ b/scripts/e2e/cdp-harness.mjs
@@ -33,18 +33,29 @@ export async function connectPlaywrightCdp({
   return await driver.connectOverCDP(endpoint, { timeout: timeoutMs });
 }
 
-export async function connectPuppeteerCdp({
-  puppeteer: puppeteerApi,
-  endpoint = resolveCdpEndpoint(),
-  timeoutMs = DEFAULT_CDP_TIMEOUT_MS,
-  defaultViewport = null,
-} = {}) {
+export async function connectPuppeteerCdp(options = {}) {
+  const {
+    puppeteer: puppeteerApi,
+    endpoint: configuredEndpoint,
+    browserURL,
+    browserWSEndpoint,
+    timeoutMs: configuredTimeoutMs,
+    protocolTimeout,
+    defaultViewport = null,
+    ...connectOptions
+  } = options;
+  const endpoint = configuredEndpoint
+    ?? browserWSEndpoint
+    ?? browserURL
+    ?? resolveCdpEndpoint();
+  const timeoutMs = configuredTimeoutMs ?? protocolTimeout ?? DEFAULT_CDP_TIMEOUT_MS;
   if (!endpoint) throw new Error('CDP endpoint is required');
   const driver = puppeteerApi ?? (await import('puppeteer-core')).default;
   const endpointOption = endpoint.startsWith('ws:')
     ? { browserWSEndpoint: endpoint }
     : { browserURL: endpoint };
   return await driver.connect({
+    ...connectOptions,
     ...endpointOption,
     defaultViewport,
     protocolTimeout: timeoutMs,

--- a/scripts/gen-store-composite.mjs
+++ b/scripts/gen-store-composite.mjs
@@ -2,9 +2,10 @@
 // 各シーン: 左に大きい headline + subtitle + SNS chip 行、右に popup card。
 // puppeteer で HTML をレンダ → screenshot。
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'node:fs';
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
 
 /**
  * `LANG=en node scripts/gen-store-composite.mjs` で英語版を生成。
@@ -231,4 +232,4 @@ for (const scene of scenes) {
   console.log('wrote', out);
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/gen-store-screenshots.mjs
+++ b/scripts/gen-store-screenshots.mjs
@@ -13,17 +13,18 @@
 //   LANG=ja node scripts/gen-store-screenshots.mjs
 //   LANG=en node scripts/gen-store-screenshots.mjs
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { mkdirSync, readFileSync } from 'node:fs';
 
 const LANG = process.env.LANG === 'en' ? 'en' : 'ja';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
 mkdirSync('docs/screenshots', { recursive: true });
 
 // 該当 locale の messages.json を読み込んで popup の i18n を上書き
 const messagesPath = `locales/${LANG}/messages.json`;
 const messages = JSON.parse(readFileSync(messagesPath, 'utf8'));
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 // SNS のタブを全部閉じる(content script で lastSeenUsers が上書きされるため)
 const SNS_HOSTS = [
@@ -237,5 +238,5 @@ for (const scene of scenes) {
   await popup.close();
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);
 console.log('\ndone. Run gen-store-composite.mjs (LANG=' + LANG + ') to make 1280x800 banners.');

--- a/scripts/real-post-3sns.mjs
+++ b/scripts/real-post-3sns.mjs
@@ -1,8 +1,9 @@
 // Real auto-post test to X / Mastodon / Tumblr with image, one at a time.
 // Captures: per-SNS console errors + network failures + final timeline state.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 const tmpImg = 'C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png';
 
@@ -106,4 +107,4 @@ await postToOne('X', 0, /x\.com|twitter\.com/);
 await postToOne('Mastodon', 3, /mastodon\.social/);
 await postToOne('Tumblr', 5, /tumblr\.com/);
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/real-post-bsky-misskey-threads.mjs
+++ b/scripts/real-post-bsky-misskey-threads.mjs
@@ -1,7 +1,8 @@
 // Real auto-post test for Bluesky / Misskey / Threads with image.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 const tmpImg = 'C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png';
 
@@ -83,4 +84,4 @@ await postOne('Bluesky', 1, /bsky\.app/);
 await postOne('Threads', 2, /threads\.(com|net)/);
 await postOne('Misskey', 4, /misskey\.io/);
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/real-post-pixiv.mjs
+++ b/scripts/real-post-pixiv.mjs
@@ -1,6 +1,7 @@
 // Real post (autoPost=true) verification for Pixiv.
 // 投稿が実際にサーバ送信されて公開されるかを確認する。test アカウント前提。
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync, appendFileSync, readFileSync } from 'fs';
 
 const LOG = 'scripts/realpost-pixiv.log';
@@ -12,9 +13,9 @@ const log = (...a) => {
 };
 process.on('uncaughtException', (e) => { log('UNCAUGHT', e.message); process.exit(1); });
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
 log('connecting to brave on 9222...');
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const EXT_ID = await resolveExtensionId(browser);
 log('connected');
 
 async function attachAll() {
@@ -135,4 +136,4 @@ log('popup state:', popupResult);
 
 if (pix) await pix.screenshot({ path: 'scripts/realpost-pixiv.png', fullPage: false });
 log('done');
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/real-post-x-only.mjs
+++ b/scripts/real-post-x-only.mjs
@@ -1,7 +1,8 @@
 // Real auto-post to X only. Verify text body appears in the actual posted tweet.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com|popup\.html/.test(p.url())) await p.close();
@@ -85,4 +86,4 @@ if (xTab) {
   console.log(JSON.stringify(posts, null, 2));
   await xTab.screenshot({ path: 'scripts/x-post-with-text.png' });
 }
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/real-post-x.mjs
+++ b/scripts/real-post-x.mjs
@@ -1,8 +1,9 @@
 // REAL post to X. Disables dryRun, posts a clearly-marked test message + image.
 // Tracks: (a) modal closes after click? (b) post appears in user timeline?
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 const TEST_TEXT = `[Tutti テスト投稿] クロスポスト機能の動作確認 ${new Date().toISOString()}`;
 console.log('TEST TEXT:', TEST_TEXT);
@@ -103,4 +104,4 @@ if (xTab) {
   await xTab.screenshot({ path: 'scripts/x-real-timeline.png' });
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-all-sns-image.mjs
+++ b/scripts/test-all-sns-image.mjs
@@ -1,9 +1,10 @@
 // Run dry-run image attach test through Tutti for all 6 SNS, one at a time.
 // Each iteration: open popup → set settings → set image → check one platform → click POST → wait → snapshot SNS tab.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync } from 'fs';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
+const EXT_ID = await resolveExtensionId(browser);
 
 const tmpImg = 'C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png';
 
@@ -105,4 +106,4 @@ for (const p of PLATFORMS) await testOne(p);
 
 console.log('\n=== relevant logs ===');
 for (const l of allLogs.slice(-50)) console.log(l);
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-api.mjs
+++ b/scripts/test-api.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 const pages = await browser.pages();
 const page = pages.find((p) => /tumblr\.com/.test(p.url())) ?? pages[0];
 
@@ -28,4 +29,4 @@ const result2 = await page.evaluate(async () => {
 console.log('\n/svc/account/get_user_data:');
 console.log(JSON.stringify(result2, null, 2));
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-bg-tab-during-post.mjs
+++ b/scripts/test-bg-tab-during-post.mjs
@@ -2,8 +2,9 @@
 // Tutti's autoPost ON already opens tabs as background, but this test forces an
 // additional tab activation right after to verify the background tab keeps posting.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com|popup\.html|mastodon|tumblr|misskey|threads|bsky/.test(p.url())) await p.close();
@@ -63,4 +64,4 @@ for (let i = 0; i < 50; i++) {
 }
 console.log(`\nelapsed: ${(Date.now() - startedAt) / 1000}s`);
 await popup.screenshot({ path: 'scripts/popup-3sns-final.png' });
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-bg-tabs-autopost.mjs
+++ b/scripts/test-bg-tabs-autopost.mjs
@@ -1,8 +1,9 @@
 // Verify autoPost ON: SNS tabs open as background (active: false), all 6 SNS posts succeed.
 // Also verify popup stays alive throughout (popup.evaluate keeps working).
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com|popup\.html/.test(p.url())) await p.close();
@@ -68,4 +69,4 @@ for (const s of samples) {
 
 await popup.screenshot({ path: 'scripts/popup-progress.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-diagnose.mjs
+++ b/scripts/test-diagnose.mjs
@@ -1,7 +1,8 @@
 // Trigger the Diagnose button and verify the report is well-formed.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (p.url().includes('popup.html')) await p.close();
@@ -28,4 +29,4 @@ console.log('=== diagnostics output ===');
 console.log(out);
 await popup.screenshot({ path: 'scripts/diagnostics-result.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-draft-media-persist.mjs
+++ b/scripts/test-draft-media-persist.mjs
@@ -1,8 +1,9 @@
 // Verify: attach image in popup → close popup → reopen → image still there.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync } from 'fs';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 // Clean session storage so we start fresh
 const tmpPopup = await browser.newPage();
@@ -56,4 +57,4 @@ const restored = await popup2.evaluate(() => {
 console.log('restored UI:', restored);
 await popup2.screenshot({ path: 'scripts/popup-after-restore.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-drag-drop.mjs
+++ b/scripts/test-drag-drop.mjs
@@ -1,7 +1,8 @@
 // Try drag & drop simulation for SNS without accessible file input.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'fs';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 const png = readFileSync('C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png');
 const b64 = png.toString('base64');
@@ -60,4 +61,4 @@ await tryDrop('Misskey', 'https://misskey.io/share?text=drop-test',
 await tryDrop('Tumblr', 'https://www.tumblr.com/new/text',
   ['[contenteditable="true"]', '.block-editor-rich-text__editable', 'main', 'div[role="dialog"]']);
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-error-dialog.mjs
+++ b/scripts/test-error-dialog.mjs
@@ -4,10 +4,11 @@
 // 3. Clicks "報告する" → expects worker call → success state with issue link
 // 4. Closes the test issue at the end
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { execSync } from 'node:child_process';
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (p.url().includes('popup.html')) await p.close();
@@ -42,7 +43,7 @@ console.log('worker response from popup context:', JSON.stringify(result, null, 
 // Snap a screenshot of the popup as-is
 await popup.screenshot({ path: 'scripts/popup-v0411.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);
 
 // Close any test issue we created
 if (result.body?.issueNumber) {

--- a/scripts/test-helper-direct.mjs
+++ b/scripts/test-helper-direct.mjs
@@ -1,8 +1,9 @@
 // Send postMessage directly to MAIN-world helper (no popup, no content script).
 // Verifies whether the helper itself can inject + trigger Mastodon's reaction.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 for (const p of await browser.pages()) {
   if (/mastodon\.social/.test(p.url())) await p.close();
@@ -60,4 +61,4 @@ const ui = await page.evaluate(() => ({
 console.log('UI 5s after inject:', JSON.stringify(ui, null, 2));
 
 await page.screenshot({ path: 'scripts/helper-direct-test.png' });
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-image-inject.mjs
+++ b/scripts/test-image-inject.mjs
@@ -1,8 +1,9 @@
 // Test which event dispatch pattern actually triggers Mastodon's upload reaction.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'fs';
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 const page = await browser.newPage();
 
 // Generate test PNG (small valid PNG)
@@ -92,4 +93,4 @@ const ui2 = await page.evaluate(() => ({
 console.log('after drop UI:', JSON.stringify(ui2, null, 2));
 await page.screenshot({ path: 'scripts/mastodon-drop-test.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-main-world.mjs
+++ b/scripts/test-main-world.mjs
@@ -1,6 +1,7 @@
 // Pure MAIN-world inject test (via puppeteer page.evaluate, no content script).
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 for (const p of await browser.pages()) {
   if (/mastodon\.social/.test(p.url())) await p.close();
@@ -35,4 +36,4 @@ const ui = await page.evaluate(() => ({
 console.log('UI 5s after inject:', JSON.stringify(ui, null, 2));
 await page.screenshot({ path: 'scripts/main-world-test.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-progress-integrated.mjs
+++ b/scripts/test-progress-integrated.mjs
@@ -1,7 +1,8 @@
 // Verify v0.4.6: progress integrated into SNS rows, preview wording instead of "Posting..."
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (p.url().includes('popup.html') || /x\.com|mastodon\.social/.test(p.url())) await p.close();
@@ -49,4 +50,4 @@ await popup.screenshot({ path: 'scripts/preview-mid.png' });
 await new Promise(r => setTimeout(r, 8000));
 await popup.screenshot({ path: 'scripts/preview-final.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-progress-spinner.mjs
+++ b/scripts/test-progress-spinner.mjs
@@ -1,7 +1,8 @@
 // Capture autoPost ON spinner state mid-flight.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (p.url().includes('popup.html') || /mastodon\.social/.test(p.url())) await p.close();
@@ -39,4 +40,4 @@ for (const at of [1, 4, 8]) {
   await popup.screenshot({ path: `scripts/preview-spinner-t${at}.png` });
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-regex.mjs
+++ b/scripts/test-regex.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 const pages = await browser.pages();
 const page = pages.find((p) => /tumblr\.com/.test(p.url())) ?? pages[0];
 
@@ -29,4 +30,4 @@ const result = await page.evaluate(() => {
 });
 
 console.log(JSON.stringify(result, null, 2));
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-section-split.mjs
+++ b/scripts/test-section-split.mjs
@@ -1,6 +1,7 @@
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 for (const p of await browser.pages()) {
   if (p.url().includes('popup.html')) await p.close();
 }
@@ -19,4 +20,4 @@ await popup.screenshot({ path: 'scripts/popup-section-split.png' });
 await popup.evaluate(() => new Promise(r => chrome.storage.local.set({
   lastSeenUsers: { x: '@ren_fujimoto', bluesky: '@ren-fujimoto89.bsky.social', threads: '@ren.fujimoto.89', mastodon: '@ren_fujimoto', misskey: '@ren_fujimoto', tumblr: '@ren-fujimoto' }
 }, r)));
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-timing.mjs
+++ b/scripts/test-timing.mjs
@@ -2,7 +2,8 @@
 // Variant A: short wait (matching Tutti) from MAIN world → does it work?
 // Variant B: long wait (4s) from MAIN world → confirmed works
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 async function test(label, waitMs) {
   console.log(`\n=== ${label} (wait ${waitMs}ms) ===`);
@@ -39,4 +40,4 @@ const r2 = await test('short', 800);
 console.log(`\nlong(4s): ${r1 ? 'OK' : 'FAIL'}`);
 console.log(`short(800ms): ${r2 ? 'OK' : 'FAIL'}`);
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tumblr-detection.mjs
+++ b/scripts/test-tumblr-detection.mjs
@@ -1,7 +1,8 @@
 // Verify new detection strategy on live Tumblr.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 const pages = await browser.pages();
 const page = pages.find((p) => /tumblr\.com/.test(p.url())) ?? pages[0];
 
@@ -34,4 +35,4 @@ const result = await page.evaluate(() => {
 console.log('matches:');
 console.log(JSON.stringify(result, null, 2));
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tumblr-paste.mjs
+++ b/scripts/test-tumblr-paste.mjs
@@ -1,7 +1,8 @@
 // Try simulating clipboard paste of an image into Tumblr's editor.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'fs';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 const png = readFileSync('C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png');
 const b64 = png.toString('base64');
@@ -42,4 +43,4 @@ const after = await page.evaluate(() => ({
 console.log('after paste:', after);
 await page.screenshot({ path: 'scripts/tumblr-paste.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-bigger.mjs
+++ b/scripts/test-tutti-bigger.mjs
@@ -1,7 +1,8 @@
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'fs';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/mastodon\.social/.test(p.url())) await p.close();
@@ -59,4 +60,4 @@ for (let i = 0; i < 25; i++) {
 }
 if (mast) await mast.screenshot({ path: 'scripts/mastodon-bigger.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-deviantart.mjs
+++ b/scripts/test-tutti-deviantart.mjs
@@ -1,5 +1,6 @@
 // Drive Tutti popup → DeviantArt dry-run, verify image + title + description filled.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync, appendFileSync } from 'fs';
 
 const LOG = 'scripts/da-test.log';
@@ -11,8 +12,8 @@ const log = (...a) => {
 };
 process.on('uncaughtException', (e) => { log('UNCAUGHT', e.message); process.exit(1); });
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 async function attachAll() {
   for (const p of await browser.pages()) {
@@ -149,4 +150,4 @@ for (let i = 0; i < 60; i++) {
 }
 if (da) await da.screenshot({ path: 'scripts/da-test-result.png', fullPage: true });
 log('done');
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-image-clean.mjs
+++ b/scripts/test-tutti-image-clean.mjs
@@ -1,7 +1,8 @@
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync } from 'fs';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
+const EXT_ID = await resolveExtensionId(browser);
 
 // Close all mastodon tabs first
 for (const p of await browser.pages()) {
@@ -70,4 +71,4 @@ for (let i = 0; i < 25; i++) {
 }
 if (mast) await mast.screenshot({ path: 'scripts/mastodon-clean-test.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-image-mastodon.mjs
+++ b/scripts/test-tutti-image-mastodon.mjs
@@ -1,9 +1,10 @@
 // Drive Tutti via popup, then watch Mastodon compose for image preview to appear (or not).
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync } from 'fs';
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
+const EXT_ID = await resolveExtensionId(browser);
 
 // log everything from any page
 async function attachAll() {
@@ -90,4 +91,4 @@ for (let i = 0; i < 25; i++) {
 }
 if (mast) await mast.screenshot({ path: 'scripts/mastodon-tutti-img.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-instagram.mjs
+++ b/scripts/test-tutti-instagram.mjs
@@ -1,5 +1,6 @@
 // Drive Tutti popup → Instagram dry-run, verify wizard 完走 (image + caption + Share highlight).
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync, appendFileSync, readFileSync } from 'fs';
 
 const LOG = 'scripts/ig-test.log';
@@ -11,8 +12,8 @@ const log = (...a) => {
 };
 process.on('uncaughtException', (e) => { log('UNCAUGHT', e.message); process.exit(1); });
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 async function attachAll() {
   for (const p of await browser.pages()) {
@@ -125,4 +126,4 @@ for (let i = 0; i < 80; i++) {
 }
 if (ig) await ig.screenshot({ path: 'scripts/ig-test-result.png', fullPage: false });
 log('done');
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-pixiv.mjs
+++ b/scripts/test-tutti-pixiv.mjs
@@ -1,5 +1,6 @@
 // Drive Tutti popup → Pixiv dry-run, verify title + caption + image got injected.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
 import { writeFileSync, appendFileSync } from 'fs';
 
 const LOG = 'scripts/pixiv-test.log';
@@ -11,8 +12,8 @@ const log = (...a) => {
 };
 process.on('uncaughtException', (e) => { log('UNCAUGHT', e.message); process.exit(1); });
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 240000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 // log everything from any page
 async function attachAll() {
@@ -130,4 +131,4 @@ for (let i = 0; i < 30; i++) {
 }
 if (pix) await pix.screenshot({ path: 'scripts/pixiv-test-result.png', fullPage: true });
 log('done');
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-tumblr-image.mjs
+++ b/scripts/test-tutti-tumblr-image.mjs
@@ -1,7 +1,8 @@
 // End-to-end: drive Tutti popup → POST with image to Tumblr only.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/tumblr\.com/.test(p.url())) await p.close();
@@ -62,4 +63,4 @@ for (let i = 0; i < 20; i++) {
 }
 if (tab) await tab.screenshot({ path: 'scripts/tumblr-tutti-flow.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-with-mainlogs.mjs
+++ b/scripts/test-tutti-with-mainlogs.mjs
@@ -1,7 +1,8 @@
 // Like test-tutti-bigger but captures MAIN-world page console logs too.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/mastodon\.social/.test(p.url())) await p.close();
@@ -68,4 +69,4 @@ if (mast) {
   await mast.screenshot({ path: 'scripts/mastodon-trace.png' });
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-tutti-x.mjs
+++ b/scripts/test-tutti-x.mjs
@@ -1,7 +1,8 @@
 // Verify X via full Tutti dry-run.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com/.test(p.url())) await p.close();
@@ -75,4 +76,4 @@ for (let i = 0; i < 18; i++) {
 }
 if (tab) await tab.screenshot({ path: 'scripts/x-tutti-flow.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-upload-wait.mjs
+++ b/scripts/test-upload-wait.mjs
@@ -2,8 +2,9 @@
 // Run dry-run (so we don't actually post) but observe inject helper's response timing
 // vs upload network completion.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 import { readFileSync } from 'fs';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
 
 const png = readFileSync('C:\\Users\\komm64\\AppData\\Local\\Temp\\tutti-test-100x100.png');
 
@@ -66,4 +67,4 @@ await probe('Misskey', 'https://misskey.io/share?text=upload-wait', 'drop', '[da
 await probe('Threads', 'https://www.threads.com/intent/post?text=upload-wait', 'input', 'input[type="file"][accept*="image"]');
 await probe('Tumblr', 'https://www.tumblr.com/new/text', 'drop', '[role="dialog"] .components-drop-zone, .components-drop-zone');
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-x-existing-tab.mjs
+++ b/scripts/test-x-existing-tab.mjs
@@ -2,8 +2,9 @@
 // background's openOrFocusTab updates URL to /intent/post in existing tab.
 // This may produce different DOM than fresh tab navigation.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 // Close existing first
 for (const p of await browser.pages()) {
@@ -72,4 +73,4 @@ for (let i = 0; i < 8; i++) {
   await xHome.screenshot({ path: `scripts/x-existing-${i}.png` });
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-x-full-screenshot.mjs
+++ b/scripts/test-x-full-screenshot.mjs
@@ -1,8 +1,9 @@
 // Reproduce X's two-compose-form scenario the user described.
 // Dry-run with image, screenshot at multiple stages, identify which form has the image.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com|popup/.test(p.url())) await p.close();
@@ -66,4 +67,4 @@ for (let i = 0; i < 8; i++) {
   await tab.screenshot({ path: `scripts/x-form-state-${i}.png` });
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/test-x-inline.mjs
+++ b/scripts/test-x-inline.mjs
@@ -1,7 +1,8 @@
 // Verify v0.3.8: X uses home inline compose, no modal.
 import puppeteer from 'puppeteer-core';
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp, resolveExtensionId } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+const EXT_ID = await resolveExtensionId(browser);
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com|popup\.html/.test(p.url())) await p.close();
@@ -77,4 +78,4 @@ const finalState = tab && await tab.evaluate(() => {
 console.log('FINAL:', JSON.stringify(finalState));
 if (tab) await tab.screenshot({ path: 'scripts/x-inline-test.png' });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-3sns-posts.mjs
+++ b/scripts/verify-3sns-posts.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 90000 });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 90000 });
 
 async function check(label, url, needle) {
   console.log(`\n=== ${label} ===`);
@@ -28,4 +29,4 @@ await check('X', 'https://x.com/ren_fujimoto', 'Tutti自動投稿テスト');
 await check('Mastodon', 'https://mastodon.social/@ren_fujimoto', 'Tutti自動投稿テスト');
 await check('Tumblr', 'https://www.tumblr.com/blog/ren-fujimoto', 'Tutti自動投稿テスト');
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-bsky-misskey-threads.mjs
+++ b/scripts/verify-bsky-misskey-threads.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 90000 });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 90000 });
 
 async function check(label, url, needle) {
   console.log(`\n=== ${label} ===`);
@@ -32,4 +33,4 @@ await check('Bluesky', 'https://bsky.app/profile/ren-fujimoto89.bsky.social', 'T
 await check('Threads', 'https://www.threads.com/@ren.fujimoto.89', 'Tutti自動投稿');
 await check('Misskey', 'https://misskey.io/@ren_fujimoto', 'Tutti自動投稿');
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-detection.mjs
+++ b/scripts/verify-detection.mjs
@@ -1,7 +1,8 @@
 // Connect to test Chrome, find tumblr tab, listen to console for [Tutti] tumblr logs.
 import puppeteer from 'puppeteer-core';
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
 
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 let pages = await browser.pages();
 let page = pages.find((p) => /tumblr\.com/.test(p.url())) ?? pages[0];
@@ -33,4 +34,4 @@ if (success) {
   console.log('\n✗ no success line; check for failure dump above');
 }
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-misskey-only.mjs
+++ b/scripts/verify-misskey-only.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
 
 for (const p of await browser.pages()) {
   if (/misskey\.io/.test(p.url())) await p.close();
@@ -30,4 +31,4 @@ const hasMatch = text.includes('Tutti自動投稿');
 console.log('found Tutti post on Misskey:', hasMatch);
 console.log('snippet:', text.substr(text.indexOf('Tutti'), 200) || '(not in body)');
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-on-brave.mjs
+++ b/scripts/verify-on-brave.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222' });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222' });
 
 let pages = await browser.pages();
 let page = pages[0];
@@ -22,4 +23,4 @@ await new Promise(r => setTimeout(r, 12000));
 console.log('\n[Tutti] logs collected:');
 for (const log of tuttiLogs) console.log(' ', log.slice(0, 200));
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-popup-version.mjs
+++ b/scripts/verify-popup-version.mjs
@@ -1,5 +1,6 @@
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
 const popup = (await browser.pages()).find(p => p.url().endsWith('popup.html'));
 if (!popup) { console.log('no popup'); process.exit(1); }
 await new Promise(r => setTimeout(r, 1500));
@@ -13,4 +14,4 @@ const v = await popup.evaluate(() => {
   return { manifestVersion, versionTexts };
 });
 console.log(JSON.stringify(v, null, 2));
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/scripts/verify-x-modal-vs-bg.mjs
+++ b/scripts/verify-x-modal-vs-bg.mjs
@@ -1,7 +1,8 @@
 // Open X with intent URL, check both modal compose AND inline (home) compose
 // for text + image state. Verify only modal has the image.
 import puppeteer from 'puppeteer-core';
-const browser = await puppeteer.connect({ browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
+import { connectPuppeteerCdp, disconnectCdp } from './e2e/cdp-harness.mjs';
+const browser = await connectPuppeteerCdp({ puppeteer, browserURL: 'http://localhost:9222', protocolTimeout: 60000 });
 
 for (const p of await browser.pages()) {
   if (/x\.com|twitter\.com/.test(p.url())) await p.close();
@@ -43,4 +44,4 @@ const state = await page.evaluate(() => {
 console.log(JSON.stringify(state, null, 2));
 await page.screenshot({ path: 'scripts/x-bg-check.png', fullPage: true });
 
-await browser.disconnect();
+await disconnectCdp(browser);

--- a/tests/cdp-harness.test.ts
+++ b/tests/cdp-harness.test.ts
@@ -63,6 +63,22 @@ describe('CDP harness', () => {
     });
   });
 
+  it('preserves legacy Puppeteer connect option aliases during migration', async () => {
+    const connect = vi.fn().mockResolvedValue({});
+    await connectPuppeteerCdp({
+      puppeteer: { connect },
+      browserURL: 'http://localhost:9222',
+      protocolTimeout: 91,
+      slowMo: 10,
+    });
+    expect(connect).toHaveBeenCalledWith({
+      browserURL: 'http://localhost:9222',
+      defaultViewport: null,
+      protocolTimeout: 91,
+      slowMo: 10,
+    });
+  });
+
   it('discovers extension IDs from configuration, workers, pages, targets, and injected runtime', async () => {
     await expect(resolveExtensionId({}, {
       env: { E2E_EXTENSION_ID: 'configuredid' },


### PR DESCRIPTION
Closes #136
Parent: #12 (Phase 9)

## Summary
- migrate 46 remaining maintained root-level Puppeteer callers to the shared CDP attach/disconnect API
- preserve legacy `browserURL`, `browserWSEndpoint`, `protocolTimeout`, viewport, and extra connect options through explicit harness compatibility aliases
- replace 27 fixed extension IDs with shared runtime/target discovery
- add a contract test for option-preserving migration

Raw WebSocket CDP clients and the three release gates remain separate final slices.

## Verification
- Node syntax checks for all 47 changed `.mjs` files
- no direct Puppeteer connect/disconnect or fixed extension ID remains in this group
- harness contract tests 12/12 PASS
- `npm run verify:commit` (architecture 15/97; regular 95/724; build PASS)
- `git diff --check`

No production extension code or CWS state changed.