### PR TITLE
feat: persist post implementation diagnostics

### DIFF
--- a/scripts/e2e/surface-posting-matrix-contract.d.mts
+++ b/scripts/e2e/surface-posting-matrix-contract.d.mts
@@ -17,6 +17,10 @@ export function validateSurfaceResultContract(input: {
     success?: boolean;
     preview?: boolean;
     confirmed?: boolean;
+    implementation?: {
+      revision?: number;
+      path?: 'next' | 'legacy';
+    };
     url?: string;
     error?: string;
     flow?: {

--- a/scripts/e2e/surface-posting-matrix-contract.mjs
+++ b/scripts/e2e/surface-posting-matrix-contract.mjs
@@ -28,6 +28,13 @@ export function validateSurfaceResultContract({
   const failures = [];
 
   if (!result) return [`${prefix}: missing result`];
+  if (
+    result.implementation?.path !== 'next'
+    || !Number.isInteger(result.implementation?.revision)
+    || result.implementation.revision < 1
+  ) {
+    failures.push(`${prefix}: missing or invalid next implementation diagnostics`);
+  }
   if (!result.flow) {
     failures.push(`${prefix}: result missing flow trace`);
   } else if (!result.flow.lastCompletedStep && !result.flow.failedStep) {

--- a/scripts/e2e/surface-posting-matrix.mjs
+++ b/scripts/e2e/surface-posting-matrix.mjs
@@ -750,6 +750,7 @@ function compactResult(result) {
     preview: result.preview,
     confirmed: result.confirmed,
     uncertain: result.uncertain,
+    implementation: result.implementation,
     userAction: result.userAction,
     flow: result.flow,
     url: result.url,

--- a/src/background/diagnostics.test.ts
+++ b/src/background/diagnostics.test.ts
@@ -67,6 +67,10 @@ describe('diagnostic redaction helpers', () => {
         x: {
           success: false,
           uncertain: true,
+          implementation: {
+            revision: 1,
+            path: 'next',
+          },
           submissionGuard: {
             decision: 'indeterminate',
             reason: 'recent-uncertain',
@@ -93,6 +97,10 @@ describe('diagnostic redaction helpers', () => {
         x: {
           success: false,
           uncertain: true,
+          implementation: {
+            revision: 1,
+            path: 'next',
+          },
           submissionGuard: {
             decision: 'indeterminate',
             reason: 'recent-uncertain',

--- a/src/background/diagnostics.ts
+++ b/src/background/diagnostics.ts
@@ -23,6 +23,7 @@ export interface DiagnosticsReport {
     results: Partial<Record<PlatformId, {
       success: boolean;
       uncertain?: boolean;
+      implementation?: HistoryPlatformResult['implementation'];
       submissionGuard?: HistoryPlatformResult['submissionGuard'];
       userAction?: HistoryPlatformResult['userAction'];
       flow?: HistoryPlatformResult['flow'];
@@ -116,6 +117,7 @@ export function redactHistoryForDiagnostics(
       Object.entries(h.results).map(([k, v]) => [k, {
         success: v?.success ?? false,
         uncertain: v?.uncertain ?? false,
+        implementation: v?.implementation,
         submissionGuard: v?.submissionGuard,
         userAction: v?.userAction,
         flow: v?.flow,

--- a/src/background/post-request-handler.ts
+++ b/src/background/post-request-handler.ts
@@ -7,6 +7,7 @@ import type { createPlatformPoster } from './platform-poster';
 import {
   normalizePostEvidence,
   shouldRunPostCompletionSideEffects,
+  withPostImplementationDiagnostics,
 } from './post-result-policy';
 import { runPostScheduler } from './post-scheduler';
 import { clearBadge, notifyResults } from './post-status-ui';
@@ -69,13 +70,16 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
       run: async (reservation) => {
         const platforms = reservation.allowedPlatforms;
         const requestedPlatforms = reservation.decisions.map(({ platform }) => platform);
+        const rejectedResults = reservation.rejectedResults.map(
+          withPostImplementationDiagnostics,
+        );
 
         // Guard reservation が確定するまで tab / posting side effect を開始しない。
         // POST_REQUEST ごとに cleanup 所有権を切り、前回 state を完全上書きする。
         openedTabs.clear();
         postingState.start(requestedPlatforms);
         postingStateStarted = true;
-        for (const rejected of reservation.rejectedResults) {
+        for (const rejected of rejectedResults) {
           const guard = rejected.submissionGuard;
           appendBackgroundLog(
             `SubmissionGuard decision=${guard?.decision ?? 'indeterminate'} ` +
@@ -88,7 +92,7 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
         if (platforms.length === 0) {
           clearBadge();
           openedTabs.clear();
-          return reservation.rejectedResults;
+          return rejectedResults;
         }
 
         // 投稿前に動画を安全な MP4/H.264/AAC へ正規化し、必要に応じて
@@ -108,20 +112,22 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
           platforms,
           autoPost,
           planOptions: { hasVideo },
-          post: async (platform, execution) => normalizePostEvidence(
-            await platformPoster.postToPlatform(
-              platform,
-              request.text,
-              adjustedImages,
-              request.cw,
-              request.visibility,
-              autoPost,
-              { forceForeground: execution.forceForeground },
+          post: async (platform, execution) => withPostImplementationDiagnostics(
+            normalizePostEvidence(
+              await platformPoster.postToPlatform(
+                platform,
+                request.text,
+                adjustedImages,
+                request.cw,
+                request.visibility,
+                autoPost,
+                { forceForeground: execution.forceForeground },
+              ),
             ),
           ),
           onResult: recordPlatformProgress,
         });
-        const results = [...reservation.rejectedResults, ...executionResults];
+        const results = [...rejectedResults, ...executionResults];
 
         if (shouldRunPostCompletionSideEffects(autoPost, executionResults)) {
           notifyResults(results);

--- a/src/background/post-result-policy.test.ts
+++ b/src/background/post-result-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { PostResultMessage } from '../messages';
 import {
   buildFinalChunkResult,
+  CURRENT_POST_IMPLEMENTATION,
   downgradeHardVerifyFailures,
   hasDurablePostEvidence,
   normalizePostEvidence,
@@ -11,9 +12,24 @@ import {
   toPreviewResult,
   unconfirmedPostResult,
   withFlow,
+  withPostImplementationDiagnostics,
 } from './post-result-policy';
 
 describe('post result policy', () => {
+  it('tags results with the background-owned next implementation revision', () => {
+    const result = withPostImplementationDiagnostics({
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      implementation: {
+        revision: 999,
+        path: 'legacy',
+      },
+    });
+
+    expect(result.implementation).toEqual(CURRENT_POST_IMPLEMENTATION);
+  });
+
   it('preserves the final chunk flow trace on aggregated preview results', () => {
     const result = buildFinalChunkResult('x', false, true, undefined, {
       mode: 'preview',

--- a/src/background/post-result-policy.ts
+++ b/src/background/post-result-policy.ts
@@ -5,6 +5,20 @@ import type {
 } from '../messages';
 import { t } from '../utils/i18n';
 
+export const CURRENT_POST_IMPLEMENTATION = {
+  revision: 1,
+  path: 'next',
+} as const;
+
+export function withPostImplementationDiagnostics(
+  result: PostResultMessage,
+): PostResultMessage {
+  return {
+    ...result,
+    implementation: CURRENT_POST_IMPLEMENTATION,
+  };
+}
+
 export function toPreviewResult(result: PostResultMessage): PostResultMessage {
   const { url: _url, verify: _verify, confirmed: _confirmed, ...rest } = result;
   return {

--- a/src/messages/posting.ts
+++ b/src/messages/posting.ts
@@ -45,6 +45,13 @@ export interface SubmissionGuardTrace {
   requestId: string;
 }
 
+export type PostImplementationPath = 'next' | 'legacy';
+
+export interface PostImplementationDiagnostics {
+  revision: number;
+  path: PostImplementationPath;
+}
+
 export interface PostRequestMessage {
   type: 'POST_REQUEST';
   requestId: string;
@@ -78,6 +85,7 @@ export interface PostResultMessage {
   preview?: boolean;
   confirmed?: boolean;
   uncertain?: boolean;
+  implementation?: PostImplementationDiagnostics;
   submissionGuard?: SubmissionGuardTrace;
   userAction?: UserActionCategory;
   flow?: PostFlowTrace;

--- a/src/storage/history-implementation.test.ts
+++ b/src/storage/history-implementation.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { addToPostHistory } from './history';
+
+describe('history implementation diagnostics', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('persists the selected implementation path and revision per platform', async () => {
+    let storedHistory: unknown[] = [];
+    const set = vi.fn(async (values: Record<string, unknown>) => {
+      storedHistory = values['postHistory'] as unknown[];
+    });
+    vi.stubGlobal('browser', {
+      storage: {
+        local: {
+          get: vi.fn(async () => ({ postHistory: storedHistory })),
+          set,
+        },
+      },
+    });
+
+    await addToPostHistory('diagnostic post', [{
+      type: 'POST_RESULT',
+      platform: 'x',
+      success: true,
+      confirmed: true,
+      implementation: {
+        revision: 1,
+        path: 'next',
+      },
+      url: 'https://x.com/example/status/1',
+    }], false);
+
+    expect(set).toHaveBeenCalledOnce();
+    expect(storedHistory).toEqual([
+      expect.objectContaining({
+        results: {
+          x: expect.objectContaining({
+            implementation: {
+              revision: 1,
+              path: 'next',
+            },
+          }),
+        },
+      }),
+    ]);
+  });
+});

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -5,6 +5,7 @@ export interface HistoryPlatformResult {
   success: boolean;
   confirmed?: boolean;
   uncertain?: boolean;
+  implementation?: PostResultMessage['implementation'];
   submissionGuard?: PostResultMessage['submissionGuard'];
   userAction?: PostResultMessage['userAction'];
   flow?: Pick<
@@ -93,6 +94,7 @@ export async function addToPostHistory(
           success: result.success,
           confirmed: result.confirmed,
           uncertain: result.uncertain,
+          implementation: result.implementation,
           submissionGuard: result.submissionGuard,
           userAction: result.userAction,
           flow: result.flow

--- a/tests/surface-posting-matrix-contract.test.ts
+++ b/tests/surface-posting-matrix-contract.test.ts
@@ -76,6 +76,10 @@ describe('Surface posting matrix result contract', () => {
       result: {
         success: true,
         preview: true,
+        implementation: {
+          revision: 1,
+          path: 'next',
+        },
         flow: {
           submitReached: false,
           lastCompletedStep: 'verify-login',
@@ -92,6 +96,10 @@ describe('Surface posting matrix result contract', () => {
       result: {
         success: true,
         preview: true,
+        implementation: {
+          revision: 1,
+          path: 'next',
+        },
         url: 'https://x.com/example/status/1',
         flow: {
           submitReached: true,
@@ -111,6 +119,10 @@ describe('Surface posting matrix result contract', () => {
       platform: 'x',
       result: {
         success: true,
+        implementation: {
+          revision: 1,
+          path: 'next',
+        },
         flow: {
           submitReached: false,
           lastCompletedStep: 'wait-submit',
@@ -120,6 +132,24 @@ describe('Surface posting matrix result contract', () => {
       'text-only/x: post result was not confirmed',
       'text-only/x: post URL was not captured',
       'text-only/x: post result did not record submitReached=true',
+    ]);
+  });
+
+  it('rejects results without background-owned next implementation diagnostics', () => {
+    expect(validateSurfaceResultContract({
+      mode: 'preview',
+      caseName: 'text-only',
+      platform: 'x',
+      result: {
+        success: true,
+        preview: true,
+        flow: {
+          submitReached: false,
+          lastCompletedStep: 'wait-submit',
+        },
+      },
+    })).toEqual([
+      'text-only/x: missing or invalid next implementation diagnostics',
     ]);
   });
 });


### PR DESCRIPTION
Closes #146
Parent: #12

## Summary
- tag every background `POST_REQUEST` result with authoritative `implementation: { revision: 1, path: "next" }`
- override any untrusted/content-provided tag at the background boundary
- persist the optional diagnostics in existing bounded History entries and include them in PII-redacted reports
- require valid next-path diagnostics in the Surface release-gate contract

## Verification
- focused: 4 files / 29 tests PASS
- architecture: 17 files / 114 tests PASS
- full: 112 files / 804 tests PASS
- TypeScript compile and production build PASS
- CI PASS

## Exact Surface artifact
- commit: `7901f1ae01fd383199a149ba5c2556ee3a1971e1`
- extension: 0.5.49 (`heffmapbljoonmjghklgjhmfnldaeome`)
- ZIP SHA-256: `5A97E8D5E5C7979F5DAB8855FEC5AC1B1B66E274A607E75A3BA85D2452A90796`
- background SHA-256: `A9746E6B1D703443E3A83205839803001F93D3BF72D48BEFF3F625B54062BFF1`
- representative all-platform preview: `text-only,image-only,video-only`, 23/23 PASS
- Pixiv supplemental `long-text-image`: 1/1 PASS
- combined: all 11 SNS covered; 24/24 results carried revision 1 / next; failures 0; unsafe submits 0

No CWS upload/submission was performed.