### PR TITLE
test: stabilize Surface matrix timeout evidence

### DIFF
--- a/docs/project-ground-rules.md
+++ b/docs/project-ground-rules.md
@@ -57,8 +57,11 @@ $env:E2E_EXTENSION_ID = '<loaded-extension-id>'
 node scripts/e2e/surface-posting-matrix.mjs --mode preview --repeat 2
 ```
 
-Use `--case-timeout-ms 180000` or lower when diagnosing failures so a hung SNS
-is recorded as a test failure instead of blocking the whole run.
+The default per-case budget is 360 seconds because grouped Surface video runs
+normally approach three minutes. Use `--case-timeout-ms 180000` or lower only
+when diagnosing failures. The JSON report is checkpointed after every completed
+or timed-out iteration and preserves any per-platform results recovered from
+background state.
 
 The matrix must cover, where supported by each SNS:
 

--- a/docs/surface-cws-release-flow.md
+++ b/docs/surface-cws-release-flow.md
@@ -157,8 +157,12 @@ node scripts/e2e/surface-posting-matrix.mjs --mode preview --repeat 2
 If a platform hangs, keep the failure visible instead of waiting indefinitely:
 
 ```powershell
-node scripts/e2e/surface-posting-matrix.mjs --mode preview --repeat 2 --case-timeout-ms 180000
+node scripts/e2e/surface-posting-matrix.mjs --mode preview --repeat 2 --case-timeout-ms 360000
 ```
+
+The report is checkpointed after every iteration. If a grouped request still
+times out, completed per-platform results and pending platform IDs are retained
+in the summary instead of losing the whole group.
 
 The matrix must pass the common draft shapes for every supported SNS: text only,
 image only, text + image, video only, text + video, image + video input

--- a/scripts/e2e/surface-posting-matrix-contract.d.mts
+++ b/scripts/e2e/surface-posting-matrix-contract.d.mts
@@ -8,3 +8,51 @@ export interface SurfaceMatrixOutcome {
 export function formatSurfaceMatrixOutcome(
   failures: readonly string[],
 ): SurfaceMatrixOutcome;
+
+export function validateSurfaceResultContract(input: {
+  mode: 'preview' | 'post';
+  caseName: string;
+  platform: string;
+  result?: {
+    success?: boolean;
+    preview?: boolean;
+    confirmed?: boolean;
+    url?: string;
+    error?: string;
+    flow?: {
+      submitReached?: boolean;
+      lastCompletedStep?: string;
+      failedStep?: string;
+    };
+    verify?: {
+      issues?: Array<{ severity?: string }>;
+    };
+  };
+}): string[];
+
+export function createTimedOutSurfaceSummary(input: {
+  caseName: string;
+  iteration: number;
+  platforms: string[];
+  error: string;
+  backgroundState: {
+    posting?: boolean;
+    postingState?: {
+      platforms?: string[];
+      pending?: string[];
+      done?: boolean;
+      results?: Array<{ platform?: string; [key: string]: unknown }>;
+    } | null;
+    error?: string;
+  };
+}): {
+  caseName: string;
+  iteration: number;
+  platforms: string[];
+  timedOut: true;
+  error: string;
+  results: Array<{ platform?: string; [key: string]: unknown }>;
+  completedPlatforms: string[];
+  pendingPlatforms: string[];
+  backgroundState: object;
+};

--- a/scripts/e2e/surface-posting-matrix-contract.mjs
+++ b/scripts/e2e/surface-posting-matrix-contract.mjs
@@ -17,3 +17,66 @@ export function formatSurfaceMatrixOutcome(failures) {
     ],
   };
 }
+
+export function validateSurfaceResultContract({
+  mode,
+  caseName,
+  platform,
+  result,
+}) {
+  const prefix = `${caseName}/${platform}`;
+  const failures = [];
+
+  if (!result) return [`${prefix}: missing result`];
+  if (!result.flow) {
+    failures.push(`${prefix}: result missing flow trace`);
+  } else if (!result.flow.lastCompletedStep && !result.flow.failedStep) {
+    failures.push(`${prefix}: flow trace has no completed or failed step`);
+  }
+  if (!result.success) {
+    failures.push(`${prefix}: success=false (${result.error ?? 'no error message'})`);
+    return failures;
+  }
+
+  if (mode === 'preview') {
+    if (result.preview !== true) failures.push(`${prefix}: preview result missing preview=true`);
+    if (result.url) failures.push(`${prefix}: preview returned URL ${result.url}`);
+    if (result.flow?.submitReached) failures.push(`${prefix}: preview reached submit action`);
+  } else {
+    if (result.preview) failures.push(`${prefix}: post result was marked preview`);
+    if (!result.confirmed) failures.push(`${prefix}: post result was not confirmed`);
+    if (!result.url) failures.push(`${prefix}: post URL was not captured`);
+    if (result.flow?.submitReached !== true) {
+      failures.push(`${prefix}: post result did not record submitReached=true`);
+    }
+  }
+
+  if (result.verify?.issues?.some((issue) => issue.severity === 'error')) {
+    failures.push(`${prefix}: verify hard error ${JSON.stringify(result.verify.issues)}`);
+  }
+  return failures;
+}
+
+export function createTimedOutSurfaceSummary({
+  caseName,
+  iteration,
+  platforms,
+  error,
+  backgroundState,
+}) {
+  const results = backgroundState?.postingState?.results ?? [];
+  const completedPlatforms = [...new Set(
+    results.map((result) => result.platform).filter(Boolean),
+  )];
+  return {
+    caseName,
+    iteration,
+    platforms,
+    timedOut: true,
+    error,
+    results,
+    completedPlatforms,
+    pendingPlatforms: platforms.filter((platform) => !completedPlatforms.includes(platform)),
+    backgroundState,
+  };
+}

--- a/scripts/e2e/surface-posting-matrix.mjs
+++ b/scripts/e2e/surface-posting-matrix.mjs
@@ -13,7 +13,7 @@
  *
  *   node scripts/e2e/surface-posting-matrix.mjs --mode post --cases image-only,text-image --platforms x,bluesky,threads
  *   node scripts/e2e/surface-posting-matrix.mjs --mode preview --repeat 2
- *   node scripts/e2e/surface-posting-matrix.mjs --mode preview --case-timeout-ms 180000
+ *   node scripts/e2e/surface-posting-matrix.mjs --mode preview --case-timeout-ms 360000
  */
 
 import { chromium } from 'playwright';
@@ -27,7 +27,11 @@ import {
   resolveExtensionId,
   withTimeout,
 } from './cdp-harness.mjs';
-import { formatSurfaceMatrixOutcome } from './surface-posting-matrix-contract.mjs';
+import {
+  createTimedOutSurfaceSummary,
+  formatSurfaceMatrixOutcome,
+  validateSurfaceResultContract,
+} from './surface-posting-matrix-contract.mjs';
 
 const ALL_PLATFORMS = [
   'x',
@@ -158,7 +162,7 @@ if (!Number.isInteger(repeat) || repeat < 1) {
   console.error(`[matrix] invalid --repeat: ${argValue('--repeat')}`);
   process.exit(2);
 }
-const caseTimeoutMs = Number(argValue('--case-timeout-ms') ?? '180000');
+const caseTimeoutMs = Number(argValue('--case-timeout-ms') ?? '360000');
 if (!Number.isInteger(caseTimeoutMs) || caseTimeoutMs < 10_000) {
   console.error(`[matrix] invalid --case-timeout-ms: ${argValue('--case-timeout-ms')}`);
   process.exit(2);
@@ -218,6 +222,18 @@ console.log(`[matrix] extension version=${version}`);
 
 const failures = [];
 const summary = [];
+const persistSummary = async () => {
+  await writeSummary(summaryPath, {
+    mode,
+    version,
+    platforms: requestedPlatforms,
+    cases: requestedCases,
+    repeat,
+    failures,
+    summary,
+    generatedAt: new Date().toISOString(),
+  });
+};
 
 for (const caseName of requestedCases) {
   const caseDef = CASES[caseName];
@@ -233,6 +249,7 @@ for (const caseName of requestedCases) {
       skipped: true,
       reason: 'no supported target platforms in this run',
     });
+    await persistSummary();
     continue;
   }
 
@@ -267,23 +284,32 @@ for (const caseName of requestedCases) {
       }), caseTimeoutMs, `${caseName}/${platforms.join(',')}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const backgroundState = debugBgStateOnTimeout
-        ? await readBackgroundState(popup).then(compactBackgroundState).catch((stateErr) => ({
-            error: stateErr instanceof Error ? stateErr.message : String(stateErr),
-          }))
-        : undefined;
-      if (backgroundState) {
+      const backgroundState = await readBackgroundState(popup)
+        .then(compactBackgroundState)
+        .catch((stateErr) => ({
+          error: stateErr instanceof Error ? stateErr.message : String(stateErr),
+        }));
+      if (debugBgStateOnTimeout) {
         console.log(`[matrix] bg-state-on-timeout ${caseName}: ${JSON.stringify(backgroundState)}`);
       }
+      const recoveredResults = backgroundState?.postingState?.results ?? [];
+      for (const result of recoveredResults) {
+        failures.push(...validateSurfaceResultContract({
+          mode,
+          caseName,
+          platform: result.platform,
+          result,
+        }));
+      }
       failures.push(`${caseName}: ${message}`);
-      summary.push({
+      summary.push(createTimedOutSurfaceSummary({
         caseName,
         iteration: i,
         platforms,
-        timedOut: true,
         error: message,
-        ...(backgroundState ? { backgroundState } : {}),
-      });
+        backgroundState,
+      }));
+      await persistSummary();
       await reloadExtension(ctx, extensionId).catch(() => {});
       await closeNonExtensionPages(ctx, extensionId).catch(() => {});
       popup = await openPopupPage(ctx, extensionId).catch(() => popup);
@@ -303,23 +329,14 @@ for (const caseName of requestedCases) {
     const byPlatform = new Map(results.map((result) => [result.platform, result]));
     for (const platform of platforms) {
       const result = byPlatform.get(platform);
-      if (!result) {
-        failures.push(`${caseName}/${platform}: missing result`);
-        continue;
-      }
-      if (!result.flow) {
-        failures.push(`${caseName}/${platform}: result missing flow trace`);
-      } else if (!result.flow.lastCompletedStep && !result.flow.failedStep) {
-        failures.push(`${caseName}/${platform}: flow trace has no completed or failed step`);
-      }
-      if (!result.success) {
-        failures.push(`${caseName}/${platform}: success=false (${result.error ?? 'no error message'})`);
-        continue;
-      }
+      failures.push(...validateSurfaceResultContract({
+        mode,
+        caseName,
+        platform,
+        result,
+      }));
+      if (!result?.success) continue;
       if (mode === 'preview') {
-        if (result.preview !== true) failures.push(`${caseName}/${platform}: preview result missing preview=true`);
-        if (result.url) failures.push(`${caseName}/${platform}: preview returned URL ${result.url}`);
-        if (result.flow?.submitReached) failures.push(`${caseName}/${platform}: preview reached submit action`);
         if (caseDef.verifyPreviewDraftText && PREVIEW_DRAFT_READERS[platform]) {
           const draft = await waitForPreviewDraftText(ctx, platform, text);
           if (!draft.found) {
@@ -333,10 +350,6 @@ for (const caseName of requestedCases) {
           }
         }
       } else {
-        if (result.preview) failures.push(`${caseName}/${platform}: post result was marked preview`);
-        if (!result.confirmed) failures.push(`${caseName}/${platform}: post result was not confirmed`);
-        if (!result.url) failures.push(`${caseName}/${platform}: post URL was not captured`);
-        if (result.flow?.submitReached !== true) failures.push(`${caseName}/${platform}: post result did not record submitReached=true`);
         const expectedUrls = platform === 'tumblr' ? extractHttpUrls(text) : [];
         if (result.url && expectedUrls.length > 0) {
           const urlCheck = await checkPublishedUrlEvidence(result.url, expectedUrls);
@@ -366,9 +379,6 @@ for (const caseName of requestedCases) {
           }
         }
       }
-      if (result.verify?.issues?.some((issue) => issue.severity === 'error')) {
-        failures.push(`${caseName}/${platform}: verify hard error ${JSON.stringify(result.verify.issues)}`);
-      }
     }
 
     if (mode === 'preview') {
@@ -392,22 +402,14 @@ for (const caseName of requestedCases) {
       ...(Object.keys(publishedTextEvidence).length > 0 ? { publishedTextEvidence } : {}),
       ...(Object.keys(publishedMediaEvidence).length > 0 ? { publishedMediaEvidence } : {}),
     });
+    await persistSummary();
     await closeNonExtensionPages(ctx, extensionId);
   }
 }
 
 console.log('\n[matrix] summary');
 console.log(JSON.stringify(summary, null, 2));
-await writeSummary(summaryPath, {
-  mode,
-  version,
-  platforms: requestedPlatforms,
-  cases: requestedCases,
-  repeat,
-  failures,
-  summary,
-  generatedAt: new Date().toISOString(),
-});
+await persistSummary();
 
 await popup.close().catch(() => {});
 await disconnectCdp(browser);
@@ -501,7 +503,14 @@ async function waitForPreviewDraftText(ctx, platform, expectedText, timeoutMs = 
   let last = { found: false };
   do {
     last = await readPreviewDraftText(ctx, platform);
-    if (last.found && last.text === expectedText) return last;
+    const exact = last.candidates?.find((candidate) => candidate.text === expectedText);
+    if (exact) {
+      return {
+        ...last,
+        text: exact.text,
+        url: exact.pageUrl,
+      };
+    }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
   } while (Date.now() < deadline);
   return last;

--- a/tests/surface-posting-matrix-contract.test.ts
+++ b/tests/surface-posting-matrix-contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { formatSurfaceMatrixOutcome } from '../scripts/e2e/surface-posting-matrix-contract.mjs';
+import {
+  createTimedOutSurfaceSummary,
+  formatSurfaceMatrixOutcome,
+  validateSurfaceResultContract,
+} from '../scripts/e2e/surface-posting-matrix-contract.mjs';
 
 describe('Surface posting matrix CLI contract', () => {
   it('keeps the successful release-gate output and exit code stable', () => {
@@ -25,5 +29,97 @@ describe('Surface posting matrix CLI contract', () => {
         '  - text-image/threads: post URL missing',
       ],
     });
+  });
+});
+
+describe('Surface posting matrix result contract', () => {
+  it('preserves completed platform results and identifies only pending platforms', () => {
+    const result = {
+      platform: 'x',
+      success: true,
+      preview: true,
+    };
+    const backgroundState = {
+      posting: true,
+      postingState: {
+        platforms: ['x', 'youtube'],
+        pending: ['youtube'],
+        done: false,
+        results: [result],
+      },
+    };
+
+    expect(createTimedOutSurfaceSummary({
+      caseName: 'video-only',
+      iteration: 2,
+      platforms: ['x', 'youtube'],
+      error: 'timed out after 360000ms',
+      backgroundState,
+    })).toEqual({
+      caseName: 'video-only',
+      iteration: 2,
+      platforms: ['x', 'youtube'],
+      timedOut: true,
+      error: 'timed out after 360000ms',
+      results: [result],
+      completedPlatforms: ['x'],
+      pendingPlatforms: ['youtube'],
+      backgroundState,
+    });
+  });
+
+  it('accepts a safe completed preview result recovered after a timeout', () => {
+    expect(validateSurfaceResultContract({
+      mode: 'preview',
+      caseName: 'video-only',
+      platform: 'x',
+      result: {
+        success: true,
+        preview: true,
+        flow: {
+          submitReached: false,
+          lastCompletedStep: 'verify-login',
+        },
+      },
+    })).toEqual([]);
+  });
+
+  it('keeps unsafe recovered results visible', () => {
+    expect(validateSurfaceResultContract({
+      mode: 'preview',
+      caseName: 'video-only',
+      platform: 'x',
+      result: {
+        success: true,
+        preview: true,
+        url: 'https://x.com/example/status/1',
+        flow: {
+          submitReached: true,
+          lastCompletedStep: 'click-submit',
+        },
+      },
+    })).toEqual([
+      'video-only/x: preview returned URL https://x.com/example/status/1',
+      'video-only/x: preview reached submit action',
+    ]);
+  });
+
+  it('requires confirmation, URL, and submit evidence in post mode', () => {
+    expect(validateSurfaceResultContract({
+      mode: 'post',
+      caseName: 'text-only',
+      platform: 'x',
+      result: {
+        success: true,
+        flow: {
+          submitReached: false,
+          lastCompletedStep: 'wait-submit',
+        },
+      },
+    })).toEqual([
+      'text-only/x: post result was not confirmed',
+      'text-only/x: post URL was not captured',
+      'text-only/x: post result did not record submitReached=true',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #20
Parent: #12 (Phase 9)

## Summary
- raise the default grouped-case budget to the observed Surface-safe 360 seconds
- checkpoint the JSON report after every completed or timed-out iteration
- recover completed per-platform results and pending IDs from background state on timeout
- apply the same preview/post safety contract to recovered results
- prefer an exact Threads draft candidate when duplicate Lexical editors briefly coexist

## Verification
- focused matrix contract: 6/6 PASS
- architecture: 16 files / 99 tests PASS
- full: 97 files / 736 tests + production build PASS
- CI `verify`: PASS

## Exact-script Surface verification
- commit: `95a3333779822e2362387a8b4b60036c91649fb7`
- extension: `0.5.49`, id `heffmapbljoonmjghklgjhmfnldaeome`
- ZIP SHA-256: `926F7B40C71FC35403D9F702696AE4D8F46D59DE9E4D4D6639EEF862A90EE084`
- `background.js` SHA-256: `7E5B1135FC7F1EEF20CEFFADC19C76A1F4DC6A6A023671BCEC0A3BA240228481`; staged Surface hash matched
- intentional timeout: `--platforms x,bluesky,mastodon,misskey,tumblr,instagram,tiktok,youtube --cases image-video --repeat 1 --case-timeout-ms 30000 --debug-bg-state-on-timeout`
  - expected CLI FAIL on the 30-second timeout
  - recovered X and Bluesky as completed safe previews (`success=true`, `preview=true`, no URL, `submitReached=false`)
  - retained Mastodon, Misskey, Tumblr, Instagram, TikTok, and YouTube as pending
  - checkpoint JSON remained readable after recovery/reload
- normal default-budget run: `--platforms x,bluesky --cases image-video --repeat 1` — PASS 2/2 with `caseTimeoutMs=360000`, no submit/URL/history side effect
- no CWS upload or submission