### PR TITLE
refactor: route raw CDP clients through harness

### DIFF
--- a/scripts/e2e/cdp-harness.d.mts
+++ b/scripts/e2e/cdp-harness.d.mts
@@ -28,6 +28,59 @@ export function connectPuppeteerCdp(options?: {
   [option: string]: unknown;
 }): Promise<unknown>;
 
+export function resolveCdpHttpEndpoint(endpoint?: string): string;
+
+export function fetchCdpJson(
+  path: string,
+  options?: {
+    endpoint?: string;
+    timeoutMs?: number;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<unknown>;
+
+export interface CdpTarget {
+  id?: string;
+  type?: string;
+  title?: string;
+  url?: string;
+  webSocketDebuggerUrl?: string;
+  [key: string]: unknown;
+}
+
+export function listCdpTargets(options?: {
+  endpoint?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<CdpTarget[]>;
+
+export function waitForCdpTarget(
+  predicate: (target: CdpTarget) => boolean,
+  options?: {
+    endpoint?: string;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<CdpTarget>;
+
+export class RawCdpClient {
+  constructor(url: string, options?: {
+    name?: string;
+    timeoutMs?: number;
+    WebSocketImpl?: unknown;
+    logger?: (message: string) => void;
+  });
+  readonly url: string;
+  readonly name: string;
+  ws: unknown;
+  connect(): Promise<this>;
+  send(method: string, params?: Record<string, unknown>): Promise<Record<string, any>>;
+  evaluate(expression: string, awaitPromise?: boolean): Promise<any>;
+  navigate(url: string, options?: { settleMs?: number }): Promise<void>;
+  close(): void;
+}
+
 export function disconnectCdp(browser: unknown): Promise<void>;
 
 export function withCdpBrowser<T>(

--- a/scripts/e2e/cdp-harness.mjs
+++ b/scripts/e2e/cdp-harness.mjs
@@ -62,6 +62,158 @@ export async function connectPuppeteerCdp(options = {}) {
   });
 }
 
+export function resolveCdpHttpEndpoint(endpoint = resolveCdpEndpoint()) {
+  if (!endpoint) throw new Error('CDP endpoint is required');
+  const url = new URL(endpoint);
+  if (url.protocol === 'ws:') url.protocol = 'http:';
+  if (url.protocol === 'wss:') url.protocol = 'https:';
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`unsupported CDP endpoint protocol: ${url.protocol}`);
+  }
+  url.pathname = '';
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+export async function fetchCdpJson(
+  path,
+  {
+    endpoint = resolveCdpEndpoint(),
+    timeoutMs = 10_000,
+    fetchImpl = globalThis.fetch,
+  } = {},
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const base = resolveCdpHttpEndpoint(endpoint);
+    const response = await fetchImpl(`${base}/${String(path).replace(/^\/+/, '')}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`CDP HTTP ${response.status} for ${path}`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function listCdpTargets(options = {}) {
+  const targets = await fetchCdpJson('json/list', options);
+  if (!Array.isArray(targets)) throw new Error('CDP target list is not an array');
+  return targets;
+}
+
+export async function waitForCdpTarget(
+  predicate,
+  {
+    timeoutMs = 30_000,
+    pollIntervalMs = 500,
+    ...listOptions
+  } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const target = (await listCdpTargets(listOptions)).find(predicate);
+    if (target) return target;
+    if (Date.now() >= deadline) break;
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+  } while (Date.now() <= deadline);
+  throw new Error(`CDP target not found within ${timeoutMs}ms`);
+}
+
+export class RawCdpClient {
+  constructor(
+    url,
+    {
+      name = 'cdp',
+      timeoutMs = 30_000,
+      WebSocketImpl,
+      logger = () => {},
+    } = {},
+  ) {
+    this.url = url;
+    this.name = name;
+    this.timeoutMs = timeoutMs;
+    this.WebSocketImpl = WebSocketImpl;
+    this.logger = logger;
+    this.id = 0;
+    this.pending = new Map();
+    this.ws = null;
+  }
+
+  async connect() {
+    const WebSocketApi = this.WebSocketImpl ?? (await import('ws')).WebSocket;
+    await withTimeout(new Promise((resolveConnect, rejectConnect) => {
+      this.ws = new WebSocketApi(this.url, { perMessageDeflate: false });
+      this.ws.once('open', resolveConnect);
+      this.ws.once('error', rejectConnect);
+      this.ws.on('message', (raw) => this.#handleMessage(raw));
+      this.ws.on('error', (error) => this.logger(`${this.name} WS error: ${error.message}`));
+      this.ws.on('close', () => this.#rejectPending(new Error(`${this.name} WS closed`)));
+    }), this.timeoutMs, `${this.name} CDP connection`);
+    return this;
+  }
+
+  async send(method, params = {}) {
+    if (!this.ws || this.ws.readyState !== 1) {
+      throw new Error(`${this.name} WS is not open`);
+    }
+    const id = ++this.id;
+    return await withTimeout(new Promise((resolveSend, rejectSend) => {
+      this.pending.set(id, { resolve: resolveSend, reject: rejectSend });
+      try {
+        this.ws.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        this.pending.delete(id);
+        rejectSend(error);
+      }
+    }), this.timeoutMs, `${this.name} CDP ${method}`).finally(() => {
+      this.pending.delete(id);
+    });
+  }
+
+  async evaluate(expression, awaitPromise = true) {
+    const result = await this.send('Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise,
+    });
+    if (result.exceptionDetails) {
+      const detail = result.exceptionDetails;
+      throw new Error(`${detail.text ?? 'Runtime.evaluate failed'} ${detail.exception?.description ?? ''}`.trim());
+    }
+    return result.result?.value;
+  }
+
+  async navigate(url, { settleMs = 0 } = {}) {
+    await this.send('Page.enable');
+    await this.send('Page.navigate', { url });
+    if (settleMs > 0) await sleep(settleMs);
+  }
+
+  close() {
+    this.#rejectPending(new Error(`${this.name} CDP client closed`));
+    this.ws?.close();
+  }
+
+  #handleMessage(raw) {
+    const message = JSON.parse(raw.toString());
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    if (message.error) pending.reject(new Error(message.error.message));
+    else pending.resolve(message.result);
+  }
+
+  #rejectPending(error) {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}
+
 export async function disconnectCdp(browser) {
   if (!browser) return;
   if (typeof browser.disconnect === 'function') {

--- a/scripts/real-post-direct.mjs
+++ b/scripts/real-post-direct.mjs
@@ -4,8 +4,13 @@
 //
 // popup UI を介さず chrome.runtime.sendMessage で直接 background に POST_REQUEST。
 // autoPost state race 問題を完全回避。
-import { WebSocket } from 'ws';
 import { writeFileSync, appendFileSync, readFileSync } from 'fs';
+import {
+  listCdpTargets,
+  RawCdpClient,
+  resolveExtensionId,
+  waitForCdpTarget,
+} from './e2e/cdp-harness.mjs';
 
 const platform = process.argv[2];
 if (!platform) { console.error('usage: node scripts/real-post-direct.mjs <platform>'); process.exit(1); }
@@ -34,48 +39,16 @@ const PLATFORM_URL_RE = {
 const re = PLATFORM_URL_RE[platform];
 if (!re) { log(`unknown platform: ${platform}`); process.exit(1); }
 
-const r = await fetch('http://localhost:9222/json/list');
-const tabs = await r.json();
+const tabs = await listCdpTargets();
 
 const popupTab = tabs.find(t => t.type === 'page' && (/popup\.html/.test(t.url) || /chrome:\/\/extensions/.test(t.url) || t.url === 'about:blank'));
 if (!popupTab) { log('no popup-capable tab. open chrome://extensions/'); process.exit(1); }
 
-class Cdp {
-  constructor(url, name) { this.name = name; this.url = url; this.id = 0; this.pending = new Map(); }
-  async connect() {
-    return new Promise((resolve) => {
-      this.ws = new WebSocket(this.url, { perMessageDeflate: false });
-      this.ws.on('open', resolve);
-      this.ws.on('error', (e) => log(`${this.name} WS_ERR`, e.message));
-      this.ws.on('message', (raw) => {
-        const m = JSON.parse(raw.toString());
-        if (m.id != null && this.pending.has(m.id)) {
-          this.pending.get(m.id).resolve(m.result);
-          this.pending.delete(m.id);
-        }
-      });
-    });
-  }
-  send(method, params = {}) {
-    const i = ++this.id;
-    return new Promise((resolve) => {
-      this.pending.set(i, { resolve });
-      this.ws.send(JSON.stringify({ id: i, method, params }));
-    });
-  }
-  async evalJs(expr, awaitPromise = true) {
-    const r = await this.send('Runtime.evaluate', { expression: expr, returnByValue: true, awaitPromise });
-    if (r.exceptionDetails) throw new Error(r.exceptionDetails.text);
-    return r.result?.value;
-  }
-  close() { this.ws.close(); }
-}
-
-const popupCdp = new Cdp(popupTab.webSocketDebuggerUrl, 'popup');
+const popupCdp = new RawCdpClient(popupTab.webSocketDebuggerUrl, { name: 'popup', logger: log });
 await popupCdp.connect();
 log('popup connected');
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const EXT_ID = await resolveExtensionId({ targets: () => tabs }, { timeoutMs: 1 });
 await popupCdp.send('Page.enable');
 if (!popupTab.url.includes('popup.html')) {
   log('navigating popup tab to popup.html');
@@ -97,7 +70,7 @@ const ts = Date.now().toString().slice(-6);
 const testText = `Tutti realpost ${platform} ${ts}\n本文 line 2.`;
 
 log('dispatching POST_REQUEST to background');
-const dispatchResult = await popupCdp.evalJs(`(async () => {
+const dispatchResult = await popupCdp.evaluate(`(async () => {
   await new Promise(r => chrome.storage.sync.set({ settings: { autoPost: true, mastodonInstance: 'https://mastodon.social', misskeyInstance: 'https://misskey.io', selectorOverrideUrl: '', logLevel: 'INFO' } }, r));
   const s = await new Promise(r => chrome.storage.sync.get('settings', d => r(d.settings)));
   if (!s?.autoPost) return { err: 'autoPost still false' };
@@ -115,20 +88,15 @@ const dispatchResult = await popupCdp.evalJs(`(async () => {
 log('dispatch:', dispatchResult);
 
 // 当該 platform のタブを探して 90s 監視
-const start = Date.now();
 const MAX = 90000;
-let tab = null;
-while (Date.now() - start < MAX) {
-  await new Promise((r) => setTimeout(r, 2000));
-  const r = await fetch('http://localhost:9222/json/list');
-  const list = await r.json();
-  tab = list.find((t) => t.type === 'page' && re.test(t.url ?? ''));
-  if (tab) break;
-}
+const tab = await waitForCdpTarget(
+  (target) => target.type === 'page' && re.test(target.url ?? ''),
+  { timeoutMs: MAX, pollIntervalMs: 2_000 },
+).catch(() => null);
 if (!tab) { log(`no ${platform} tab opened in ${MAX}ms`); popupCdp.close(); process.exit(1); }
 
 log(`watching ${platform} tab: ${tab.url}`);
-const tabCdp = new Cdp(tab.webSocketDebuggerUrl, platform);
+const tabCdp = new RawCdpClient(tab.webSocketDebuggerUrl, { name: platform, logger: log });
 await tabCdp.connect();
 
 // 60s 監視 (URL 変化と発火)
@@ -138,7 +106,7 @@ let lastUrl = '';
 while (Date.now() - wstart < WMAX) {
   await new Promise((r) => setTimeout(r, 2000));
   let url;
-  try { url = await tabCdp.evalJs(`location.href`, false); } catch (e) { log(`eval err: ${e.message?.slice(0, 80)}`); continue; }
+  try { url = await tabCdp.evaluate(`location.href`, false); } catch (e) { log(`eval err: ${e.message?.slice(0, 80)}`); continue; }
   if (url !== lastUrl) { log(`t+${Math.round((Date.now() - wstart) / 1000)}s url=${url}`); lastUrl = url; }
 }
 log('done');

--- a/scripts/real-post-pixiv-cdp.mjs
+++ b/scripts/real-post-pixiv-cdp.mjs
@@ -7,7 +7,11 @@
 //
 // require: ws (puppeteer-core が dep に持ってるはず)
 import { writeFileSync, appendFileSync, readFileSync } from 'fs';
-import { WebSocket } from 'ws';
+import {
+  listCdpTargets,
+  RawCdpClient,
+  resolveExtensionId,
+} from './e2e/cdp-harness.mjs';
 
 const LOG = 'scripts/realpost-pixiv-cdp.log';
 writeFileSync(LOG, `=== ${new Date().toISOString()} ===\n`);
@@ -20,89 +24,11 @@ process.on('uncaughtException', (e) => { log('UNCAUGHT', e.message?.slice(0, 200
 process.on('unhandledRejection', (e) => { log('UNHANDLED_REJ', String(e)?.slice(0, 200)); });
 process.on('exit', (code) => { log(`process.exit(${code})`); });
 
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
-
-// CDP WebSocket client (1 target = 1 WS connection)
-class CdpClient {
-  constructor(url) {
-    this.url = url;
-    this.ws = null;
-    this.id = 0;
-    this.pending = new Map();
-  }
-  async connect() {
-    return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url, { perMessageDeflate: false });
-      this.ws.on('open', () => resolve());
-      this.ws.on('error', (e) => {
-        process.stdout.write(`WS_ERROR ${e.message?.slice(0, 100)}\n`);
-        if (this.pending.size === 0) reject(e);
-        else for (const { reject: rej } of this.pending.values()) rej(e);
-        this.pending.clear();
-      });
-      this.ws.on('close', (code, reason) => {
-        process.stdout.write(`WS_CLOSE code=${code} reason=${reason?.toString?.()?.slice?.(0, 60)}\n`);
-        for (const { reject: rej } of this.pending.values()) rej(new Error('WS closed'));
-        this.pending.clear();
-      });
-      this.ws.on('message', (raw) => {
-        const msg = JSON.parse(raw.toString());
-        if (msg.id != null && this.pending.has(msg.id)) {
-          const { resolve, reject } = this.pending.get(msg.id);
-          this.pending.delete(msg.id);
-          if (msg.error) reject(new Error(msg.error.message));
-          else resolve(msg.result);
-        }
-      });
-    });
-  }
-  send(method, params = {}) {
-    const id = ++this.id;
-    return new Promise((resolve, reject) => {
-      if (this.ws?.readyState !== WebSocket.OPEN) {
-        return reject(new Error(`WS not open (readyState=${this.ws?.readyState ?? 'null'})`));
-      }
-      this.pending.set(id, { resolve, reject });
-      try {
-        this.ws.send(JSON.stringify({ id, method, params }));
-      } catch (e) {
-        this.pending.delete(id);
-        reject(e);
-        return;
-      }
-      setTimeout(() => {
-        if (this.pending.has(id)) {
-          this.pending.delete(id);
-          reject(new Error(`CDP ${method} timeout`));
-        }
-      }, 30000);
-    });
-  }
-  async evaluate(expression, awaitPromise = false) {
-    const r = await this.send('Runtime.evaluate', {
-      expression,
-      returnByValue: true,
-      awaitPromise,
-    });
-    if (r.exceptionDetails) {
-      const exc = r.exceptionDetails;
-      throw new Error(`${exc.text} ${exc.exception?.description ?? ''}`.slice(0, 400));
-    }
-    return r.result?.value;
-  }
-  async navigate(url) {
-    await this.send('Page.enable');
-    await this.send('Page.navigate', { url });
-    await new Promise((r) => setTimeout(r, 2500)); // simple settle
-  }
-  close() { this.ws?.close(); }
-}
-
 // targets list
 log('fetching /json/list...');
-const r = await fetch('http://localhost:9222/json/list');
-const tabs = await r.json();
+const tabs = await listCdpTargets();
 log(`tabs: ${tabs.length}`);
+const EXT_ID = await resolveExtensionId({ targets: () => tabs }, { timeoutMs: 1 });
 
 // 任意の pixiv.net タブ。Tutti の openOrFocusTab が自動で /illustration/create に navigate
 const pixTab = tabs.find((t) => t.type === 'page' && /pixiv\.net\//.test(t.url));
@@ -116,8 +42,8 @@ if (!extTab) { log('no usable popup tab. open popup.html, chrome://extensions/, 
 log(`pixiv ws: ${pixTab.webSocketDebuggerUrl}`);
 log(`ext ws: ${extTab.webSocketDebuggerUrl}`);
 
-const pix = new CdpClient(pixTab.webSocketDebuggerUrl);
-const ext = new CdpClient(extTab.webSocketDebuggerUrl);
+const pix = new RawCdpClient(pixTab.webSocketDebuggerUrl, { name: 'pixiv', logger: log });
+const ext = new RawCdpClient(extTab.webSocketDebuggerUrl, { name: 'extension', logger: log });
 await pix.connect();
 log('pix connected');
 await ext.connect();

--- a/scripts/real-post-pixiv-direct.mjs
+++ b/scripts/real-post-pixiv-direct.mjs
@@ -1,7 +1,11 @@
 // popup UI を経由せず、background に直接 POST_REQUEST メッセージを送る driver。
 // popup の autoPost state race 問題を完全回避。
-import { WebSocket } from 'ws';
 import { writeFileSync, appendFileSync, readFileSync } from 'fs';
+import {
+  listCdpTargets,
+  RawCdpClient,
+  resolveExtensionId,
+} from './e2e/cdp-harness.mjs';
 
 const LOG = 'scripts/realpost-pixiv-direct.log';
 writeFileSync(LOG, `=== ${new Date().toISOString()} ===\n`);
@@ -11,52 +15,20 @@ const log = (...a) => {
   process.stdout.write(line + '\n');
 };
 
-const r = await fetch('http://localhost:9222/json/list');
-const tabs = await r.json();
+const tabs = await listCdpTargets();
 const pix = tabs.find(t => t.type === 'page' && /pixiv\.net/.test(t.url));
 const popupTab = tabs.find(t => t.type === 'page' && (/popup\.html|chrome:\/\/extensions/.test(t.url) || t.url === 'about:blank'));
 if (!pix || !popupTab) { log('missing tab', { pix: !!pix, popup: !!popupTab }); process.exit(1); }
 
-class Cdp {
-  constructor(url, name) { this.name = name; this.url = url; this.id = 0; this.pending = new Map(); }
-  async connect() {
-    return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url, { perMessageDeflate: false });
-      this.ws.on('open', resolve);
-      this.ws.on('error', (e) => log(`${this.name} WS_ERR`, e.message));
-      this.ws.on('message', (raw) => {
-        const m = JSON.parse(raw.toString());
-        if (m.id != null && this.pending.has(m.id)) {
-          this.pending.get(m.id).resolve(m.result);
-          this.pending.delete(m.id);
-        }
-      });
-    });
-  }
-  send(method, params = {}) {
-    const i = ++this.id;
-    return new Promise((resolve) => {
-      this.pending.set(i, { resolve });
-      this.ws.send(JSON.stringify({ id: i, method, params }));
-    });
-  }
-  async evalJs(expr, awaitPromise = true) {
-    const r = await this.send('Runtime.evaluate', { expression: expr, returnByValue: true, awaitPromise });
-    if (r.exceptionDetails) throw new Error(r.exceptionDetails.text);
-    return r.result?.value;
-  }
-  close() { this.ws.close(); }
-}
-
-const pixCdp = new Cdp(pix.webSocketDebuggerUrl, 'pix');
-const popupCdp = new Cdp(popupTab.webSocketDebuggerUrl, 'popup');
+const pixCdp = new RawCdpClient(pix.webSocketDebuggerUrl, { name: 'pixiv', logger: log });
+const popupCdp = new RawCdpClient(popupTab.webSocketDebuggerUrl, { name: 'popup', logger: log });
 await pixCdp.connect();
 await popupCdp.connect();
 log('both connected');
 
 // popup タブを popup.html に navigate (chrome.runtime API を使うため)
 await popupCdp.send('Page.enable');
-const EXT_ID = 'dophemlpjldcejjdjefpjbgngodopkfe';
+const EXT_ID = await resolveExtensionId({ targets: () => tabs }, { timeoutMs: 1 });
 if (!popupTab.url.includes('popup.html')) {
   log('navigating popup tab to popup.html');
   await popupCdp.send('Page.navigate', { url: `chrome-extension://${EXT_ID}/popup.html` });
@@ -78,7 +50,7 @@ const ts = Date.now().toString().slice(-6);
 const testText = `Tutti realpost ${ts}\n本文 line 2.`;
 
 log('dispatching POST_REQUEST to background (bypasses popup UI)');
-const dispatchResult = await popupCdp.evalJs(`(async () => {
+const dispatchResult = await popupCdp.evaluate(`(async () => {
   const bin = atob(${JSON.stringify(b64)});
   const arr = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
@@ -112,7 +84,7 @@ while (Date.now() - start < MAX) {
   await new Promise((r) => setTimeout(r, 2000));
   let snap;
   try {
-    snap = await pixCdp.evalJs(`({
+    snap = await pixCdp.evaluate(`({
       url: location.href,
       title: document.querySelector('input[name="title"]')?.value ?? null,
       capLen: (document.querySelector('textarea[name="comment"]')?.value ?? '').length,

--- a/scripts/test-tiktok-paste.mjs
+++ b/scripts/test-tiktok-paste.mjs
@@ -1,14 +1,10 @@
-import { WebSocket } from 'ws';
-const r = await fetch('http://localhost:9222/json/list');
-const tabs = await r.json();
+import { listCdpTargets, RawCdpClient } from './e2e/cdp-harness.mjs';
+
+const tabs = await listCdpTargets();
 const tt = tabs.find(t => t.type === 'page' && /tiktok\.com\/tiktokstudio/.test(t.url));
-const ws = new WebSocket(tt.webSocketDebuggerUrl);
-let id = 0;
-const pending = new Map();
-ws.on('message', raw => { const m = JSON.parse(raw.toString()); if (m.id != null && pending.has(m.id)) { pending.get(m.id).resolve(m.result); pending.delete(m.id); } });
-await new Promise(r => ws.on('open', r));
-const evalJs = (expr, awaitPromise = true) => new Promise(resolve => { const i = ++id; pending.set(i, { resolve }); ws.send(JSON.stringify({ id: i, method: 'Runtime.evaluate', params: { expression: expr, returnByValue: true, awaitPromise } })); }).then(r => r.result?.value);
-const result = await evalJs(`(async () => {
+if (!tt?.webSocketDebuggerUrl) throw new Error('TikTok Studio CDP target not found');
+const cdp = await new RawCdpClient(tt.webSocketDebuggerUrl, { name: 'tiktok' }).connect();
+const result = await cdp.evaluate(`(async () => {
   const ed = document.querySelector('.public-DraftEditor-content[contenteditable="true"]');
   if (!ed) return { err: 'no editor' };
   const before = (ed.textContent ?? '').slice(0, 50);
@@ -22,4 +18,4 @@ const result = await evalJs(`(async () => {
   return { before, after: (ed.textContent ?? '').slice(0, 100) };
 })()`);
 console.log(result);
-ws.close();
+cdp.close();

--- a/tests/cdp-harness.test.ts
+++ b/tests/cdp-harness.test.ts
@@ -6,13 +6,18 @@ import {
   connectPuppeteerCdp,
   disconnectCdp,
   extensionIdFromUrl,
+  fetchCdpJson,
+  listCdpTargets,
   loadE2eFixture,
+  RawCdpClient,
   resolveCdpEndpoint,
+  resolveCdpHttpEndpoint,
   resolveExtensionId,
   resolveFixturePath,
   withCdpBrowser,
   withTemporaryDirectory,
   withTimeout,
+  waitForCdpTarget,
 } from '../scripts/e2e/cdp-harness.mjs';
 
 describe('CDP harness', () => {
@@ -77,6 +82,85 @@ describe('CDP harness', () => {
       protocolTimeout: 91,
       slowMo: 10,
     });
+  });
+
+  it('normalizes HTTP endpoints and lists CDP targets', async () => {
+    expect(resolveCdpHttpEndpoint('ws://surface:9223/devtools/browser/abc'))
+      .toBe('http://surface:9223');
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ type: 'page', url: 'https://x.com/home' }],
+    });
+    await expect(listCdpTargets({
+      endpoint: 'http://surface:9223',
+      fetchImpl,
+    })).resolves.toEqual([{ type: 'page', url: 'https://x.com/home' }]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://surface:9223/json/list',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('rejects failed and malformed CDP target responses', async () => {
+    await expect(fetchCdpJson('json/list', {
+      endpoint: 'http://surface:9223',
+      fetchImpl: vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    })).rejects.toThrow('CDP HTTP 503');
+    await expect(listCdpTargets({
+      endpoint: 'http://surface:9223',
+      fetchImpl: vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    })).rejects.toThrow('not an array');
+  });
+
+  it('polls CDP targets with a bounded timeout', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ type: 'page', url: 'https://x.com/home' }],
+      });
+    await expect(waitForCdpTarget(
+      (target) => target.url?.includes('x.com') === true,
+      {
+        endpoint: 'http://surface:9223',
+        fetchImpl,
+        timeoutMs: 100,
+        pollIntervalMs: 1,
+      },
+    )).resolves.toEqual({ type: 'page', url: 'https://x.com/home' });
+  });
+
+  it('bounds raw CDP requests and resolves protocol results', async () => {
+    class FakeWebSocket {
+      static OPEN = 1;
+      readyState = 1;
+      listeners = new Map<string, Array<(...args: any[]) => void>>();
+      once(event: string, listener: (...args: any[]) => void) {
+        this.on(event, listener);
+        if (event === 'open') queueMicrotask(listener);
+      }
+      on(event: string, listener: (...args: any[]) => void) {
+        this.listeners.set(event, [...(this.listeners.get(event) ?? []), listener]);
+      }
+      send(payload: string) {
+        const request = JSON.parse(payload);
+        queueMicrotask(() => {
+          for (const listener of this.listeners.get('message') ?? []) {
+            listener(Buffer.from(JSON.stringify({
+              id: request.id,
+              result: { result: { value: 'ok' } },
+            })));
+          }
+        });
+      }
+      close() {}
+    }
+    const client = await new RawCdpClient('ws://surface/devtools/page/1', {
+      WebSocketImpl: FakeWebSocket,
+      timeoutMs: 50,
+    }).connect();
+    await expect(client.evaluate('location.href')).resolves.toBe('ok');
+    client.close();
   });
 
   it('discovers extension IDs from configuration, workers, pages, targets, and injected runtime', async () => {


### PR DESCRIPTION
Closes #138
Parent: #12 (Phase 9)

## Summary
- add shared CDP HTTP normalization, JSON target listing, bounded target polling, and a timeout-safe raw WebSocket client
- replace three duplicate raw CDP client classes plus the ad hoc TikTok client
- replace direct `/json/list` requests and fixed extension IDs with shared discovery
- preserve Runtime.evaluate, navigation, logging, and explicit close behavior

## Verification
- changed MJS syntax checks PASS
- raw harness contract tests 16/16 PASS
- `npm run verify:commit` (architecture 15/97; regular 95/728; build PASS)
- `git diff --check`

No production extension code or CWS state changed.