### PR TITLE
fix: open Threads composer from authenticated home

### DIFF
--- a/entrypoints/threads.content.ts
+++ b/entrypoints/threads.content.ts
@@ -50,6 +50,9 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     timeoutMs: 20_000,
     clickInMainWorld: true,
   });
+  if (!replyContinuation) {
+    await ensureThreadsComposerOpen(sel.textarea);
+  }
   const textareaSelector = replyContinuation ? replyTextareaSelector : sel.textarea;
   const dropTargetSelector = replyContinuation
     ? '[role="dialog"] [role="textbox"]'
@@ -151,6 +154,22 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     confirmed,
     url,
   };
+}
+
+async function ensureThreadsComposerOpen(textareaSelector: string): Promise<void> {
+  if (document.querySelector(textareaSelector)) return;
+
+  await clickElementInMainWorld(
+    '[role="button"], button',
+    ['New thread', '新しいスレッド', "What's new?", '新規投稿', '新しい投稿'],
+  );
+  const textarea = await waitForCondition<HTMLElement>(
+    () => document.querySelector<HTMLElement>(textareaSelector),
+    { timeoutMs: 12_000 },
+  );
+  if (!textarea) {
+    throw new Error('Threads composer dialog did not open from the authenticated home page.');
+  }
 }
 
 async function assertThreadsMediaAttached(timeoutMs: number): Promise<void> {

--- a/scripts/e2e/platforms/threads.mjs
+++ b/scripts/e2e/platforms/threads.mjs
@@ -2,9 +2,9 @@
  * Threads E2E real-post test
  *
  * 流れ:
- *   1. https://www.threads.com/intent/post に navigate (= compose modal が開く)
- *   2. ログイン状態確認 (compose textarea が居る)
- *   3. POST_TO_PLATFORM 投げて投稿成功を待つ
+ *   1. https://www.threads.com/ に navigate
+ *   2. ログイン状態確認
+ *   3. POST_TO_PLATFORM を投げ、content script が native composer を開いて投稿
  *
  * Cleanup は未実装 (Threads UI 経由の delete は menu 多段で fragile)
  */
@@ -14,8 +14,10 @@ import { ensureLoggedIn, sendPostMessage, timestampedText } from '../_lib.mjs';
 // Chrome の match pattern は TLD 部分の `*` (例 'https://www.threads.*/*') を受け
 // 付けない。array で 2 個渡すと chrome.tabs.query が or 条件で検索してくれる。
 const URL_GLOB = ['https://www.threads.com/*', 'https://www.threads.net/*'];
-const COMPOSE_URL = 'https://www.threads.com/intent/post';
-const TEXTAREA = 'div[contenteditable="true"][role="textbox"], div[contenteditable="plaintext-only"]';
+const COMPOSE_URL = 'https://www.threads.com/';
+const HOME_TRIGGER =
+  'svg[aria-label="New thread"], svg[aria-label="新しいスレッド"],' +
+  '[role="button"][aria-label*="compose"]';
 
 export async function run({ ctx, debug }) {
   const text = timestampedText('threads');
@@ -25,10 +27,9 @@ export async function run({ ctx, debug }) {
   });
 
   await page.goto(COMPOSE_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
-  // intent/post は compose modal が立つので少し待つ
   await page.waitForTimeout(2000);
 
-  const auth = await ensureLoggedIn(page, TEXTAREA, 'threads');
+  const auth = await ensureLoggedIn(page, HOME_TRIGGER, 'threads');
   if (!auth.ok) return auth;
 
   const sendResult = await sendPostMessage(ctx, {

--- a/src/adapters/threads.test.ts
+++ b/src/adapters/threads.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { THREADS_SELECTORS, threadsAdapter } from './threads';
 
 describe('Threads adapter compose flow', () => {
-  it('does not send text through the intent URL because Threads corrupts non-BMP Unicode', () => {
+  it('opens the authenticated home composer without putting text in the URL', () => {
     const text = 'emoji 😀 🧑‍💻 ❤️‍🔥 日本語';
     const composeUrl = threadsAdapter.getComposeUrl(text);
 
-    expect(composeUrl).toBe('https://www.threads.com/intent/post');
+    expect(composeUrl).toBe('https://www.threads.com/');
     expect(composeUrl).not.toContain(encodeURIComponent(text));
     expect(threadsAdapter.prefillsViaUrl).toBe(false);
   });
 
-  it('targets only the visible intent dialog editor, not the feed composer behind it', () => {
+  it('targets only the visible composer dialog editor, not the feed trigger behind it', () => {
     expect(THREADS_SELECTORS.textarea).toContain('[role="dialog"]');
     expect(THREADS_SELECTORS.textarea).not.toMatch(/(?:^|,)\s*div\[contenteditable/);
   });

--- a/src/adapters/threads.ts
+++ b/src/adapters/threads.ts
@@ -13,8 +13,9 @@ export const threadsAdapter: PlatformAdapter = {
   defaultSelected: true,
   // 2025 以降 threads.com に段階移行中。両ドメインを許容
   matchUrl: (url) => /^https:\/\/www\.threads\.(?:net|com)\//.test(url),
-  // 新ドメイン threads.com の空 composer を使う(threads.net は redirect 想定)。
-  getComposeUrl: () => 'https://www.threads.com/intent/post',
+  // /intent/post はログイン済み session だけ HTTP 429 になる場合がある。
+  // 認証済み home を開き、content script から native composer dialog を起動する。
+  getComposeUrl: () => 'https://www.threads.com/',
   getLoginUrl: () => 'https://www.threads.com/',
   prefillsViaUrl: false,
   videoConstraints: {

--- a/src/utils/compose-url.test.ts
+++ b/src/utils/compose-url.test.ts
@@ -4,6 +4,7 @@ import { isKnownComposeUrl } from './compose-url';
 describe('isKnownComposeUrl', () => {
   it('recognizes URL-prefill compose routes used in issue diagnostics', () => {
     expect(isKnownComposeUrl('bluesky', 'https://bsky.app/intent/compose?text=hi')).toBe(true);
+    expect(isKnownComposeUrl('threads', 'https://www.threads.com/')).toBe(true);
     expect(isKnownComposeUrl('threads', 'https://www.threads.com/intent/post?text=hi')).toBe(true);
     expect(isKnownComposeUrl('misskey', 'https://misskey.io/share?text=hi')).toBe(true);
   });

--- a/src/utils/compose-url.ts
+++ b/src/utils/compose-url.ts
@@ -18,7 +18,8 @@ export function isKnownComposeUrl(platform: PlatformId, rawUrl: string): boolean
     case 'bluesky':
       return host === 'bsky.app' && path === '/intent/compose';
     case 'threads':
-      return /^www\.threads\.(com|net)$/.test(host) && path === '/intent/post';
+      return /^www\.threads\.(com|net)$/.test(host) &&
+        (path === '/' || path === '/intent/post');
     case 'mastodon':
     case 'misskey':
       return path === '/share';


### PR DESCRIPTION
Closes #144
Unblocks #12 Surface gate

## Summary
- navigate fresh Threads posts to the authenticated home page instead of the rate-limited /intent/post route
- open the native New thread dialog in MAIN world before the existing dialog-scoped injection flow
- preserve reply continuation and all existing editor/media/post selectors
- recognize both home and legacy intent URLs in diagnostics
- update the maintained Threads E2E route

## Verification
- focused 3 files / 24 tests PASS
- architecture 16 / 99 PASS
- full 98 files / 737 tests + production build PASS

## Exact Surface artifact
- commit: b22997e
- extension: 0.5.49 (`heffmapbljoonmjghklgjhmfnldaeome`)
- ZIP SHA-256: `1461405243D962BD78A198F6635E97CE03FE3726370272B4F7FBE62EFAD7BB10`
- background SHA-256: `10725EA5E18AFFBF988646AADD1D2174E9F5539397FF528F960EC1B5C8F4926F`
- preview command: `node scripts/e2e/surface-posting-matrix.mjs --mode preview --platforms threads --cases text-only,text-emoji,image-only,text-image,video-only,text-video --repeat 2 --case-timeout-ms 360000`
- preview: PASS, 12/12; all `flow.submitReached=false`, no URLs, no history writes
- real command: `node scripts/e2e/surface-posting-matrix.mjs --mode post --platforms threads --cases text-only --repeat 1 --case-timeout-ms 360000`
- real post: PASS; `success=true`, `confirmed=true`, `flow.submitReached=true`, verify issues=[]
- post URL: https://www.threads.com/@ren.fujimoto.89/post/DbULwUsE87gwnLt92OBRlvX31HReW5c-pXP3Zo0

No CWS upload/submission was performed.