### PR TITLE
perf: reduce next posting latency

### DIFF
--- a/entrypoints/bluesky.content.ts
+++ b/entrypoints/bluesky.content.ts
@@ -1,8 +1,17 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { BLUESKY_EDITOR_SELECTOR, BLUESKY_SELECTORS, blueskyAdapter } from '../src/adapters/bluesky';
 import { executePostFlow, resolvePostButtonTimeoutMs } from '../src/utils/post-flow';
-import { sleep, waitForCondition, waitForElement } from '../src/utils/dom';
+import {
+  sleep,
+  waitForCondition,
+  waitForElement,
+  waitForStableEditableText,
+} from '../src/utils/dom';
 import { resolveSelectors } from '../src/utils/selector-overrides';
 import { bootstrapContentScript } from '../src/utils/content-script-bootstrap';
 import { clickElementInMainWorld, dropImages, injectImages, injectTextIntoElement } from '../src/utils/image';
@@ -99,6 +108,7 @@ async function executeBlueskyInlineThread(
   chunks: string[],
   images: ImageAttachment[] | undefined,
   dryRun: boolean | undefined,
+  implementationPath: PostImplementationPath | undefined,
 ): Promise<void> {
   const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
   // 最初の textarea の wait (compose modal のロード待ち)
@@ -107,16 +117,42 @@ async function executeBlueskyInlineThread(
 
   // /intent/compose?text= で chunk 0 は通常 prefill 済み。再注入すると TipTap が
   // 既存本文へ追記して重複するため、空または不一致の場合だけ補完する。
-  await sleep(300);
   const normalizeText = (value: string) => value.replace(/\s+/g, ' ').trim();
-  if (normalizeText(textarea0.textContent ?? '') !== normalizeText(chunks[0]!)) {
+  if (implementationPath === 'next') {
+    await waitForStableEditableText(sel.textarea, chunks[0]!, {
+      timeoutMs: 300,
+      quietMs: 75,
+      intervalMs: 25,
+    });
+  } else {
+    await sleep(300);
+  }
+  const currentTextarea0 =
+    document.querySelector<HTMLElement>(sel.textarea) ?? textarea0;
+  if (
+    normalizeText(currentTextarea0.textContent ?? '') !==
+    normalizeText(chunks[0]!)
+  ) {
     await injectTextIntoElement(chunks[0]!, sel.textarea);
   }
-  await sleep(500);
+  if (implementationPath === 'next') {
+    await waitForStableEditableText(sel.textarea, chunks[0]!, {
+      timeoutMs: 500,
+      quietMs: 100,
+      intervalMs: 25,
+    });
+  } else {
+    await sleep(500);
+  }
 
   // images は最初の chunk にだけ attach
   if (images && images.length > 0) {
-    await attachBlueskyMedia(images, sel, hasVideo);
+    await attachBlueskyMedia(
+      images,
+      sel,
+      hasVideo,
+      implementationPath,
+    );
   }
 
   // 各 chunk を 「+」 click → wait → inject の繰り返し
@@ -135,7 +171,19 @@ async function executeBlueskyInlineThread(
     const marker = `tutti-bsky-chunk-${i}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     target.setAttribute('data-tutti-marker', marker);
     await injectTextIntoElement(chunks[i]!, `[data-tutti-marker="${marker}"]`);
-    await sleep(300);
+    if (implementationPath === 'next') {
+      await waitForStableEditableText(
+        `[data-tutti-marker="${marker}"]`,
+        chunks[i]!,
+        {
+          timeoutMs: 300,
+          quietMs: 75,
+          intervalMs: 25,
+        },
+      );
+    } else {
+      await sleep(300);
+    }
   }
 
   // Post button (preview なら highlight、 autoPost なら click)
@@ -255,7 +303,13 @@ export default defineContentScript({
   }),
 });
 
-async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolean, textChunks?: string[]): Promise<PostResultMessage> {
+async function runPost(
+  text: string,
+  images?: ImageAttachment[],
+  dryRun?: boolean,
+  textChunks?: string[],
+  implementationPath?: PostImplementationPath,
+): Promise<PostResultMessage> {
   const sel = await resolveSelectors('bluesky', BLUESKY_SELECTORS);
   const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
   log.info(`Bluesky runPost: dryRun=${dryRun} media=${images?.length ?? 0} video=${hasVideo}`);
@@ -264,10 +318,21 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
   // compose modal の 「+」 button で reply block を追加して、 全 chunks を 1 click
   // で thread 投稿する。
   if (textChunks && textChunks.length > 1) {
-    await executeBlueskyInlineThread(sel, textChunks, images, dryRun);
+    await executeBlueskyInlineThread(
+      sel,
+      textChunks,
+      images,
+      dryRun,
+      implementationPath,
+    );
   } else {
     if (images && images.length > 0) {
-      await attachBlueskyMedia(images, sel, hasVideo);
+      await attachBlueskyMedia(
+        images,
+        sel,
+        hasVideo,
+        implementationPath,
+      );
     }
     await executePostFlow({
       prefillsViaUrl: blueskyAdapter.prefillsViaUrl,
@@ -276,6 +341,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
       postButtonTexts: ['Publish', 'Post', '投稿', 'Publish post'],
       text,
       dryRun,
+      implementationPath,
       beforeSubmit: hasVideo ? assertBlueskyVideoAttached : undefined,
       clickPostButton: () => clickElementInMainWorld(sel.postButton),
     });
@@ -333,6 +399,7 @@ async function attachBlueskyMedia(
   images: ImageAttachment[],
   sel: typeof BLUESKY_SELECTORS,
   hasVideo: boolean,
+  implementationPath?: PostImplementationPath,
 ): Promise<void> {
   const order: Array<'input' | 'drop'> = hasVideo ? ['input', 'drop'] : ['drop', 'input'];
   let lastError: unknown;
@@ -344,12 +411,14 @@ async function attachBlueskyMedia(
         await injectImages(images, sel.fileInput, {
           requireVideoAccepted: hasVideo ? false : undefined,
           requireMediaAccepted: hasVideo ? false : undefined,
+          implementationPath,
         });
       } else {
         await dropImages(images, sel.dropTarget, {
           requireVideoAccepted: hasVideo ? false : undefined,
           requireMediaAccepted: hasVideo ? false : undefined,
           beforeDropDelayMs: hasVideo ? 500 : undefined,
+          implementationPath,
         });
       }
       if (hasVideo) await assertBlueskyVideoAttached(30_000);

--- a/entrypoints/deviantart.content.ts
+++ b/entrypoints/deviantart.content.ts
@@ -1,9 +1,17 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { DEVIANTART_SELECTORS, buildDeviantArtTitle } from '../src/adapters/deviantart';
 import { executeMultiStepFlow, type Step } from '../src/utils/step-runner';
 import { injectImages, injectTagList, injectTextIntoElement } from '../src/utils/image';
-import { sleep, waitForElement } from '../src/utils/dom';
+import {
+  sleep,
+  waitForElement,
+  waitForStableEditableText,
+} from '../src/utils/dom';
 import { extractHashtags } from '../src/utils/hashtags';
 import { waitForPostUrl } from '../src/utils/url-capture';
 import { resolveSelectors } from '../src/utils/selector-overrides';
@@ -58,6 +66,8 @@ async function runPost(
   text: string,
   images?: ImageAttachment[],
   dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   if (!images || images.length === 0) {
     throw new Error(t('runtimeDeviantArtImageRequired'));
@@ -82,9 +92,14 @@ async function runPost(
           log.info('DA: metadata form already visible, skipping image inject');
           return;
         }
-        await injectImages([images[0]!], sel.fileInput);
+        await injectImages([images[0]!], sel.fileInput, {
+          requireMediaAccepted: implementationPath === 'next',
+          requireMediaPreview: implementationPath === 'next',
+          implementationPath,
+        });
       },
       settleMs: 200,
+      waitAfterAction: async () => {},
     },
     // Step 2: title 入力。inject 後の modal mount + upload 完了まで最大 30s 待つ。
     {
@@ -97,6 +112,13 @@ async function runPost(
         await injectTextIntoElement(title, sel.titleInput);
       },
       settleMs: 300,
+      waitAfterAction: async () => {
+        await waitForStableEditableText(sel.titleInput, title, {
+          timeoutMs: 300,
+          quietMs: 75,
+          intervalMs: 25,
+        });
+      },
     },
     // Step 3: description 入力 (TipTap / ProseMirror)。**best-effort**。
     // v0.4.74 で DA の description は **完全 lazy-mount** だと確定 (probe 2026-05-22):
@@ -150,6 +172,7 @@ async function runPost(
         }
       },
       settleMs: 500,
+      waitAfterAction: async () => {},
     },
     // Step 4: tags chip 入力 (v0.4.72〜)。 本文 #hashtag を抽出して DA tags
     // field に commit。 DA は tags 必須ではないので best-effort で。
@@ -168,13 +191,14 @@ async function runPost(
           return;
         }
         try {
-          await injectTagList(tags, sel.tagInput);
+          await injectTagList(tags, sel.tagInput, { implementationPath });
           log.info(`DA: ${tags.length} 個の tag を chip 化`);
         } catch (e) {
           log.warn(`DA: tag commit 失敗: ${e instanceof Error ? e.message : String(e)}`);
         }
       },
       settleMs: 300,
+      waitAfterAction: async () => {},
     },
   ];
 
@@ -191,6 +215,7 @@ async function runPost(
       afterClickDelayMs: 250,
     },
     dryRun,
+    implementationPath,
   });
 
   // dryRun でなければ DA が /<user>/art/<title>-<id> へ redirect するのを待つ

--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -19,9 +19,11 @@
 
 import {
   installNetworkObserver,
+  type NetworkCaptureRule,
   type NetworkObserverDiagnostic,
   type NetworkObserverTag,
 } from '../src/page-world/network-observer';
+import { extractMediaUploadFailure } from '../src/page-world/media-upload-result';
 import {
   createPagePostCaptureRules,
   type PostCapturePendingState,
@@ -112,6 +114,8 @@ interface InjectRequest {
   requireMediaAccepted?: boolean;
   /** upload 完了だけでなく compose preview evidence を必須にする */
   requireMediaPreview?: boolean;
+  /** previewだけでは受理せず、upload resourceの完了通知を必須にする */
+  requireUploadComplete?: boolean;
 }
 
 interface InjectResponse {
@@ -134,6 +138,9 @@ interface InjectResponse {
 interface UploadTracker {
   successCount: number;
   lastSuccessAt: number;
+  failureCount: number;
+  lastFailureAt: number;
+  lastError?: string;
 }
 
 declare global {
@@ -276,13 +283,27 @@ export default defineContentScript({
     }
 
     function installPostCaptureObserver(): void {
-      const rules = createPagePostCaptureRules({
-        host: location.host,
-        origin: location.origin,
-        readPending: readPostCapturePending,
-        onCaptured: persistPostCapture,
-      });
-      if (rules.length === 0) return;
+      const uploadFailureRule: NetworkCaptureRule = {
+        id: 'media-upload-failure',
+        prepare: (request) => (
+          UPLOAD_URL_RE.test(request.url)
+            ? {}
+            : null
+        ),
+        capture: (payload) => {
+          const failure = extractMediaUploadFailure(payload);
+          if (failure) recordUploadFailure(failure);
+        },
+      };
+      const rules = [
+        ...createPagePostCaptureRules({
+          host: location.host,
+          origin: location.origin,
+          readPending: readPostCapturePending,
+          onCaptured: persistPostCapture,
+        }),
+        uploadFailureRule,
+      ];
       installNetworkObserver(window, {
         owner: NETWORK_OBSERVER_OWNER,
         revision: NETWORK_OBSERVER_REVISION,
@@ -294,7 +315,12 @@ export default defineContentScript({
     function installUploadHook() {
       if (window.__tuttiUploadHookInstalled) return;
       window.__tuttiUploadHookInstalled = true;
-      window.__tuttiUpload = { successCount: 0, lastSuccessAt: 0 };
+      window.__tuttiUpload = {
+        successCount: 0,
+        lastSuccessAt: 0,
+        failureCount: 0,
+        lastFailureAt: 0,
+      };
       const tracker = window.__tuttiUpload;
 
       // PerformanceObserver は fetch / XHR / img src など出処を問わず全リクエストの
@@ -307,6 +333,13 @@ export default defineContentScript({
           for (const entry of list.getEntries()) {
             const e = entry as PerformanceResourceTiming;
             if (UPLOAD_URL_RE.test(e.name)) {
+              const responseStatus = 'responseStatus' in e
+                ? Number(e.responseStatus)
+                : 0;
+              if (responseStatus >= 400) {
+                recordUploadFailure(`Media upload failed (HTTP ${responseStatus}).`);
+                continue;
+              }
               tracker.successCount++;
               tracker.lastSuccessAt = Date.now();
             }
@@ -316,6 +349,19 @@ export default defineContentScript({
       } catch (e) {
         console.warn('[Tutti inject-helper] PerformanceObserver unavailable:', e);
       }
+    }
+
+    function recordUploadFailure(message: string): void {
+      const tracker = window.__tuttiUpload ?? {
+        successCount: 0,
+        lastSuccessAt: 0,
+        failureCount: 0,
+        lastFailureAt: 0,
+      };
+      tracker.failureCount += 1;
+      tracker.lastFailureAt = Date.now();
+      tracker.lastError = message.slice(0, 300);
+      window.__tuttiUpload = tracker;
     }
 
     function sleep(ms: number): Promise<void> {
@@ -336,16 +382,23 @@ export default defineContentScript({
       options: {
         requireMediaAccepted?: boolean;
         requirePreviewAccepted?: boolean;
+        requireUploadComplete?: boolean;
         isMediaPreviewVisible?: () => boolean;
         getMediaRejectionMessage?: () => string | undefined;
       } = {},
     ): Promise<{ uploadCount: number; timedOut: boolean; acceptedByPreview: boolean; error?: string }> {
       if (!window.__tuttiUpload) {
         console.warn('[Tutti inject-helper] upload tracker was missing; recreating');
-        window.__tuttiUpload = { successCount: 0, lastSuccessAt: 0 };
+        window.__tuttiUpload = {
+          successCount: 0,
+          lastSuccessAt: 0,
+          failureCount: 0,
+          lastFailureAt: 0,
+        };
       }
       const tracker = window.__tuttiUpload;
       const startCount = tracker.successCount;
+      const startFailureCount = tracker.failureCount;
       const start = Date.now();
       const deadline = start + timeoutMs;
       const QUIET_MS = 800;
@@ -355,7 +408,16 @@ export default defineContentScript({
 
       while (Date.now() < deadline) {
         const newSuccess = tracker.successCount - startCount;
+        const newFailure = tracker.failureCount - startFailureCount;
         const elapsed = Date.now() - start;
+        if (newFailure > 0) {
+          return {
+            uploadCount: newSuccess,
+            timedOut: false,
+            acceptedByPreview: false,
+            error: tracker.lastError ?? 'Media upload failed.',
+          };
+        }
         const rejection = options.getMediaRejectionMessage?.();
         if (rejection) {
           return {
@@ -376,7 +438,11 @@ export default defineContentScript({
             }
             return { uploadCount: newSuccess, timedOut: false, acceptedByPreview };
           }
-        } else if (acceptedByPreview && options.requireMediaAccepted) {
+        } else if (
+          acceptedByPreview &&
+          options.requireMediaAccepted &&
+          !options.requireUploadComplete
+        ) {
           return { uploadCount: 0, timedOut: false, acceptedByPreview: true };
         } else if (!options.requireMediaAccepted && elapsed >= NO_UPLOAD_GIVE_UP_MS) {
           return { uploadCount: 0, timedOut: false, acceptedByPreview: false };
@@ -981,6 +1047,7 @@ export default defineContentScript({
         requireVideoAccepted: typeof data.requireVideoAccepted === 'boolean' ? data.requireVideoAccepted : undefined,
         requireMediaAccepted: typeof data.requireMediaAccepted === 'boolean' ? data.requireMediaAccepted : undefined,
         requireMediaPreview: typeof data.requireMediaPreview === 'boolean' ? data.requireMediaPreview : undefined,
+        requireUploadComplete: typeof data.requireUploadComplete === 'boolean' ? data.requireUploadComplete : undefined,
       };
       void handle(req)
         .then((res) => {

--- a/entrypoints/instagram.content.ts
+++ b/entrypoints/instagram.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { INSTAGRAM_SELECTORS } from '../src/adapters/instagram';
 import { executeMultiStepFlow, type Step } from '../src/utils/step-runner';
 import { injectImages, injectTextIntoElement } from '../src/utils/image';
@@ -78,6 +82,8 @@ async function runPost(
   text: string,
   images?: ImageAttachment[],
   dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   if (!images || images.length === 0) {
     throw new Error(t('runtimeInstagramMediaRequired'));
@@ -154,6 +160,7 @@ async function runPost(
         }
       },
       settleMs: 300,
+      waitAfterAction: async () => {},
     },
     // Step 2: image / video inject。Modal #2 (Crop / Reel intro) に自動遷移する
     {
@@ -164,14 +171,20 @@ async function runPost(
         if (!fi) {
           throw new Error(t('runtimeInstagramFileInputMissing'));
         }
-        await injectImages(images, sel.fileInput, { requireVideoAccepted: false });
+        await injectImages(images, sel.fileInput, {
+          requireVideoAccepted: false,
+          requireMediaAccepted: implementationPath === 'next',
+          requireMediaPreview: implementationPath === 'next',
+          implementationPath,
+        });
         // v0.4.61: Crop dialog が mount された直後に Original aspect ratio を選んで、
         // 横長/縦長の写真が IG default の 1:1 で左右 (or 上下) 見切れるのを回避。
         // 失敗は warn のみで続行 (IG が許す範囲外なら IG 側で勝手に fit させる、
         // ユーザー報告は: 2026-05-17 横長で左右見切れ)。
-        await selectOriginalCrop();
+        await selectOriginalCrop(implementationPath);
       },
       settleMs: 200,
+      waitAfterAction: async () => {},
       // Crop / Reel intro 画面の primary action ボタン click で進む。
       // v0.5.11: video の場合、 file 注入後に IG が 「Post as Reel?」 系の
       // 中間 dialog (OK / Continue / Confirm / Got it) を挟んでくることがある。
@@ -198,6 +211,7 @@ async function runPost(
         // filter は default のまま (画像加工しない)
       },
       settleMs: 500,
+      waitAfterAction: async () => {},
       advance: {
         // polling のたびにエラー dialog 検出も走らせて、IG 側が
         // 'Something went wrong' / 'File too small' 等を後から被せた場合に
@@ -245,6 +259,7 @@ async function runPost(
         await waitForShareEnabled(8000);
       },
       settleMs: 500,
+      waitAfterAction: async () => {},
     },
   ];
 
@@ -256,6 +271,7 @@ async function runPost(
       afterClickDelayMs: 250,
     },
     dryRun,
+    implementationPath,
   });
 
   // dry-run は finalize click をスキップしてるので verify も skip
@@ -298,7 +314,9 @@ async function runPost(
  * 元アスペクト比を保つ (v0.4.61)。IG が許す範囲外でも IG 側で fit するので
  * 失敗は warn のみで続行 (= 既存挙動 = 1:1 default)。
  */
-async function selectOriginalCrop(): Promise<void> {
+async function selectOriginalCrop(
+  implementationPath?: PostImplementationPath,
+): Promise<void> {
   const cropBtn = await waitForCondition<HTMLElement>(findCropAspectButton, {
     timeoutMs: 800,
     intervalMs: 100,
@@ -316,12 +334,16 @@ async function selectOriginalCrop(): Promise<void> {
   if (!originalItem) {
     log.warn('IG: Crop popover に "Original" 系の選択肢が無い、default 1:1 で続行');
     cropBtn.click(); // popover を閉じる (toggle)
-    await sleep(200);
+    if (implementationPath !== 'next') {
+      await sleep(200);
+    }
     return;
   }
   originalItem.click();
   log.info('IG: Original aspect ratio を選択');
-  await sleep(400);
+  if (implementationPath !== 'next') {
+    await sleep(400);
+  }
 }
 
 function findCropAspectButton(): HTMLElement | null {

--- a/entrypoints/mastodon.content.ts
+++ b/entrypoints/mastodon.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import {
   MASTODON_SELECTORS,
 } from '../src/adapters/mastodon';
@@ -108,7 +112,13 @@ export default defineContentScript({
   }),
 });
 
-async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolean): Promise<PostResultMessage> {
+async function runPost(
+  text: string,
+  images?: ImageAttachment[],
+  dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
+): Promise<PostResultMessage> {
   const sel = await resolveSelectors('mastodon', MASTODON_SELECTORS);
   if (!dryRun) {
     try {
@@ -119,6 +129,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
 
   await openReplyComposerIfOnPostPage('mastodon', sel.textarea, {
     timeoutMs: 20_000,
+    implementationPath,
   });
 
   await executePostFlow({
@@ -135,6 +146,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     text,
     images,
     dryRun,
+    implementationPath,
     composeInputTimeoutMs: 30000,
     postButtonTimeoutMs: 30000,
   });

--- a/entrypoints/misskey.content.ts
+++ b/entrypoints/misskey.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { MISSKEY_SELECTORS, misskeyAdapter } from '../src/adapters/misskey';
 import { sleep, waitForCondition } from '../src/utils/dom';
 import { executePostFlow } from '../src/utils/post-flow';
@@ -71,7 +75,13 @@ export default defineContentScript({
   }),
 });
 
-async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolean): Promise<PostResultMessage> {
+async function runPost(
+  text: string,
+  images?: ImageAttachment[],
+  dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
+): Promise<PostResultMessage> {
   const sel = await resolveSelectors('misskey', MISSKEY_SELECTORS);
   const initialPageState = await waitForCondition<'compose' | 'sign-in'>(() => {
     if (isMisskeyComposePresent(document, sel)) return 'compose';
@@ -92,6 +102,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     text,
     images,
     dryRun,
+    implementationPath,
     clickPostButton: () => clickElementInMainWorld('button, [role="button"]', ['投稿', 'ノート', 'Note', 'Post', 'Submit']),
   });
   if (!dryRun) {

--- a/entrypoints/pixiv.content.ts
+++ b/entrypoints/pixiv.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { getSettings } from '../src/storage';
 import {
   PIXIV_SELECTORS,
@@ -9,7 +13,10 @@ import {
 } from '../src/adapters/pixiv';
 import { executeMultiStepFlow, type Step } from '../src/utils/step-runner';
 import { injectImages, injectTagList, injectTextIntoElement } from '../src/utils/image';
-import { waitForCondition } from '../src/utils/dom';
+import {
+  waitForCondition,
+  waitForStableEditableText,
+} from '../src/utils/dom';
 import { waitForPostUrl } from '../src/utils/url-capture';
 import { resolveSelectors } from '../src/utils/selector-overrides';
 import { bootstrapContentScript } from '../src/utils/content-script-bootstrap';
@@ -96,6 +103,8 @@ async function runPost(
   text: string,
   images?: ImageAttachment[],
   dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   log.info(`Pixiv runPost: dryRun=${dryRun} images=${images?.length ?? 0} textLen=${text.length}`);
   if (!images || images.length === 0) {
@@ -116,11 +125,16 @@ async function runPost(
     {
       name: 'inject-images',
       action: async () => {
-        await injectImages(images, sel.fileInput);
+        await injectImages(images, sel.fileInput, {
+          requireMediaAccepted: implementationPath === 'next',
+          requireMediaPreview: implementationPath === 'next',
+          implementationPath,
+        });
       },
       // サムネイル描画 + 内部 React state 反映を待つ。Pixiv のサーバ upload は
       // injectImages 内の MAIN-world helper で完了確認済 (PerformanceObserver)。
       settleMs: 1500,
+      waitAfterAction: async () => {},
     },
     {
       name: 'fill-title',
@@ -128,6 +142,13 @@ async function runPost(
         await injectTextIntoElement(title, sel.titleInput);
       },
       settleMs: 200,
+      waitAfterAction: async () => {
+        await waitForStableEditableText(sel.titleInput, title, {
+          timeoutMs: 200,
+          quietMs: 50,
+          intervalMs: 25,
+        });
+      },
     },
     {
       name: 'fill-caption',
@@ -136,15 +157,23 @@ async function runPost(
         await injectTextIntoElement(caption, sel.captionTextarea);
       },
       settleMs: 200,
+      waitAfterAction: async () => {
+        await waitForStableEditableText(sel.captionTextarea, caption, {
+          timeoutMs: 200,
+          quietMs: 50,
+          intervalMs: 25,
+        });
+      },
     },
     {
       // Pixiv は tags が必須 (Required ラベル付き)。本文の #hashtag を抽出、
       // 無ければ default ['Tutti'] が使われる。Enter で 1 tag ずつ確定。
       name: 'fill-tags',
       action: async () => {
-        await injectTagList(tags, sel.tagInput);
+        await injectTagList(tags, sel.tagInput, { implementationPath });
       },
       settleMs: 400,
+      waitAfterAction: async () => {},
     },
     {
       // Visible to (x_restrict) も必須。 default は Settings.pixivVisibility
@@ -162,6 +191,9 @@ async function runPost(
         r.click();
       },
       settleMs: 200,
+      waitAfterAction: async () => {
+        await waitForCheckedControl('input[name="x_restrict"]:checked', 200);
+      },
     },
     {
       // AI-generated work (ai_type) も必須。 Settings.pixivAiType 経由で切替。
@@ -175,6 +207,9 @@ async function runPost(
         r.click();
       },
       settleMs: 200,
+      waitAfterAction: async () => {
+        await waitForCheckedControl('input[name="ai_type"]:checked', 200);
+      },
     },
     {
       // Adult content (sexual) も必須。クロスポスト content は基本 non-sexual。
@@ -186,6 +221,9 @@ async function runPost(
         r.click();
       },
       settleMs: 200,
+      waitAfterAction: async () => {
+        await waitForCheckedControl(sel.sexualNo, 200);
+      },
     },
     {
       // Pixiv は時々 "Security check" / captcha section を出して bottom Post を
@@ -208,8 +246,10 @@ async function runPost(
           const text = document.body?.innerText ?? '';
           return /Security check|セキュリティチェック|reCAPTCHA/i.test(text);
         };
-        // 200ms 程度 React state 反映を待つ (radio click 後)
-        await new Promise((r) => setTimeout(r, 200));
+        // next は直前のradio stepでchecked反映を条件待ち済み。
+        if (implementationPath !== 'next') {
+          await new Promise((r) => setTimeout(r, 200));
+        }
         if (!isPostDisabled() || !hasSecurityCheck()) return;
 
         // banner overlay 注入 (既存があれば再利用)
@@ -246,6 +286,7 @@ async function runPost(
         throw new Error(t('runtimePixivSecurityTimeout'));
       },
       settleMs: 100,
+      waitAfterAction: async () => {},
     },
   ];
 
@@ -282,6 +323,7 @@ async function runPost(
       afterClickDelayMs: 500,
     },
     dryRun,
+    implementationPath,
   });
 
   // dryRun でなければ Pixiv が /artworks/<id> に redirect
@@ -307,4 +349,22 @@ async function runPost(
     success: true,
     url,
   };
+}
+
+async function waitForCheckedControl(
+  selector: string,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForCondition<HTMLElement>(() => {
+    const control = document.querySelector<HTMLElement>(selector);
+    if (!control) return null;
+    if (
+      (control as HTMLInputElement).checked === true ||
+      control.getAttribute('aria-checked') === 'true' ||
+      control.hasAttribute('checked')
+    ) {
+      return control;
+    }
+    return null;
+  }, { timeoutMs, intervalMs: 25 });
 }

--- a/entrypoints/threads.content.ts
+++ b/entrypoints/threads.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { THREADS_SELECTORS, threadsAdapter } from '../src/adapters/threads';
 import { findClickableByText, sleep, waitForCondition } from '../src/utils/dom';
 import { executePostFlow } from '../src/utils/post-flow';
@@ -26,7 +30,13 @@ export default defineContentScript({
   }),
 });
 
-async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolean): Promise<PostResultMessage> {
+async function runPost(
+  text: string,
+  images?: ImageAttachment[],
+  dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
+): Promise<PostResultMessage> {
   const sel = await resolveSelectors('threads', THREADS_SELECTORS);
   const postingUser = detectThreadsUser()?.replace(/^@/, '') ?? null;
   const hasMedia = !!images?.length;
@@ -49,6 +59,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
   const replyContinuation = await openReplyComposerIfOnPostPage('threads', replyTextareaSelector, {
     timeoutMs: 20_000,
     clickInMainWorld: true,
+    implementationPath,
   });
   if (!replyContinuation) {
     await ensureThreadsComposerOpen(sel.textarea);
@@ -70,6 +81,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     images,
     postButtonTimeoutMs: 12000,
     dryRun,
+    implementationPath,
     requireMediaAccepted: hasMedia,
     requireMediaPreview: hasMedia,
     beforeDropDelayMs: hasMedia ? 5000 : undefined,

--- a/entrypoints/tiktok.content.ts
+++ b/entrypoints/tiktok.content.ts
@@ -1,9 +1,13 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { TIKTOK_SELECTORS, buildTikTokCaption } from '../src/adapters/tiktok';
 import { executeMultiStepFlow, type Step } from '../src/utils/step-runner';
 import { injectImages, injectTextIntoElement } from '../src/utils/image';
-import { sleep, waitForElement } from '../src/utils/dom';
+import { sleep, waitForCondition, waitForElement } from '../src/utils/dom';
 import { waitForPostUrl } from '../src/utils/url-capture';
 import { resolveSelectors } from '../src/utils/selector-overrides';
 import { bootstrapContentScript } from '../src/utils/content-script-bootstrap';
@@ -52,6 +56,8 @@ async function runPost(
   text: string,
   images?: ImageAttachment[],
   dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   log.info(`TikTok runPost: dryRun=${dryRun} media=${images?.length ?? 0}`);
   const video = images?.find((m) => m.type.startsWith('video/'));
@@ -72,10 +78,11 @@ async function runPost(
           const buttonHint = buttons ? ` [visible buttons: ${buttons}]` : '';
           throw new Error(`file input not found on ${location.pathname}${buttonHint}`);
         }
-        await injectImages([video], sel.fileInput);
+        await injectImages([video], sel.fileInput, { implementationPath });
       },
       // upload + caption form 描画。30s 程度かかることもあるので長め
       settleMs: 200,
+      waitAfterAction: async () => {},
     },
     {
       // caption 入力。動画 upload 完了を待ってから fill (waitForElement で出現確認)
@@ -85,9 +92,14 @@ async function runPost(
         if (!el) {
           throw new Error(t('runtimeTikTokCaptionMissing'));
         }
-        await setTikTokCaption(caption, sel.captionEditor);
+        await setTikTokCaption(
+          caption,
+          sel.captionEditor,
+          implementationPath,
+        );
       },
       settleMs: 500,
+      waitAfterAction: async () => {},
     },
   ];
 
@@ -110,6 +122,7 @@ async function runPost(
       afterClickDelayMs: 250,
     },
     dryRun,
+    implementationPath,
   });
 
   // dryRun でなければ個別の post URL への遷移を待つ。
@@ -137,7 +150,11 @@ async function runPost(
   };
 }
 
-async function setTikTokCaption(caption: string, selector: string): Promise<void> {
+async function setTikTokCaption(
+  caption: string,
+  selector: string,
+  implementationPath?: PostImplementationPath,
+): Promise<void> {
   let lastError: string | undefined;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
@@ -146,7 +163,14 @@ async function setTikTokCaption(caption: string, selector: string): Promise<void
       lastError = e instanceof Error ? e.message : String(e);
     }
 
-    await sleep(500);
+    if (implementationPath === 'next') {
+      await waitForCondition<boolean>(
+        () => captionMatches(readTikTokCaption(selector), caption) || null,
+        { timeoutMs: 500, intervalMs: 25 },
+      );
+    } else {
+      await sleep(500);
+    }
     const visible = readTikTokCaption(selector);
     if (captionMatches(visible, caption)) return;
 
@@ -155,7 +179,14 @@ async function setTikTokCaption(caption: string, selector: string): Promise<void
       : `caption was not cleared after inject attempt ${attempt}: "${visible.slice(0, 80)}"`;
     log.warn(`TikTok: ${lastError}`);
     await injectTextIntoElement('', selector).catch(() => {});
-    await sleep(300);
+    if (implementationPath === 'next') {
+      await waitForCondition<boolean>(
+        () => captionMatches(readTikTokCaption(selector), '') || null,
+        { timeoutMs: 300, intervalMs: 25 },
+      );
+    } else {
+      await sleep(300);
+    }
   }
   throw new Error(lastError ?? 'TikTok caption injection failed');
 }

--- a/entrypoints/tumblr.content.ts
+++ b/entrypoints/tumblr.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { TUMBLR_SELECTORS, tumblrAdapter } from '../src/adapters/tumblr';
 import { executePostFlow } from '../src/utils/post-flow';
 import { sleep, waitForCondition, waitForElement } from '../src/utils/dom';
@@ -304,7 +308,13 @@ export default defineContentScript({
   }),
 });
 
-async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolean): Promise<PostResultMessage> {
+async function runPost(
+  text: string,
+  images?: ImageAttachment[],
+  dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
+): Promise<PostResultMessage> {
   const sel = await resolveSelectors('tumblr', TUMBLR_SELECTORS);
   const tumblrText = mergeStandaloneUrlParagraphs(text);
   const postingUser = dryRun ? null : await detectTumblrUser();
@@ -356,6 +366,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
     confirmDialogGraceMs: 5000,
     text: tumblrText,
     images,
+    implementationPath,
     postButtonTimeoutMs: 10000,
     textInjector: injectTumblrTextIntoElement,
     requireMediaAccepted: hasVideo || undefined,
@@ -374,7 +385,14 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
       if (tumblrText && !validation.ok) {
         log.warn(`Tumblr: body validation failed before submit; reinjecting (${validation.error ?? 'unknown'})`);
         await injectTumblrTextIntoElement(tumblrText, sel.textarea);
-        await sleep(300);
+        if (implementationPath === 'next') {
+          await waitForCondition(
+            () => validateCurrentBody().ok || null,
+            { timeoutMs: 300, intervalMs: 25 },
+          );
+        } else {
+          await sleep(300);
+        }
         const after = validateCurrentBody();
         if (!after.ok) {
           throw new Error(after.error ?? 'Tumblr body validation failed');
@@ -392,7 +410,7 @@ async function runPost(text: string, images?: ImageAttachment[], dryRun?: boolea
         throw new Error('Tumblr tags input not found; refusing to submit because the draft contains hashtags.');
       }
       try {
-        await injectTagList(tags, sel.tagInput);
+        await injectTagList(tags, sel.tagInput, { implementationPath });
         log.info(`Tumblr: ${tags.length} 個の tag を chip 化`);
       } catch (e) {
         throw new Error(`Tumblr tag commit failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/entrypoints/tumblr.content.ts
+++ b/entrypoints/tumblr.content.ts
@@ -371,6 +371,7 @@ async function runPost(
     textInjector: injectTumblrTextIntoElement,
     requireMediaAccepted: hasVideo || undefined,
     requireMediaPreview: hasVideo || undefined,
+    requireUploadComplete: hasVideo || undefined,
     allowDisabledPostButtonInPreview: dryRun && hasVideo && !tumblrText.trim(),
     beforeDropDelayMs: hasVideo ? 500 : undefined,
     mediaAttachOrder: hasVideo ? ['input', 'drop'] : undefined,

--- a/entrypoints/x.content.ts
+++ b/entrypoints/x.content.ts
@@ -1,10 +1,19 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import { X_SELECTORS } from '../src/adapters/x';
 import { resolvePostButtonTimeoutMs } from '../src/utils/post-flow';
 import { resolveSelectors } from '../src/utils/selector-overrides';
 import { bootstrapContentScript } from '../src/utils/content-script-bootstrap';
-import { sleep, waitForCondition } from '../src/utils/dom';
+import {
+  sleep,
+  waitForCondition,
+  waitForStableCondition,
+  waitForStableEditableText,
+} from '../src/utils/dom';
 import {
   clickElementInMainWorld,
   getLatestXPostUrlInMainWorld,
@@ -92,6 +101,7 @@ async function runPost(
   images?: ImageAttachment[],
   dryRun?: boolean,
   textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   const sel = await resolveSelectors('x', X_SELECTORS);
 
@@ -111,9 +121,20 @@ async function runPost(
   // preview mode は post button を click せずに highlight、 user が確認後に押す。
   let submittedAt: number | undefined;
   if (textChunks && textChunks.length > 1) {
-    submittedAt = await executeXInlineThread(sel, textChunks, images, dryRun);
+    submittedAt = await executeXInlineThread(
+      sel,
+      textChunks,
+      images,
+      dryRun,
+      implementationPath,
+    );
   } else {
-    submittedAt = await executeXSinglePost(text, images, dryRun);
+    submittedAt = await executeXSinglePost(
+      text,
+      images,
+      dryRun,
+      implementationPath,
+    );
   }
 
   // dryRun でなければ post URL を capture (= 本当の完了)。 reply chain の連結
@@ -144,6 +165,7 @@ async function executeXSinglePost(
   text: string,
   images: ImageAttachment[] | undefined,
   dryRun: boolean | undefined,
+  implementationPath: PostImplementationPath | undefined,
 ): Promise<number | undefined> {
   const composeRoot = await waitForXComposeDialog(X_SINGLE_COMPOSE_READY_TIMEOUT_MS);
   if (!composeRoot) {
@@ -178,12 +200,24 @@ async function executeXSinglePost(
       await injectImages(images, scopedXComposeSelector(rootMarker, X_COMPOSE_FILE_INPUT_SELECTOR), {
         requireMediaAccepted: true,
         requireMediaPreview: true,
+        implementationPath,
       });
-      await sleep(X_SINGLE_MEDIA_SETTLE_MS);
+      await settleXEditorAfterMedia(
+        composeRoot,
+        0,
+        implementationPath,
+        X_SINGLE_MEDIA_SETTLE_MS,
+      );
     }
 
     if (text) {
-      await injectTextWithRetry(text, textareaSelector, text, images && images.length > 0 ? 4 : 3);
+      await injectTextWithRetry(
+        text,
+        textareaSelector,
+        text,
+        images && images.length > 0 ? 4 : 3,
+        implementationPath,
+      );
     }
 
     const hasVideo = (images ?? []).some((image) => image.type.startsWith('video/'));
@@ -238,6 +272,7 @@ async function executeXInlineThread(
   chunks: string[],
   images: ImageAttachment[] | undefined,
   dryRun: boolean | undefined,
+  implementationPath: PostImplementationPath | undefined,
 ): Promise<number | undefined> {
   // Thread compose は /compose/post modal 専用。home の inline composer には
   // Add post UI が安定して存在しないため、fallback selector で拾わない。
@@ -269,12 +304,24 @@ async function executeXInlineThread(
       await injectImages(images, scopedXComposeSelector(rootMarker, X_COMPOSE_FILE_INPUT_SELECTOR), {
         requireMediaAccepted: true,
         requireMediaPreview: true,
+        implementationPath,
       });
-      await sleep(2500);
+      await settleXEditorAfterMedia(
+        composeRoot,
+        0,
+        implementationPath,
+        X_SINGLE_MEDIA_SETTLE_MS,
+      );
     }
 
     // chunk 0 を retry 付きで inject
-    await injectTextIntoXThreadTextarea(composeRoot, 0, chunks[0]!);
+    await injectTextIntoXThreadTextarea(
+      composeRoot,
+      0,
+      chunks[0]!,
+      4,
+      implementationPath,
+    );
 
     // 各 chunk を「+」 click → wait → inject の繰り返し。
     for (let i = 1; i < chunks.length; i++) {
@@ -297,7 +344,13 @@ async function executeXInlineThread(
           describeXComposeState(composeRoot),
         ));
       }
-      await injectTextIntoXThreadTextarea(composeRoot, i, chunks[i]!);
+      await injectTextIntoXThreadTextarea(
+        composeRoot,
+        i,
+        chunks[i]!,
+        4,
+        implementationPath,
+      );
     }
 
     // 全 inject 完了後の最終 verify (上記 retry でも残った orphan を救う)。
@@ -313,7 +366,13 @@ async function executeXInlineThread(
       const lenOk = currentText.length >= Math.min(20, expected.length * 0.6);
       if (!prefixOk || !lenOk) {
         log.warn(`X: chunk ${i + 1} final verify failed (got "${currentText.slice(0, 30)}"), re-injecting`);
-        await injectTextIntoXThreadTextarea(composeRoot, i, chunks[i]!, 2);
+        await injectTextIntoXThreadTextarea(
+          composeRoot,
+          i,
+          chunks[i]!,
+          2,
+          implementationPath,
+        );
       }
     }
 
@@ -352,11 +411,20 @@ async function injectTextWithRetry(
   selector: string,
   expectedSnippet: string,
   maxAttempts = 3,
+  implementationPath?: PostImplementationPath,
 ): Promise<void> {
   const expectedPrefix = expectedSnippet.slice(0, 20).trim();
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     await injectTextIntoElement(text, selector);
-    await sleep(500 + attempt * 200); // 700 / 900 / 1100ms verify wait
+    if (implementationPath === 'next') {
+      await waitForStableEditableText(selector, expectedSnippet, {
+        timeoutMs: 500 + attempt * 200,
+        quietMs: 125,
+        intervalMs: 25,
+      });
+    } else {
+      await sleep(500 + attempt * 200); // 700 / 900 / 1100ms verify wait
+    }
     const el = document.querySelector(selector);
     const got = (el?.textContent ?? '').trim();
     // prefix 一致 + 一定長 で OK 判定
@@ -376,6 +444,7 @@ async function injectTextIntoXThreadTextarea(
   index: number,
   text: string,
   maxAttempts = 4,
+  implementationPath?: PostImplementationPath,
 ): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -388,7 +457,13 @@ async function injectTextIntoXThreadTextarea(
     const marker = `tutti-x-chunk-${index}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     target.setAttribute('data-tutti-marker', marker);
     try {
-      await injectTextWithRetry(text, `[data-tutti-marker="${marker}"]`, text, 2);
+      await injectTextWithRetry(
+        text,
+        `[data-tutti-marker="${marker}"]`,
+        text,
+        2,
+        implementationPath,
+      );
       return;
     } catch (e) {
       lastError = e;
@@ -397,6 +472,27 @@ async function injectTextIntoXThreadTextarea(
     }
   }
   throw lastError instanceof Error ? lastError : new Error(t('runtimeTextInjectFailed'));
+}
+
+async function settleXEditorAfterMedia(
+  scope: ParentNode,
+  index: number,
+  implementationPath: PostImplementationPath | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  if (implementationPath !== 'next') {
+    await sleep(timeoutMs);
+    return;
+  }
+  await waitForStableCondition<HTMLElement>(
+    () => getXThreadTextareas(scope)[index] ?? null,
+    {
+      timeoutMs,
+      quietMs: 350,
+      intervalMs: 50,
+      root: scope,
+    },
+  );
 }
 
 function isVisible(el: HTMLElement): boolean {

--- a/entrypoints/youtube.content.ts
+++ b/entrypoints/youtube.content.ts
@@ -1,5 +1,9 @@
 import { log } from '../src/utils/logger';
-import type { ImageAttachment, PostResultMessage } from '../src/messages';
+import type {
+  ImageAttachment,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../src/messages';
 import {
   YOUTUBE_SELECTORS,
   buildYouTubeTitle,
@@ -7,7 +11,11 @@ import {
 } from '../src/adapters/youtube';
 import { executeMultiStepFlow, type Step } from '../src/utils/step-runner';
 import { injectImages, injectTagList, injectTextIntoElement } from '../src/utils/image';
-import { waitForCondition, waitForElement } from '../src/utils/dom';
+import {
+  waitForCondition,
+  waitForElement,
+  waitForStableEditableText,
+} from '../src/utils/dom';
 import { extractHashtags } from '../src/utils/hashtags';
 import { resolveSelectors } from '../src/utils/selector-overrides';
 import { bootstrapContentScript } from '../src/utils/content-script-bootstrap';
@@ -93,6 +101,8 @@ async function runPost(
   text: string,
   images?: ImageAttachment[],
   dryRun?: boolean,
+  _textChunks?: string[],
+  implementationPath?: PostImplementationPath,
 ): Promise<PostResultMessage> {
   log.info(`YouTube runPost: dryRun=${dryRun} media=${images?.length ?? 0}`);
   const video = images?.find((m) => m.type.startsWith('video/'));
@@ -129,13 +139,15 @@ async function runPost(
         await waitForElement<HTMLElement>(sel.fileInput, 10000);
       },
       settleMs: 1500,
+      waitAfterAction: async () => {},
     },
     {
       name: 'inject-video',
       action: async () => {
-        await injectImages([video], sel.fileInput);
+        await injectImages([video], sel.fileInput, { implementationPath });
       },
       settleMs: 200,
+      waitAfterAction: async () => {},
     },
     {
       // metadata form 出現待ち + title 入力。
@@ -168,6 +180,13 @@ async function runPost(
         await injectTextIntoElement(title, `[data-tutti-marker="${marker}"]`);
       },
       settleMs: 300,
+      waitAfterAction: async () => {
+        await waitForStableEditableText(sel.titleInput, title, {
+          timeoutMs: 300,
+          quietMs: 75,
+          intervalMs: 25,
+        });
+      },
     },
     {
       name: 'fill-description',
@@ -186,6 +205,13 @@ async function runPost(
         await injectTextIntoElement(text, `[data-tutti-marker="${marker}"]`);
       },
       settleMs: 300,
+      waitAfterAction: async () => {
+        await waitForStableEditableText(sel.descriptionEditor, text, {
+          timeoutMs: 300,
+          quietMs: 75,
+          intervalMs: 25,
+        });
+      },
     },
     // v0.4.72: tags chip 入力。 YouTube Studio Details ページの "Show more" 下に
     // 隠れている tags field を展開して、 本文の #hashtag を抽出して commit。
@@ -218,13 +244,14 @@ async function runPost(
           return;
         }
         try {
-          await injectTagList(tags, sel.tagInput);
+            await injectTagList(tags, sel.tagInput, { implementationPath });
           log.info(`YouTube: ${tags.length} 個の tag を chip 化`);
         } catch (e) {
           log.warn(`YouTube: tag commit 失敗: ${e instanceof Error ? e.message : String(e)}`);
         }
       },
       settleMs: 300,
+      waitAfterAction: async () => {},
     },
     {
       // Made for Kids 必須選択。Tutti default は "No, it's not 'Made for Kids'"
@@ -241,6 +268,9 @@ async function runPost(
         radio.click();
       },
       settleMs: 500,
+      waitAfterAction: async () => {
+        await waitForSelectedYouTubeRadio(sel.notMadeForKidsRadio, 500);
+      },
       // Next ボタンを click して次の wizard step (Video elements) へ
       advance: {
         finder: findEnabledYouTubeNextButton,
@@ -292,6 +322,9 @@ async function runPost(
         publicRadio.click();
       },
       settleMs: 500,
+      waitAfterAction: async () => {
+        await waitForSelectedYouTubeRadio(sel.publicVisibilityRadio, 500);
+      },
     },
   ];
 
@@ -318,6 +351,7 @@ async function runPost(
       allowDisabledInPreview: true,
     },
     dryRun,
+    implementationPath,
   });
 
   // dryRun でなければ Studio が channel content listing もしくは個別 video
@@ -359,6 +393,20 @@ function findYouTubePublishButton(): HTMLElement | null {
     });
   const buttons = uniqueElements([...selectorMatches, ...textMatches]);
   return buttons.find((button) => !isDisabledButton(button)) ?? buttons[0] ?? null;
+}
+
+async function waitForSelectedYouTubeRadio(
+  selector: string,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForCondition<HTMLElement>(() => {
+    const radio = document.querySelector<HTMLElement>(selector);
+    if (!radio) return null;
+    return radio.getAttribute('aria-checked') === 'true' ||
+      radio.hasAttribute('checked')
+      ? radio
+      : null;
+  }, { timeoutMs, intervalMs: 25 });
 }
 
 function findEnabledYouTubeNextButton(): HTMLElement | null {

--- a/scripts/e2e/cdp-harness.mjs
+++ b/scripts/e2e/cdp-harness.mjs
@@ -214,12 +214,19 @@ export class RawCdpClient {
   }
 }
 
-export async function disconnectCdp(browser) {
+export async function disconnectCdp(
+  browser,
+  { preserveRemoteBrowser = false } = {},
+) {
   if (!browser) return;
   if (typeof browser.disconnect === 'function') {
     await browser.disconnect();
     return;
   }
+  // Playwright の connectOverCDP() が返す Browser には disconnect() が無く、
+  // close() はSurfaceのリモートBrave本体まで終了する。継続利用するCLIは
+  // keepalive pageを残し、このoption指定後にprocessを終了してsocketを解放する。
+  if (preserveRemoteBrowser && typeof browser.contexts === 'function') return;
   if (typeof browser.close === 'function') {
     await browser.close();
   }

--- a/scripts/e2e/surface-posting-matrix.mjs
+++ b/scripts/e2e/surface-posting-matrix.mjs
@@ -423,13 +423,18 @@ console.log('\n[matrix] summary');
 console.log(JSON.stringify(summary, null, 2));
 await persistSummary();
 
+// CDP接続用に起動したSurface Braveで最後のpopupまで閉じると、windowが0枚に
+// なってbrowser process自体が終了する。次のmatrixも同じsession/profileで
+// 継続できるよう、接続を切る前に通常pageを1枚残す。
+const keepalivePage = await ctx.newPage();
+await keepalivePage.goto('about:blank', { waitUntil: 'domcontentloaded' });
 await popup.close().catch(() => {});
-await disconnectCdp(browser);
+await disconnectCdp(browser, { preserveRemoteBrowser: true });
 
 const outcome = formatSurfaceMatrixOutcome(failures);
 for (const line of outcome.stdout) console.log(line);
 for (const line of outcome.stderr) console.error(line);
-if (!outcome.passed) process.exit(outcome.exitCode);
+process.exit(outcome.passed ? 0 : outcome.exitCode);
 
 function argValue(name) {
   const idx = args.indexOf(name);

--- a/scripts/e2e/verify-x-thread-existing-home.mjs
+++ b/scripts/e2e/verify-x-thread-existing-home.mjs
@@ -43,7 +43,9 @@ async function fail(message, detail) {
     console.error(JSON.stringify(detail, null, 2));
   }
   if (!cdpEndpoint && ctx) await ctx.close().catch(() => {});
-  if (browser) await disconnectCdp(browser).catch(() => {});
+  if (browser) {
+    await disconnectCdp(browser, { preserveRemoteBrowser: Boolean(cdpEndpoint) }).catch(() => {});
+  }
   process.exit(1);
 }
 
@@ -339,7 +341,9 @@ if (postMode) {
   console.log('[verify-x-thread] PASS');
   await popup.close().catch(() => {});
   if (!cdpEndpoint) await ctx.close();
-  if (browser) await disconnectCdp(browser).catch(() => {});
+  if (browser) {
+    await disconnectCdp(browser, { preserveRemoteBrowser: Boolean(cdpEndpoint) }).catch(() => {});
+  }
   process.exit(0);
 }
 
@@ -408,5 +412,7 @@ console.log('[verify-x-thread] PASS');
 
 await popup.close().catch(() => {});
 if (!cdpEndpoint) await ctx.close();
-if (browser) await disconnectCdp(browser).catch(() => {});
+if (browser) {
+  await disconnectCdp(browser, { preserveRemoteBrowser: Boolean(cdpEndpoint) }).catch(() => {});
+}
 process.exit(0);

--- a/src/adapters/bluesky.ts
+++ b/src/adapters/bluesky.ts
@@ -6,6 +6,7 @@ export const blueskyAdapter: PlatformAdapter = {
   charLimit: 300,
   popupOrder: 2,
   defaultSelected: true,
+  realPostLane: 'background',
   matchUrl: (url) => /^https:\/\/bsky\.app\//.test(url),
   // /intent/compose?text= で compose dialog が開いて text が入る
   getComposeUrl: (text) =>

--- a/src/adapters/mastodon.ts
+++ b/src/adapters/mastodon.ts
@@ -13,6 +13,7 @@ export const mastodonAdapter: PlatformAdapter = {
   charLimit: 500,
   popupOrder: 5,
   defaultSelected: true,
+  realPostLane: 'background',
   preSubmitLoad: {
     retryCount: 1,
     urlReady: 'same-origin-path',

--- a/src/adapters/misskey.ts
+++ b/src/adapters/misskey.ts
@@ -14,6 +14,7 @@ export const misskeyAdapter: PlatformAdapter = {
   charLimit: 3000, // misskey.io は 3000 文字、インスタンス依存
   popupOrder: 6,
   defaultSelected: true,
+  realPostLane: 'background',
   matchUrl: (url) => url.startsWith(`${MISSKEY_DEFAULT_INSTANCE}/`),
   // Misskey の Web Intent: /share?text=...
   getComposeUrl: (text) =>

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -57,6 +57,11 @@ export interface PlatformAdapter {
    * requiresForegroundTab は別の強い要件として常に foreground を優先する。
    */
   previewLane?: 'foreground';
+  /**
+   * next実投稿をinactive tabで実行してよいことを明示する。
+   * 未指定は安全側のforeground。指定adapterはリリース前にSurface gateで継続検証する。
+   */
+  realPostLane?: 'background';
   /** 投稿操作前の compose page load timeout に対する宣言policy */
   preSubmitLoad?: PreSubmitLoadPolicy;
   /** 動画投稿で優先する表示aspect。未指定なら原寸を維持する */

--- a/src/adapters/x.ts
+++ b/src/adapters/x.ts
@@ -7,6 +7,7 @@ export const xAdapter: PlatformAdapter = {
   popupOrder: 1,
   defaultSelected: true,
   previewLane: 'foreground',
+  realPostLane: 'background',
   matchUrl: (url) => /^https:\/\/(x|twitter)\.com\//.test(url),
   /**
    * X は `/compose/post` の modal compose を使う。ホームの inline compose は

--- a/src/api/bluesky.test.ts
+++ b/src/api/bluesky.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { postViaSession } from './bluesky';
+import { postThreadViaSession, postViaSession } from './bluesky';
 
 describe('Bluesky API client', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -103,5 +103,83 @@ describe('Bluesky API client', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('cannot combine video and images');
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates an entire thread in one session with root and parent chaining', async () => {
+    let createIndex = 0;
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url.endsWith('/xrpc/com.atproto.repo.createRecord')) {
+        createIndex += 1;
+        return new Response(JSON.stringify({
+          uri: `at://did:plc:alice/app.bsky.feed.post/chunk${createIndex}`,
+          cid: `cid${createIndex}`,
+        }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await postThreadViaSession(
+      { accessJwt: 'jwt', did: 'did:plc:alice', handle: 'alice.test' },
+      { chunks: ['first', 'second', 'third'] },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      postUrl: 'https://bsky.app/profile/alice.test/post/chunk3',
+    });
+    const createCalls = fetchSpy.mock.calls
+      .filter(([url]) => String(url).endsWith('/xrpc/com.atproto.repo.createRecord'));
+    expect(createCalls).toHaveLength(3);
+    const records = createCalls.map(([, init]) => JSON.parse(String(init?.body)).record);
+    expect(records[0].reply).toBeUndefined();
+    expect(records[1].reply).toEqual({
+      root: {
+        uri: 'at://did:plc:alice/app.bsky.feed.post/chunk1',
+        cid: 'cid1',
+      },
+      parent: {
+        uri: 'at://did:plc:alice/app.bsky.feed.post/chunk1',
+        cid: 'cid1',
+      },
+    });
+    expect(records[2].reply).toEqual({
+      root: {
+        uri: 'at://did:plc:alice/app.bsky.feed.post/chunk1',
+        cid: 'cid1',
+      },
+      parent: {
+        uri: 'at://did:plc:alice/app.bsky.feed.post/chunk2',
+        cid: 'cid2',
+      },
+    });
+  });
+
+  it('marks a thread as uncertain when a later chunk fails after the root exists', async () => {
+    let createIndex = 0;
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (!url.endsWith('/xrpc/com.atproto.repo.createRecord')) {
+        throw new Error(`unexpected fetch: ${url}`);
+      }
+      createIndex += 1;
+      if (createIndex === 2) {
+        return new Response('rate limited', { status: 429 });
+      }
+      return new Response(JSON.stringify({
+        uri: 'at://did:plc:alice/app.bsky.feed.post/root',
+        cid: 'rootcid',
+      }), { status: 200 });
+    });
+
+    const result = await postThreadViaSession(
+      { accessJwt: 'jwt', did: 'did:plc:alice', handle: 'alice.test' },
+      { chunks: ['first', 'second'] },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      uncertain: true,
+      postUrl: 'https://bsky.app/profile/alice.test/post/root',
+    });
+    expect(result.error).toContain('chunk 2/2');
   });
 });

--- a/src/api/bluesky.ts
+++ b/src/api/bluesky.ts
@@ -61,6 +61,11 @@ export interface BlueskyReplyTarget {
   parentCid: string;
 }
 
+export interface BlueskyThreadPostInput {
+  chunks: string[];
+  images?: ApiPostInput['images'];
+}
+
 async function createSession(creds: BlueskyCredentials): Promise<Session> {
   const pds = creds.pdsHost || DEFAULT_PDS;
   const res = await fetch(`${pds}/xrpc/com.atproto.server.createSession`, {
@@ -270,6 +275,86 @@ export async function postViaApi(
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : String(e) };
   }
+}
+
+/**
+ * 1 sessionで全chunkを順次createRecordし、root/parentのuri+cidでthread化する。
+ * 投稿間の固定waitは不要。途中失敗時は先頭postが既に存在するためuncertainを返し、
+ * 上位層がDOM fallbackで重複投稿しないようにする。
+ */
+export async function postThreadViaApi(
+  creds: BlueskyCredentials,
+  input: BlueskyThreadPostInput,
+): Promise<ApiPostResult> {
+  try {
+    const session = await createSession(creds);
+    return await postThreadViaSession(session, input);
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export async function postThreadViaSession(
+  session: Session,
+  input: BlueskyThreadPostInput,
+): Promise<ApiPostResult> {
+  if (input.chunks.length === 0) {
+    return { success: false, error: 'Bluesky API thread requires at least one chunk' };
+  }
+
+  let root: { uri: string; cid: string } | undefined;
+  let parent: { uri: string; cid: string } | undefined;
+  let lastPostUrl: string | undefined;
+
+  for (let index = 0; index < input.chunks.length; index += 1) {
+    const replyTarget = root && parent
+      ? {
+          rootUri: root.uri,
+          rootCid: root.cid,
+          parentUri: parent.uri,
+          parentCid: parent.cid,
+        }
+      : undefined;
+    const result = await postViaSession(
+      session,
+      {
+        text: input.chunks[index]!,
+        images: index === 0 ? input.images : undefined,
+      },
+      replyTarget,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        uncertain: index > 0 || result.uncertain || undefined,
+        postUrl: lastPostUrl,
+        error:
+          `Bluesky thread chunk ${index + 1}/${input.chunks.length} failed: ` +
+          `${result.error ?? 'unknown error'}`,
+      };
+    }
+    if (!result.uri || !result.cid) {
+      return {
+        success: false,
+        uncertain: true,
+        postUrl: result.postUrl ?? lastPostUrl,
+        error:
+          `Bluesky thread chunk ${index + 1}/${input.chunks.length} ` +
+          'was created without uri/cid',
+      };
+    }
+
+    const created = { uri: result.uri, cid: result.cid };
+    root ??= created;
+    parent = created;
+    lastPostUrl = result.postUrl ?? lastPostUrl;
+  }
+
+  return {
+    success: true,
+    postUrl: lastPostUrl,
+  };
 }
 
 /**

--- a/src/background/api-posting.test.ts
+++ b/src/background/api-posting.test.ts
@@ -1,10 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { postViaApi as postBlueskyApi, postViaSession as postBlueskySessionApi } from '../api/bluesky';
+import {
+  postThreadViaApi as postBlueskyThreadApi,
+  postThreadViaSession as postBlueskyThreadSessionApi,
+  postViaApi as postBlueskyApi,
+  postViaSession as postBlueskySessionApi,
+} from '../api/bluesky';
 import { postViaApi as postMastodonApi } from '../api/mastodon';
 import { getApiCredentials } from '../utils/api-credentials';
-import { backgroundPlatformStrategies, tryApiPath } from './platform-strategies';
+import {
+  backgroundPlatformStrategies,
+  tryApiPath,
+  tryApiThreadPath,
+} from './platform-strategies';
 
 vi.mock('../api/bluesky', () => ({
+  postThreadViaApi: vi.fn(async () => ({ success: true, postUrl: 'https://bsky.app/profile/alice/post/thread-api' })),
+  postThreadViaSession: vi.fn(async () => ({ success: true, postUrl: 'https://bsky.app/profile/alice/post/thread-session' })),
   postViaApi: vi.fn(async () => ({ success: true, postUrl: 'https://bsky.app/profile/alice/post/abc' })),
   postViaSession: vi.fn(async () => ({ success: true, postUrl: 'https://bsky.app/profile/alice/post/session-abc' })),
 }));
@@ -25,6 +36,8 @@ describe('tryApiPath', () => {
   const getCreds = vi.mocked(getApiCredentials);
   const postBluesky = vi.mocked(postBlueskyApi);
   const postBlueskySession = vi.mocked(postBlueskySessionApi);
+  const postBlueskyThread = vi.mocked(postBlueskyThreadApi);
+  const postBlueskyThreadSession = vi.mocked(postBlueskyThreadSessionApi);
   const postMastodon = vi.mocked(postMastodonApi);
 
   beforeEach(() => {
@@ -42,6 +55,9 @@ describe('tryApiPath', () => {
     expect(Object.entries(backgroundPlatformStrategies)
       .filter(([, strategy]) => strategy.apiPost)
       .map(([platform]) => platform)).toEqual(['bluesky', 'mastodon', 'misskey']);
+    expect(Object.entries(backgroundPlatformStrategies)
+      .filter(([, strategy]) => strategy.apiThreadPost)
+      .map(([platform]) => platform)).toEqual(['bluesky']);
   });
 
   it('returns no-credentials without credential lookup when no API strategy is registered', async () => {
@@ -120,6 +136,50 @@ describe('tryApiPath', () => {
           durationS: 1,
         }],
       },
+    );
+  });
+
+  it('posts all Bluesky chunks through one credential-backed API thread call', async () => {
+    const result = await tryApiThreadPath(
+      'bluesky',
+      ['first', 'second'],
+      [{ name: 'photo.png', type: 'image/png', data: 'AA==' }],
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(postBlueskyThread).toHaveBeenCalledWith(
+      { identifier: 'alice.test', appPassword: 'xxxx-xxxx-xxxx-xxxx' },
+      {
+        chunks: ['first', 'second'],
+        images: [{ name: 'photo.png', type: 'image/png', data: 'AA==' }],
+      },
+    );
+  });
+
+  it('uses a borrowed Bluesky session for API threads without saved credentials', async () => {
+    getCreds.mockResolvedValue({});
+    vi.stubGlobal('browser', {
+      tabs: {
+        query: vi.fn(async () => [{ id: 42, url: 'https://bsky.app/profile/alice.test' }]),
+        sendMessage: vi.fn(async () => ({
+          type: 'BLUESKY_SESSION_RESULT',
+          accessJwt: 'jwt',
+          did: 'did:plc:alice',
+          handle: 'alice.test',
+        })),
+      },
+    });
+
+    const result = await tryApiThreadPath('bluesky', ['first', 'second']);
+
+    expect(result).toMatchObject({ success: true });
+    expect(postBlueskyThreadSession).toHaveBeenCalledWith(
+      {
+        accessJwt: 'jwt',
+        did: 'did:plc:alice',
+        handle: 'alice.test',
+      },
+      { chunks: ['first', 'second'], images: undefined },
     );
   });
 

--- a/src/background/api-posting.test.ts
+++ b/src/background/api-posting.test.ts
@@ -9,6 +9,7 @@ import { postViaApi as postMastodonApi } from '../api/mastodon';
 import { getApiCredentials } from '../utils/api-credentials';
 import {
   backgroundPlatformStrategies,
+  resolveCredentialBackedApiPlatforms,
   tryApiPath,
   tryApiThreadPath,
 } from './platform-strategies';
@@ -63,6 +64,15 @@ describe('tryApiPath', () => {
   it('returns no-credentials without credential lookup when no API strategy is registered', async () => {
     expect(await tryApiPath('x', 'hello')).toBe('no-credentials');
     expect(getCreds).not.toHaveBeenCalled();
+  });
+
+  it('classifies only platforms with saved credentials into the API scheduler lane', async () => {
+    expect(await resolveCredentialBackedApiPlatforms([
+      'x',
+      'bluesky',
+      'mastodon',
+      'misskey',
+    ])).toEqual(['bluesky']);
   });
 
   it('uses the Bluesky API path for video attachments', async () => {

--- a/src/background/api-posting.ts
+++ b/src/background/api-posting.ts
@@ -1,6 +1,11 @@
 import type { ImageAttachment } from '../messages';
 import type { BlueskySessionResult } from '../messages';
-import { postViaApi as postBlueskyApi, postViaSession as postBlueskySession } from '../api/bluesky';
+import {
+  postThreadViaApi as postBlueskyThreadApi,
+  postThreadViaSession as postBlueskyThreadSession,
+  postViaApi as postBlueskyApi,
+  postViaSession as postBlueskySession,
+} from '../api/bluesky';
 import type { Session as BlueskySession } from '../api/bluesky';
 import { postViaApi as postMastodonApi } from '../api/mastodon';
 import { postViaApi as postMisskeyApi } from '../api/misskey';
@@ -23,6 +28,15 @@ export type ApiPostingStrategy = (
   input: ApiPostingInput,
 ) => Promise<ApiPostResult | 'no-credentials'>;
 
+export interface ApiThreadPostingInput {
+  chunks: string[];
+  images?: ImageAttachment[];
+}
+
+export type ApiThreadPostingStrategy = (
+  input: ApiThreadPostingInput,
+) => Promise<ApiPostResult | 'no-credentials'>;
+
 export async function tryBlueskyApiPost({
   text,
   images,
@@ -36,6 +50,26 @@ export async function tryBlueskyApiPost({
     const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
     log.info(`bluesky via borrowed web session API start: media=${images?.length ?? 0} video=${hasVideo}`);
     return await postBlueskySession(session, { text, images });
+  }
+  return 'no-credentials';
+}
+
+export async function tryBlueskyApiThreadPost({
+  chunks,
+  images,
+}: ApiThreadPostingInput): Promise<ApiPostResult | 'no-credentials'> {
+  const creds = await getApiCredentials();
+  if (creds.bluesky) {
+    return await postBlueskyThreadApi(creds.bluesky, { chunks, images });
+  }
+  const session = await readBlueskySessionFromOpenTab();
+  if (session) {
+    const hasVideo = !!images?.some((image) => image.type.startsWith('video/'));
+    log.info(
+      `bluesky thread via borrowed web session API start: ` +
+      `chunks=${chunks.length} media=${images?.length ?? 0} video=${hasVideo}`,
+    );
+    return await postBlueskyThreadSession(session, { chunks, images });
   }
   return 'no-credentials';
 }

--- a/src/background/dom-attempt-policy.test.ts
+++ b/src/background/dom-attempt-policy.test.ts
@@ -84,6 +84,19 @@ describe('DOM posting attempt policy', () => {
     });
   });
 
+  it('keeps background-real retries inactive instead of promoting them into the foreground lane', () => {
+    expect(buildDomPostAttempts(adapter(), true, false, true)).toEqual([
+      { label: 'background' },
+      {
+        label: 'fresh background compose',
+        skipApi: true,
+        reuseExistingTab: false,
+        loadRetries: 1,
+        delayBeforeMs: 750,
+      },
+    ]);
+  });
+
   it('derives foreground policy from post mode and platform requirements', () => {
     expect(shouldOpenActive(adapter(), false, undefined, true)).toBe(true);
     expect(shouldOpenActive(adapter(), true, undefined, false)).toBe(false);

--- a/src/background/dom-attempt-policy.ts
+++ b/src/background/dom-attempt-policy.ts
@@ -48,8 +48,21 @@ export function buildDomPostAttempts(
   adapter: PlatformAdapter,
   autoPost: boolean,
   forceForeground = false,
+  forceBackground = false,
 ): DomPostAttempt[] {
   const dryRun = !autoPost;
+  if (forceBackground) {
+    return [
+      { label: 'background' },
+      {
+        label: 'fresh background compose',
+        skipApi: true,
+        reuseExistingTab: false,
+        loadRetries: 1,
+        delayBeforeMs: dryRun ? 250 : 750,
+      },
+    ];
+  }
   const attempts: DomPostAttempt[] = [
     forceForeground ? { label: 'default', forceActive: true } : { label: 'default' },
     {

--- a/src/background/platform-poster-inline-thread.test.ts
+++ b/src/background/platform-poster-inline-thread.test.ts
@@ -125,7 +125,7 @@ describe('X inline thread orchestration', () => {
     expect(message.textChunks?.length).toBeGreaterThan(1);
     expect(message.text).toBe(message.textChunks?.[0]);
     expect(message.textChunks?.join('')).toContain('word119');
-  });
+  }, 10_000);
 
   it('uses captured post URLs when the legacy sequential mode is selected', async () => {
     vi.useFakeTimers();

--- a/src/background/platform-poster-inline-thread.test.ts
+++ b/src/background/platform-poster-inline-thread.test.ts
@@ -1,9 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { PostResultMessage, PostToPlatformMessage } from '../messages';
+import type { ApiPostResult } from '../api/types';
+import type {
+  ImageAttachment,
+  PlatformId,
+  PostResultMessage,
+  PostToPlatformMessage,
+} from '../messages';
 
 const mocks = vi.hoisted(() => ({
+  attachVerifyResult: vi.fn(async () => undefined),
   openOrFocusTab: vi.fn(),
   sendPostMessageWhenReady: vi.fn(),
+  tryApiThreadPath: vi.fn<(
+    platform: PlatformId,
+    chunks: string[],
+    images?: ImageAttachment[],
+  ) => Promise<ApiPostResult | 'no-credentials'>>(
+    async () => 'no-credentials',
+  ),
 }));
 
 vi.mock('./tab-management', async (importOriginal) => {
@@ -19,6 +33,22 @@ vi.mock('./content-dispatch', async (importOriginal) => {
   return {
     ...actual,
     sendPostMessageWhenReady: mocks.sendPostMessageWhenReady,
+  };
+});
+
+vi.mock('./platform-strategies', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./platform-strategies')>();
+  return {
+    ...actual,
+    tryApiThreadPath: mocks.tryApiThreadPath,
+  };
+});
+
+vi.mock('./post-confirmation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./post-confirmation')>();
+  return {
+    ...actual,
+    attachVerifyResult: mocks.attachVerifyResult,
   };
 });
 
@@ -39,6 +69,7 @@ describe('X inline thread orchestration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.tryApiThreadPath.mockResolvedValue('no-credentials');
     mocks.openOrFocusTab.mockResolvedValue({
       tab: {
         id: 42,
@@ -147,5 +178,80 @@ describe('X inline thread orchestration', () => {
     >) {
       expect(message.textChunks).toBeUndefined();
     }
+  });
+});
+
+describe('Bluesky inline thread orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tryApiThreadPath.mockResolvedValue({
+      success: true,
+      postUrl: 'https://bsky.app/profile/alice.test/post/final',
+    });
+  });
+
+  it('uses one API thread operation without opening a compose tab', async () => {
+    const poster = createPlatformPoster({
+      openedTabs: {
+        record: vi.fn(),
+        forget: vi.fn(),
+      },
+    });
+    const text = 'a'.repeat(400);
+
+    const result = await poster.postToPlatform(
+      'bluesky',
+      text,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(result).toMatchObject({
+      platform: 'bluesky',
+      success: true,
+      confirmed: true,
+      url: 'https://bsky.app/profile/alice.test/post/final',
+    });
+    expect(mocks.tryApiThreadPath).toHaveBeenCalledOnce();
+    const [, chunks] = mocks.tryApiThreadPath.mock.calls[0]!;
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(mocks.openOrFocusTab).not.toHaveBeenCalled();
+    expect(mocks.sendPostMessageWhenReady).not.toHaveBeenCalled();
+    expect(mocks.attachVerifyResult).toHaveBeenCalledOnce();
+  });
+
+  it('does not fall back to DOM after a partially posted API thread', async () => {
+    mocks.tryApiThreadPath.mockResolvedValue({
+      success: false,
+      uncertain: true,
+      postUrl: 'https://bsky.app/profile/alice.test/post/root',
+      error: 'chunk 2/2 failed',
+    });
+    const poster = createPlatformPoster({
+      openedTabs: {
+        record: vi.fn(),
+        forget: vi.fn(),
+      },
+    });
+
+    const result = await poster.postToPlatform(
+      'bluesky',
+      'a'.repeat(400),
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(result).toMatchObject({
+      platform: 'bluesky',
+      success: false,
+      uncertain: true,
+      userAction: 'check-post-before-retry',
+    });
+    expect(mocks.openOrFocusTab).not.toHaveBeenCalled();
+    expect(mocks.sendPostMessageWhenReady).not.toHaveBeenCalled();
   });
 });

--- a/src/background/platform-poster-transport.test.ts
+++ b/src/background/platform-poster-transport.test.ts
@@ -134,6 +134,66 @@ describe('platform poster transport boundaries', () => {
     expect(mocks.sendPostMessageWhenReady).not.toHaveBeenCalled();
   });
 
+  it('does not fall back to DOM when an API-only lane loses its credentials', async () => {
+    mocks.tryApiPath.mockResolvedValue('no-credentials');
+
+    const result = await createPoster().postToPlatform(
+      'mastodon',
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      true,
+      {
+        postingAlgorithm: 'next',
+        transportPolicy: 'api-only',
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      flow: {
+        attempt: 'api',
+        submitReached: false,
+        failedStep: 'preflight:api-credentials',
+      },
+    });
+    expect(mocks.openOrFocusTab).not.toHaveBeenCalled();
+    expect(mocks.sendPostMessageWhenReady).not.toHaveBeenCalled();
+  });
+
+  it('opens certified background real-post flows as inactive tabs', async () => {
+    mocks.tryApiPath.mockResolvedValue('no-credentials');
+    mocks.sendPostMessageWhenReady.mockResolvedValue({
+      type: 'POST_RESULT',
+      platform: 'mastodon',
+      success: true,
+      confirmed: true,
+      url: 'https://social.example/@alice/123',
+    } satisfies PostResultMessage);
+
+    const result = await createPoster().postToPlatform(
+      'mastodon',
+      'hello',
+      undefined,
+      undefined,
+      undefined,
+      true,
+      {
+        postingAlgorithm: 'next',
+        forceBackground: true,
+        transportPolicy: 'dom-only',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.openOrFocusTab).toHaveBeenCalledOnce();
+    const openCalls = mocks.openOrFocusTab.mock.calls as unknown as Array<
+      [string, (url: string) => boolean, boolean]
+    >;
+    expect(openCalls[0]?.[2]).toBe(false);
+  });
+
   it('stops after one real-post dispatch when the content response times out', async () => {
     mocks.tryApiPath.mockResolvedValue('no-credentials');
     mocks.sendPostMessageWhenReady.mockRejectedValue(

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -9,9 +9,11 @@ import {
 } from '../utils/post-verify';
 import {
   tryBlueskyApiPost,
+  tryBlueskyApiThreadPost,
   tryMastodonApiPost,
   tryMisskeyApiPost,
   type ApiPostingStrategy,
+  type ApiThreadPostingStrategy,
   type ApiPostingVisibility,
 } from './api-posting';
 import {
@@ -43,6 +45,8 @@ export interface BackgroundPlatformStrategy {
   parsePostId: (url: URL) => string | null;
   /** credentials / borrowed session がある場合だけ使う API posting 手続き。 */
   apiPost?: ApiPostingStrategy;
+  /** 複数chunkを1 sessionでreply chainにするAPI posting手続き。 */
+  apiThreadPost?: ApiThreadPostingStrategy;
   /** API posting strategyがreply URLをthread continuationとして処理できる。 */
   apiReplyContinuation?: true;
   /** 複数chunkを1つのcompose surfaceへまとめるplatform固有policy。 */
@@ -94,6 +98,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryBlueskyApiPost,
+    apiThreadPost: tryBlueskyApiThreadPost,
     inlineThread: {
       shouldUse: () => true,
     },
@@ -207,6 +212,16 @@ export async function tryApiPath(
   const strategy = getBackgroundPlatformStrategy(platform).apiPost;
   if (!strategy) return 'no-credentials';
   return await strategy({ text, images, cw, visibility, replyToUrl });
+}
+
+export async function tryApiThreadPath(
+  platform: PlatformId,
+  chunks: string[],
+  images?: ImageAttachment[],
+): Promise<ApiPostResult | 'no-credentials'> {
+  const strategy = getBackgroundPlatformStrategy(platform).apiThreadPost;
+  if (!strategy) return 'no-credentials';
+  return await strategy({ chunks, images });
 }
 
 export function continuationNeedsReplyUrl(platform: PlatformId): boolean {

--- a/src/background/platform-strategies.ts
+++ b/src/background/platform-strategies.ts
@@ -35,6 +35,10 @@ import {
   type CapturePostUrlOptions,
 } from './post-url-capture';
 import { extractHttpUrls } from '../utils/text-urls';
+import {
+  getApiCredentials,
+  type ApiCredentials,
+} from '../utils/api-credentials';
 
 export type PostUrlCaptureStrategy = (
   options: CapturePostUrlOptions,
@@ -45,6 +49,8 @@ export interface BackgroundPlatformStrategy {
   parsePostId: (url: URL) => string | null;
   /** credentials / borrowed session がある場合だけ使う API posting 手続き。 */
   apiPost?: ApiPostingStrategy;
+  /** schedulerが副作用なしでAPI laneを確定するための保存credential key。 */
+  apiCredentialKey?: keyof ApiCredentials;
   /** 複数chunkを1 sessionでreply chainにするAPI posting手続き。 */
   apiThreadPost?: ApiThreadPostingStrategy;
   /** API posting strategyがreply URLをthread continuationとして処理できる。 */
@@ -98,6 +104,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   bluesky: {
     parsePostId: ({ pathname }) => pathname.match(/\/post\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryBlueskyApiPost,
+    apiCredentialKey: 'bluesky',
     apiThreadPost: tryBlueskyApiThreadPost,
     inlineThread: {
       shouldUse: () => true,
@@ -118,6 +125,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
       ?? null
     ),
     apiPost: tryMastodonApiPost,
+    apiCredentialKey: 'mastodon',
     apiReplyContinuation: true,
     continuationUrl: (previousPostUrl) => previousPostUrl,
     verifyPost: verifyMastodonPost,
@@ -126,6 +134,7 @@ export const backgroundPlatformStrategies: Record<PlatformId, BackgroundPlatform
   misskey: {
     parsePostId: ({ pathname }) => pathname.match(/\/notes\/([a-zA-Z0-9]+)/)?.[1] ?? null,
     apiPost: tryMisskeyApiPost,
+    apiCredentialKey: 'misskey',
     verifyPost: verifyMisskeyPost,
     capturePostUrl: capturePostUrlWithGenericFlow,
   },
@@ -222,6 +231,18 @@ export async function tryApiThreadPath(
   const strategy = getBackgroundPlatformStrategy(platform).apiThreadPost;
   if (!strategy) return 'no-credentials';
   return await strategy({ chunks, images });
+}
+
+export async function resolveCredentialBackedApiPlatforms(
+  platforms: readonly PlatformId[],
+): Promise<PlatformId[]> {
+  const credentials = await getApiCredentials();
+  return platforms.filter((platform) => {
+    const strategy = getBackgroundPlatformStrategy(platform);
+    return !!strategy.apiPost &&
+      !!strategy.apiCredentialKey &&
+      credentials[strategy.apiCredentialKey] !== undefined;
+  });
 }
 
 export function continuationNeedsReplyUrl(platform: PlatformId): boolean {

--- a/src/background/post-concurrency.test.ts
+++ b/src/background/post-concurrency.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPostExecutionPlan,
   needsForegroundPreview,
+  needsForegroundRealPost,
   resolvePostConcurrency,
 } from './post-concurrency';
 
@@ -11,6 +12,58 @@ describe('post execution plan', () => {
     expect(buildPostExecutionPlan(['x', 'bluesky', 'threads'], true).lanes).toEqual([{
       id: 'serial',
       platforms: ['x', 'bluesky', 'threads'],
+      concurrency: 1,
+      forceForeground: false,
+    }]);
+  });
+
+  it('splits next real posts into API, foreground DOM, and background DOM lanes', () => {
+    const platforms = [
+      'x',
+      'bluesky',
+      'threads',
+      'mastodon',
+      'misskey',
+      'instagram',
+    ] as const;
+    expect(buildPostExecutionPlan(platforms, true, {
+      postingAlgorithm: 'next',
+      apiPlatforms: ['bluesky', 'mastodon'],
+    }).lanes).toEqual([
+      {
+        id: 'api',
+        platforms: ['bluesky', 'mastodon'],
+        concurrency: 3,
+        forceForeground: false,
+        transportPolicy: 'api-only',
+      },
+      {
+        id: 'foreground',
+        platforms: ['threads', 'instagram'],
+        concurrency: 1,
+        forceForeground: true,
+      },
+      {
+        id: 'background',
+        platforms: ['x', 'misskey'],
+        concurrency: 3,
+        forceForeground: false,
+        forceBackground: true,
+      },
+    ]);
+    expect(needsForegroundRealPost('x')).toBe(false);
+    expect(needsForegroundRealPost('misskey')).toBe(false);
+    expect(needsForegroundRealPost('threads')).toBe(true);
+    expect(needsForegroundRealPost('instagram')).toBe(true);
+  });
+
+  it('keeps legacy real posts serialized even when API hints are present', () => {
+    expect(buildPostExecutionPlan(['bluesky', 'x'], true, {
+      postingAlgorithm: 'legacy',
+      apiPlatforms: ['bluesky'],
+    }).lanes).toEqual([{
+      id: 'serial',
+      platforms: ['bluesky', 'x'],
       concurrency: 1,
       forceForeground: false,
     }]);

--- a/src/background/post-concurrency.ts
+++ b/src/background/post-concurrency.ts
@@ -1,18 +1,24 @@
 import type { PlatformId } from '../types/platform';
+import type { PostingAlgorithm } from '../types/posting';
 import { getAdapter } from '../adapters/registry';
 
 export const REAL_POST_CONCURRENCY = 1;
+export const REAL_API_CONCURRENCY = 3;
+export const REAL_BACKGROUND_CONCURRENCY = 3;
 export const PREVIEW_BACKGROUND_CONCURRENCY = 3;
 export const PREVIEW_VIDEO_BACKGROUND_CONCURRENCY = 1;
 export const PREVIEW_FOREGROUND_CONCURRENCY = 1;
 
-export type PostExecutionLaneId = 'serial' | 'foreground' | 'background';
+export type PostExecutionLaneId = 'serial' | 'api' | 'foreground' | 'background';
+export type PostTransportPolicy = 'auto' | 'api-only' | 'dom-only';
 
 export interface PostExecutionLane {
   id: PostExecutionLaneId;
   platforms: PlatformId[];
   concurrency: number;
   forceForeground: boolean;
+  forceBackground?: boolean;
+  transportPolicy?: PostTransportPolicy;
 }
 
 export interface PostExecutionPlan {
@@ -21,6 +27,8 @@ export interface PostExecutionPlan {
 
 export interface PostExecutionPlanOptions {
   hasVideo?: boolean;
+  postingAlgorithm?: PostingAlgorithm;
+  apiPlatforms?: readonly PlatformId[];
 }
 
 export function buildPostExecutionPlan(
@@ -29,6 +37,9 @@ export function buildPostExecutionPlan(
   options: PostExecutionPlanOptions = {},
 ): PostExecutionPlan {
   if (autoPost) {
+    if (options.postingAlgorithm === 'next') {
+      return buildNextRealPostExecutionPlan(platforms, options);
+    }
     return {
       lanes: [{
         id: 'serial',
@@ -76,6 +87,61 @@ export function buildPostExecutionPlan(
   }
 
   return { lanes };
+}
+
+function buildNextRealPostExecutionPlan(
+  platforms: readonly PlatformId[],
+  options: PostExecutionPlanOptions,
+): PostExecutionPlan {
+  const apiSet = new Set(options.apiPlatforms ?? []);
+  const api: PlatformId[] = [];
+  const foreground: PlatformId[] = [];
+  const background: PlatformId[] = [];
+
+  for (const platform of platforms) {
+    if (apiSet.has(platform)) {
+      api.push(platform);
+    } else if (needsForegroundRealPost(platform)) {
+      foreground.push(platform);
+    } else {
+      background.push(platform);
+    }
+  }
+
+  const lanes: PostExecutionLane[] = [];
+  if (api.length > 0) {
+    lanes.push({
+      id: 'api',
+      platforms: api,
+      concurrency: REAL_API_CONCURRENCY,
+      forceForeground: false,
+      transportPolicy: 'api-only',
+    });
+  }
+  if (foreground.length > 0) {
+    lanes.push({
+      id: 'foreground',
+      platforms: foreground,
+      concurrency: REAL_POST_CONCURRENCY,
+      forceForeground: true,
+    });
+  }
+  if (background.length > 0) {
+    lanes.push({
+      id: 'background',
+      platforms: background,
+      concurrency: options.hasVideo ? 1 : REAL_BACKGROUND_CONCURRENCY,
+      forceForeground: false,
+      forceBackground: true,
+    });
+  }
+  return { lanes };
+}
+
+export function needsForegroundRealPost(platform: PlatformId): boolean {
+  const adapter = getAdapter(platform);
+  return adapter?.realPostLane !== 'background' ||
+    adapter.requiresForegroundTab === true;
 }
 
 export function needsForegroundPreview(

--- a/src/background/post-orchestrator.ts
+++ b/src/background/post-orchestrator.ts
@@ -100,6 +100,7 @@ export function createNextPostOrchestrator(options: PostOrchestratorOptions) {
         images,
         autoPost,
         text,
+        postOptions,
       );
     }
 
@@ -213,14 +214,15 @@ export function createNextPostOrchestrator(options: PostOrchestratorOptions) {
     images?: ImageAttachment[],
     autoPost = true,
     fullText = chunks.join(''),
+    postOptions: PostExecutionOptions = {},
   ): Promise<PostResultMessage> {
-    if (autoPost) {
+    if (autoPost && postOptions.transportPolicy !== 'dom-only') {
       const apiResult = await tryApiThreadPath(adapter.id, chunks, images);
       const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, {
         mode: 'post',
         submitReached: false,
         lastCompletedStep: 'preflight',
-      });
+      }, postOptions.transportPolicy === 'api-only');
       if (apiOutcome) {
         let finalOutcome = apiOutcome;
         if (apiOutcome.success && apiOutcome.url) {
@@ -254,6 +256,8 @@ export function createNextPostOrchestrator(options: PostOrchestratorOptions) {
       undefined,
       undefined,
       autoPost,
+      undefined,
+      postOptions,
     );
   }
 

--- a/src/background/post-orchestrator.ts
+++ b/src/background/post-orchestrator.ts
@@ -18,6 +18,7 @@ import {
   continuationNeedsReplyUrl,
   isVerifySupported,
   shouldUseInlineThread,
+  tryApiThreadPath,
 } from './platform-strategies';
 import { prepareMediaForPlatform } from './platform-media';
 import {
@@ -29,6 +30,7 @@ import {
 import {
   createPostingTransport,
   PostFlowError,
+  resolveApiPostOutcome,
 } from './posting-transport';
 import type {
   PostExecutionOptions,
@@ -92,7 +94,13 @@ export function createNextPostOrchestrator(options: PostOrchestratorOptions) {
       )
       && chunks.length > 1
     ) {
-      return await postSingleChunkInlineThread(adapter, chunks, images, autoPost);
+      return await postSingleChunkInlineThread(
+        adapter,
+        chunks,
+        images,
+        autoPost,
+        text,
+      );
     }
 
     let previousPostUrl: string | undefined;
@@ -204,7 +212,35 @@ export function createNextPostOrchestrator(options: PostOrchestratorOptions) {
     chunks: string[],
     images?: ImageAttachment[],
     autoPost = true,
+    fullText = chunks.join(''),
   ): Promise<PostResultMessage> {
+    if (autoPost) {
+      const apiResult = await tryApiThreadPath(adapter.id, chunks, images);
+      const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, {
+        mode: 'post',
+        submitReached: false,
+        lastCompletedStep: 'preflight',
+      });
+      if (apiOutcome) {
+        let finalOutcome = apiOutcome;
+        if (apiOutcome.success && apiOutcome.url) {
+          if (isVerifySupported(adapter.id)) {
+            await attachVerifyResult(
+              apiOutcome,
+              adapter.id,
+              apiOutcome.url,
+              chunks,
+              fullText,
+              images,
+            );
+            finalOutcome = downgradeHardVerifyFailures(apiOutcome);
+          }
+          void maybeAutoOpenPostUrl(apiOutcome.url, finalOutcome.verify);
+        }
+        return finalOutcome;
+      }
+    }
+
     log.info(
       `${adapter.id}: inline thread compose で ` +
       `${chunks.length} chunks を 1 つの compose に並べる`,

--- a/src/background/post-request-handler.test.ts
+++ b/src/background/post-request-handler.test.ts
@@ -69,4 +69,71 @@ describe('post request settings boundary', () => {
       && result.implementation.path === 'legacy'
     ))).toBe(true);
   });
+
+  it('adds local stage timings only to the next implementation', async () => {
+    vi.stubGlobal('browser', {
+      storage: {
+        sync: {
+          get: vi.fn(async () => ({
+            settings: {
+              autoPost: false,
+              postingAlgorithm: 'next',
+            },
+          })),
+        },
+      },
+      action: {
+        setBadgeText: vi.fn(async () => undefined),
+      },
+    });
+    const postToPlatform = vi.fn(async (
+      platform: PostResultMessage['platform'],
+    ): Promise<PostResultMessage> => ({
+      type: 'POST_RESULT',
+      platform,
+      success: true,
+      preview: true,
+      flow: {
+        submitReached: false,
+        stageTimings: [{
+          step: 'inject-text',
+          durationMs: 12,
+          outcome: 'completed',
+        }],
+      },
+    }));
+    const handler = createPostRequestHandler({
+      submissionGuard: createSubmissionGuard(),
+      openedTabs: {
+        clear: vi.fn(),
+        record: vi.fn(),
+        forget: vi.fn(),
+        cleanup: vi.fn(async () => undefined),
+      },
+      postingState: createPostingStateManager(),
+      platformPoster: {
+        forAlgorithm: vi.fn(() => ({ postToPlatform })),
+        postToPlatform,
+      },
+      appendBackgroundLog: vi.fn(),
+      sendRuntimeMessage: vi.fn(async () => undefined),
+    });
+
+    const [result] = await handler({
+      type: 'POST_REQUEST',
+      requestId: 'request-next-timing',
+      intent: 'new',
+      text: 'timed preview',
+      platforms: ['x'],
+    });
+
+    expect(result?.flow).toMatchObject({
+      totalDurationMs: expect.any(Number),
+      stageTimings: [
+        { step: 'inject-text', durationMs: 12 },
+        { step: 'scheduler-queue:foreground', durationMs: expect.any(Number) },
+        { step: 'platform-total', durationMs: expect.any(Number) },
+      ],
+    });
+  });
 });

--- a/src/background/post-request-handler.ts
+++ b/src/background/post-request-handler.ts
@@ -12,6 +12,7 @@ import {
   normalizePostEvidence,
   shouldRunPostCompletionSideEffects,
   withPostImplementationDiagnostics,
+  withPostTiming,
 } from './post-result-policy';
 import { runPostScheduler } from './post-scheduler';
 import { clearBadge, notifyResults } from './post-status-ui';
@@ -115,25 +116,43 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
         );
         const hasVideo = adjustedImages?.some((image) => image.type.startsWith('video/')) === true;
         const requestPoster = platformPoster.forAlgorithm(postingAlgorithm);
+        const schedulerStartedAt = Date.now();
         const executionResults = await runPostScheduler({
           platforms,
           autoPost,
           planOptions: { hasVideo },
-          post: async (platform, execution) => annotateImplementation(
-            normalizePostEvidence(
-              await requestPoster.postToPlatform(
-                platform,
-                request.text,
-                adjustedImages,
-                request.cw,
-                request.visibility,
-                autoPost,
-                {
-                  forceForeground: execution.forceForeground,
-                },
+          post: async (platform, execution) => {
+            const platformStartedAt = Date.now();
+            let result = annotateImplementation(
+              normalizePostEvidence(
+                await requestPoster.postToPlatform(
+                  platform,
+                  request.text,
+                  adjustedImages,
+                  request.cw,
+                  request.visibility,
+                  autoPost,
+                  {
+                    forceForeground: execution.forceForeground,
+                  },
+                ),
               ),
-            ),
-          ),
+            );
+            if (postingAlgorithm === 'next') {
+              const completedAt = Date.now();
+              result = withPostTiming(result, {
+                step: `scheduler-queue:${execution.lane}`,
+                durationMs: Math.max(0, platformStartedAt - schedulerStartedAt),
+                outcome: 'completed',
+              });
+              result = withPostTiming(result, {
+                step: 'platform-total',
+                durationMs: Math.max(0, completedAt - platformStartedAt),
+                outcome: result.success ? 'completed' : 'failed',
+              }, Math.max(0, completedAt - schedulerStartedAt));
+            }
+            return result;
+          },
           onResult: recordPlatformProgress,
         });
         const results = [...rejectedResults, ...executionResults];

--- a/src/background/post-request-handler.ts
+++ b/src/background/post-request-handler.ts
@@ -15,6 +15,7 @@ import {
   withPostTiming,
 } from './post-result-policy';
 import { runPostScheduler } from './post-scheduler';
+import { resolveCredentialBackedApiPlatforms } from './platform-strategies';
 import { clearBadge, notifyResults } from './post-status-ui';
 import type { createPostingStateManager } from './posting-state';
 import { executeGuardedSubmission } from './submission-execution';
@@ -116,11 +117,18 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
         );
         const hasVideo = adjustedImages?.some((image) => image.type.startsWith('video/')) === true;
         const requestPoster = platformPoster.forAlgorithm(postingAlgorithm);
+        const apiPlatforms = postingAlgorithm === 'next' && autoPost
+          ? await resolveCredentialBackedApiPlatforms(platforms)
+          : [];
         const schedulerStartedAt = Date.now();
         const executionResults = await runPostScheduler({
           platforms,
           autoPost,
-          planOptions: { hasVideo },
+          planOptions: {
+            hasVideo,
+            postingAlgorithm,
+            apiPlatforms,
+          },
           post: async (platform, execution) => {
             const platformStartedAt = Date.now();
             let result = annotateImplementation(
@@ -134,6 +142,8 @@ export function createPostRequestHandler(options: PostRequestHandlerOptions) {
                   autoPost,
                   {
                     forceForeground: execution.forceForeground,
+                    forceBackground: execution.forceBackground,
+                    transportPolicy: execution.transportPolicy,
                   },
                 ),
               ),

--- a/src/background/post-result-policy.ts
+++ b/src/background/post-result-policy.ts
@@ -133,6 +133,10 @@ export function withFlow(
   result: PostResultMessage,
   flow: Partial<PostFlowTrace>,
 ): PostResultMessage {
+  const stageTimings = [
+    ...(flow.stageTimings ?? []),
+    ...(result.flow?.stageTimings ?? []),
+  ];
   return {
     ...result,
     flow: {
@@ -143,6 +147,24 @@ export function withFlow(
       submissionStartedAt: result.flow?.submissionStartedAt ?? flow.submissionStartedAt,
       tabUrlBefore: result.flow?.tabUrlBefore ?? flow.tabUrlBefore,
       tabUrlAfter: result.flow?.tabUrlAfter ?? flow.tabUrlAfter,
+      totalDurationMs: result.flow?.totalDurationMs ?? flow.totalDurationMs,
+      stageTimings: stageTimings.length > 0 ? stageTimings : undefined,
+    },
+  };
+}
+
+export function withPostTiming(
+  result: PostResultMessage,
+  timing: NonNullable<PostFlowTrace['stageTimings']>[number],
+  totalDurationMs?: number,
+): PostResultMessage {
+  return {
+    ...result,
+    flow: {
+      submitReached: result.flow?.submitReached ?? false,
+      ...result.flow,
+      totalDurationMs: totalDurationMs ?? result.flow?.totalDurationMs,
+      stageTimings: [...(result.flow?.stageTimings ?? []), timing],
     },
   };
 }

--- a/src/background/post-scheduler.test.ts
+++ b/src/background/post-scheduler.test.ts
@@ -85,6 +85,54 @@ describe('runPostScheduler', () => {
     expect(forceForegroundFlags).toEqual([false, false, false]);
   });
 
+  it('runs next API and background DOM lanes beside one serialized foreground lane', async () => {
+    const platforms: PlatformId[] = [
+      'bluesky',
+      'mastodon',
+      'x',
+      'misskey',
+      'threads',
+      'instagram',
+    ];
+    const started = new Map<PlatformId, string>();
+    const release = deferred<void>();
+    const firstWaveStarted = deferred<void>();
+    let firstWaveCount = 0;
+
+    const resultPromise = runPostScheduler({
+      platforms,
+      autoPost: true,
+      planOptions: {
+        postingAlgorithm: 'next',
+        apiPlatforms: ['bluesky', 'mastodon'],
+      },
+      post: async (platform, execution): Promise<PostResultMessage> => {
+        started.set(
+          platform,
+          `${execution.lane}:${execution.forceForeground}:` +
+          `${execution.forceBackground}:${execution.transportPolicy}`,
+        );
+        firstWaveCount += 1;
+        if (firstWaveCount === 5) firstWaveStarted.resolve();
+        await release.promise;
+        return { type: 'POST_RESULT', platform, success: true };
+      },
+    });
+
+    await firstWaveStarted.promise;
+    expect(started.get('bluesky')).toBe('api:false:false:api-only');
+    expect(started.get('mastodon')).toBe('api:false:false:api-only');
+    expect(started.get('x')).toBe('background:false:true:auto');
+    expect(started.get('misskey')).toBe('background:false:true:auto');
+    expect(started.get('threads')).toBe('foreground:true:false:auto');
+    expect(started.has('instagram')).toBe(false);
+
+    release.resolve();
+    const results = await resultPromise;
+    expect(results).toHaveLength(platforms.length);
+    expect(started.get('instagram')).toBe('foreground:true:false:auto');
+  });
+
   it('serializes video previews in the foreground lane', async () => {
     const seen = new Map<PlatformId, string>();
     let activeForeground = 0;

--- a/src/background/post-scheduler.ts
+++ b/src/background/post-scheduler.ts
@@ -3,12 +3,15 @@ import {
   buildPostExecutionPlan,
   type PostExecutionLane,
   type PostExecutionPlanOptions,
+  type PostTransportPolicy,
 } from './post-concurrency';
 import { runPostWorkerPool } from './post-worker-pool';
 
 export interface PostExecutionOptions {
   forceForeground: boolean;
+  forceBackground: boolean;
   lane: PostExecutionLane['id'];
+  transportPolicy: PostTransportPolicy;
 }
 
 export interface PostSchedulerOptions {
@@ -43,7 +46,9 @@ async function runLane(
     concurrency: lane.concurrency,
     post: (platform) => options.post(platform, {
       forceForeground: lane.forceForeground,
+      forceBackground: lane.forceBackground === true,
       lane: lane.id,
+      transportPolicy: lane.transportPolicy ?? 'auto',
     }),
     onResult,
   });

--- a/src/background/posting-orchestrator-contract.ts
+++ b/src/background/posting-orchestrator-contract.ts
@@ -5,11 +5,14 @@ import type {
 } from '../messages';
 import type { PostingAlgorithm } from '../types/posting';
 import type { OpenedTabRegistry } from './opened-tab-registry';
+import type { PostTransportPolicy } from './post-concurrency';
 
 export type PostingVisibility = 'public' | 'unlisted' | 'private' | 'direct';
 
 export interface PostExecutionOptions {
   forceForeground?: boolean;
+  forceBackground?: boolean;
+  transportPolicy?: PostTransportPolicy;
 }
 
 export interface PostAlgorithmSelectionOptions extends PostExecutionOptions {

--- a/src/background/posting-transport.ts
+++ b/src/background/posting-transport.ts
@@ -257,6 +257,7 @@ export function createPostingTransport(options: PostingTransportOptions) {
       const message: PostToPlatformMessage = {
         type: 'POST_TO_PLATFORM',
         platform: adapter.id,
+        implementationPath: 'next',
         text,
         textChunks,
         images,

--- a/src/background/posting-transport.ts
+++ b/src/background/posting-transport.ts
@@ -80,6 +80,7 @@ export function createPostingTransport(options: PostingTransportOptions) {
       adapter,
       autoPost,
       postOptions.forceForeground === true,
+      postOptions.forceBackground === true,
     );
     let lastError: unknown;
     for (let index = 0; index < attempts.length; index += 1) {
@@ -164,7 +165,8 @@ export function createPostingTransport(options: PostingTransportOptions) {
       autoPost &&
       (!overrideUrl || canUseApiWithReplyUrl(adapter.id, replyToUrl)) &&
       !textChunks &&
-      !attempt.skipApi
+      !attempt.skipApi &&
+      postOptions.transportPolicy !== 'dom-only'
     ) {
       const apiResult = await tryApiPath(
         adapter.id,
@@ -174,7 +176,12 @@ export function createPostingTransport(options: PostingTransportOptions) {
         visibility,
         replyToUrl,
       );
-      const apiOutcome = resolveApiPostOutcome(adapter.id, apiResult, baseFlow);
+      const apiOutcome = resolveApiPostOutcome(
+        adapter.id,
+        apiResult,
+        baseFlow,
+        postOptions.transportPolicy === 'api-only',
+      );
       if (apiOutcome) {
         if (apiOutcome.success) {
           log.info(`${adapter.id} via API ✓ ${apiOutcome.url ?? ''}`);
@@ -193,10 +200,20 @@ export function createPostingTransport(options: PostingTransportOptions) {
       }
     }
 
+    if (postOptions.transportPolicy === 'api-only') {
+      return apiTransportUnavailableResult(adapter.id, baseFlow);
+    }
+
     const dryRun = !autoPost;
     const forceForeground = postOptions.forceForeground === true;
-    const active = forceForeground || attempt.forceActive === true ||
-      shouldOpenActive(adapter, dryRun, textChunks, autoPost);
+    const forceBackground = postOptions.forceBackground === true;
+    if (forceForeground && forceBackground) {
+      throw new Error('Conflicting post tab activation policy');
+    }
+    const active = !forceBackground && (
+      forceForeground || attempt.forceActive === true ||
+      shouldOpenActive(adapter, dryRun, textChunks, autoPost)
+    );
     const reuseExistingTab = shouldReuseExistingTabForAttempt(
       adapter,
       autoPost,
@@ -365,8 +382,13 @@ export function resolveApiPostOutcome(
   platform: PlatformId,
   apiResult: ApiPostResult | 'no-credentials',
   baseFlow: Partial<PostFlowTrace> = {},
+  requireApi = false,
 ): PostResultMessage | null {
-  if (apiResult === 'no-credentials') return null;
+  if (apiResult === 'no-credentials') {
+    return requireApi
+      ? apiTransportUnavailableResult(platform, baseFlow)
+      : null;
+  }
   const flow = {
     ...baseFlow,
     attempt: 'api',
@@ -401,6 +423,25 @@ export function resolveApiPostOutcome(
     ...flow,
     submitReached: false,
     failedStep: 'api-post',
+  });
+}
+
+function apiTransportUnavailableResult(
+  platform: PlatformId,
+  baseFlow: Partial<PostFlowTrace>,
+): PostResultMessage {
+  return withFlow({
+    type: 'POST_RESULT',
+    platform,
+    success: false,
+    error:
+      'Saved API credentials became unavailable before posting. ' +
+      'No DOM fallback was attempted.',
+  }, {
+    ...baseFlow,
+    attempt: 'api',
+    submitReached: false,
+    failedStep: 'preflight:api-credentials',
   });
 }
 

--- a/src/background/verify-dispatcher.test.ts
+++ b/src/background/verify-dispatcher.test.ts
@@ -9,6 +9,7 @@ import {
   cleanXDescription,
   cleanYouTubeDescription,
   judgeInstagramImage,
+  judgeTikTokVideo,
   judgeXImage,
   verifyViaOg,
 } from '../utils/post-verify-og';
@@ -74,23 +75,24 @@ describe('verification strategy routing', () => {
       PlatformId,
       typeof cleanGenericDescription,
       typeof judgeXImage | undefined,
+      typeof judgeTikTokVideo | undefined,
     ]> = [
-      ['x', cleanXDescription, judgeXImage],
-      ['instagram', cleanInstagramDescription, judgeInstagramImage],
-      ['threads', cleanThreadsDescription, undefined],
-      ['tumblr', cleanGenericDescription, undefined],
-      ['pixiv', cleanGenericDescription, undefined],
-      ['deviantart', cleanGenericDescription, undefined],
-      ['tiktok', cleanGenericDescription, undefined],
-      ['youtube', cleanYouTubeDescription, undefined],
+      ['x', cleanXDescription, judgeXImage, undefined],
+      ['instagram', cleanInstagramDescription, judgeInstagramImage, undefined],
+      ['threads', cleanThreadsDescription, undefined, undefined],
+      ['tumblr', cleanGenericDescription, undefined, undefined],
+      ['pixiv', cleanGenericDescription, undefined, undefined],
+      ['deviantart', cleanGenericDescription, undefined, undefined],
+      ['tiktok', cleanGenericDescription, undefined, judgeTikTokVideo],
+      ['youtube', cleanYouTubeDescription, undefined, undefined],
     ];
 
-    for (const [platform, cleanDescription, judgeImage] of cases) {
+    for (const [platform, cleanDescription, judgeImage, judgeVideo] of cases) {
       await runVerify(platform, `https://example.test/${platform}`, expected);
       expect(vi.mocked(verifyViaOg)).toHaveBeenLastCalledWith(
         `https://example.test/${platform}`,
         expected,
-        { cleanDescription, judgeImage },
+        { cleanDescription, judgeImage, judgeVideo },
       );
     }
 
@@ -127,5 +129,31 @@ describe('verification strategy routing', () => {
     expect(create).toHaveBeenCalledOnce();
     expect(sendMessage).toHaveBeenCalledOnce();
     expect(remove).toHaveBeenCalledWith(42);
+  });
+
+  it('passes TikTok hydrated JSON video evidence to the OG verifier', async () => {
+    vi.mocked(verifyViaOg).mockImplementationOnce(async (url, expectation, options) => {
+      const hasVideo = options?.judgeVideo?.(
+        '<script>{"playAddr":"https://cdn.example/video.mp4"}</script>',
+        url,
+      );
+      return {
+        verified: true,
+        issues: hasVideo || !expectation.hasVideo
+          ? []
+          : [{ kind: 'video-missing', message: 'missing', severity: 'error' }],
+      };
+    });
+
+    await expect(runVerify(
+      'tiktok',
+      'https://www.tiktok.com/@tester/video/1234567890',
+      { ...expected, hasVideo: true },
+    )).resolves.toMatchObject({ verified: true, issues: [] });
+    expect(vi.mocked(verifyViaOg)).toHaveBeenCalledWith(
+      'https://www.tiktok.com/@tester/video/1234567890',
+      { ...expected, hasVideo: true },
+      expect.objectContaining({ judgeVideo: judgeTikTokVideo }),
+    );
   });
 });

--- a/src/background/verify-dispatcher.ts
+++ b/src/background/verify-dispatcher.ts
@@ -23,6 +23,7 @@ import {
   cleanYouTubeDescription,
   cleanGenericDescription,
   judgeInstagramImage,
+  judgeTikTokVideo,
   judgeXImage,
 } from '../utils/post-verify-og';
 import { buildVerifyResult, type VerifyExpectation, type VerifyResult } from '../utils/post-verify';
@@ -38,11 +39,17 @@ export type VerificationStrategy = (
 interface OgVerificationPolicy {
   cleanDescription: (description: string) => string;
   judgeImage?: (ogImage: string) => boolean;
+  judgeVideo?: (html: string, postUrl: string) => boolean;
   forceDomFallback?: (initial: VerifyResult, expected: VerifyExpectation) => boolean;
   resolveDomHasImages?: (
     response: VerifyPostDomResult,
     expected: VerifyExpectation,
     ogImage: string,
+  ) => boolean;
+  resolveDomHasVideo?: (
+    response: VerifyPostDomResult,
+    expected: VerifyExpectation,
+    postUrl: string,
   ) => boolean;
   acceptDomResult?: (result: VerifyResult) => boolean;
 }
@@ -108,7 +115,15 @@ export const verifyTikTokPost: VerificationStrategy = (postUrl, expected) => ver
   expected,
   {
     cleanDescription: cleanGenericDescription,
+    judgeVideo: judgeTikTokVideo,
     forceDomFallback: (initial) => initial.issues.length > 0,
+    resolveDomHasVideo: (response, expectation, url) => (
+      expectation.hasVideo === true &&
+      (
+        response.hasVideo === true ||
+        /^https:\/\/(?:www\.)?tiktok\.com\/@[^/]+\/video\/\d+/i.test(url)
+      )
+    ),
   },
 );
 
@@ -138,6 +153,7 @@ async function verifyOgPost(
   const r1 = await verifyViaOg(postUrl, expected, {
     cleanDescription: policy.cleanDescription,
     judgeImage: policy.judgeImage,
+    judgeVideo: policy.judgeVideo,
   });
   const needsDomFallback =
     !r1.verified ||
@@ -188,7 +204,12 @@ async function verifyViaDomTab(
         const hasImages = policy.resolveDomHasImages
           ? policy.resolveDomHasImages(resp, expected, img)
           : policy.judgeImage ? policy.judgeImage(img) : !!img;
-        const hasVideo = expected.hasVideo ? resp.hasVideo === true : undefined;
+        const hasVideo = expected.hasVideo
+          ? (
+              policy.resolveDomHasVideo?.(resp, expected, postUrl) ??
+              (resp.hasVideo === true)
+            )
+          : undefined;
         latestResult = buildVerifyResult(expected, {
           text,
           hasImages,

--- a/src/messages/posting.ts
+++ b/src/messages/posting.ts
@@ -19,6 +19,12 @@ export type UserActionCategory =
 
 export type PostFlowStep = string;
 
+export interface PostStageTiming {
+  step: PostFlowStep;
+  durationMs: number;
+  outcome?: 'completed' | 'failed';
+}
+
 export interface PostFlowTrace {
   mode?: 'preview' | 'post';
   attempt?: string;
@@ -29,6 +35,9 @@ export interface PostFlowTrace {
   tabUrlBefore?: string;
   tabUrlAfter?: string;
   urlCaptureTrace?: string[];
+  /** ローカル診断用。投稿内容・URL・account情報を含めない。 */
+  totalDurationMs?: number;
+  stageTimings?: PostStageTiming[];
 }
 
 export type PostRequestIntent = 'new' | 'retry' | 'history-repost';

--- a/src/messages/posting.ts
+++ b/src/messages/posting.ts
@@ -79,6 +79,8 @@ export interface PostRequestMessage {
 export interface PostToPlatformMessage {
   type: 'POST_TO_PLATFORM';
   platform: PlatformId;
+  /** request rootで固定済みの実装。欠落は配布済みlegacy callerとして扱う。 */
+  implementationPath?: PostImplementationPath;
   text: string;
   textChunks?: string[];
   images?: ImageAttachment[];

--- a/src/page-world/media-commands.test.ts
+++ b/src/page-world/media-commands.test.ts
@@ -85,6 +85,7 @@ describe('page-world media commands', () => {
     expect(runtime.waitForUploadComplete).toHaveBeenCalledWith(1234, {
       requireMediaAccepted: false,
       requirePreviewAccepted: false,
+      requireUploadComplete: false,
       isMediaPreviewVisible: undefined,
       getMediaRejectionMessage: undefined,
     });
@@ -147,8 +148,29 @@ describe('page-world media commands', () => {
     expect(runtime.waitForUploadComplete).toHaveBeenCalledWith(30000, expect.objectContaining({
       requireMediaAccepted: true,
       requirePreviewAccepted: true,
+      requireUploadComplete: false,
       isMediaPreviewVisible: expect.any(Function),
       getMediaRejectionMessage: expect.any(Function),
+    }));
+  });
+
+  it('forwards strict upload completion separately from preview acceptance', async () => {
+    document.body.innerHTML = '<input type="file">';
+    const runtime = createRuntime();
+    const handlers = createMediaCommandHandlers(SOURCE, runtime);
+
+    await handlers.input({
+      id: 'strict-video-upload',
+      selector: 'input',
+      files: [video],
+      requireMediaPreview: true,
+      requireUploadComplete: true,
+    });
+
+    expect(runtime.waitForUploadComplete).toHaveBeenCalledWith(30000, expect.objectContaining({
+      requireMediaAccepted: true,
+      requirePreviewAccepted: true,
+      requireUploadComplete: true,
     }));
   });
 
@@ -225,6 +247,21 @@ describe('page-world media commands', () => {
       id: 'timed-out',
       selector: 'input',
       files: [video],
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'Timed out while waiting for the media upload or preview',
+    });
+
+    const strict = createMediaCommandHandlers(SOURCE, createRuntime({
+      uploadCount: 0,
+      timedOut: true,
+      acceptedByPreview: true,
+    }));
+    await expect(strict.input({
+      id: 'strict-timeout',
+      selector: 'input',
+      files: [video],
+      requireUploadComplete: true,
     })).resolves.toMatchObject({
       ok: false,
       error: 'Timed out while waiting for the media upload or preview',

--- a/src/page-world/media-commands.ts
+++ b/src/page-world/media-commands.ts
@@ -12,6 +12,7 @@ export interface MediaCommandRequest {
   requireVideoAccepted?: boolean;
   requireMediaAccepted?: boolean;
   requireMediaPreview?: boolean;
+  requireUploadComplete?: boolean;
 }
 
 export interface MediaCommandResponse<Source extends string> {
@@ -29,6 +30,7 @@ export interface MediaCommandResponse<Source extends string> {
 export interface MediaUploadWaitOptions {
   requireMediaAccepted?: boolean;
   requirePreviewAccepted?: boolean;
+  requireUploadComplete?: boolean;
   isMediaPreviewVisible?: () => boolean;
   getMediaRejectionMessage?: () => string | undefined;
 }
@@ -106,7 +108,7 @@ async function handleInputCommand<Source extends string>(
     request.uploadTimeoutMs ?? 30000,
     buildWaitOptions(request, input, beforePreviewCount, requireMediaAccepted, runtime),
   );
-  const ok = waitSucceeded(wait);
+  const ok = waitSucceeded(wait, request.requireUploadComplete === true);
   return {
     source,
     id: request.id,
@@ -155,7 +157,7 @@ async function handleDropCommand<Source extends string>(
     request.uploadTimeoutMs ?? 30000,
     buildWaitOptions(request, target, beforePreviewCount, requireMediaAccepted, runtime),
   );
-  const ok = waitSucceeded(wait);
+  const ok = waitSucceeded(wait, request.requireUploadComplete === true);
   return {
     source,
     id: request.id,
@@ -187,6 +189,7 @@ function buildWaitOptions(
   return {
     requireMediaAccepted,
     requirePreviewAccepted: request.requireMediaPreview === true,
+    requireUploadComplete: request.requireUploadComplete === true,
     isMediaPreviewVisible: requireMediaAccepted
       ? runtime.mediaAcceptedPredicate(target, beforePreviewCount)
       : undefined,
@@ -196,8 +199,15 @@ function buildWaitOptions(
   };
 }
 
-function waitSucceeded(result: MediaUploadWaitResult): boolean {
-  return !result.error && (!result.timedOut || result.acceptedByPreview);
+function waitSucceeded(
+  result: MediaUploadWaitResult,
+  requireUploadComplete: boolean,
+): boolean {
+  return !result.error &&
+    (
+      !result.timedOut ||
+      (result.acceptedByPreview && !requireUploadComplete)
+    );
 }
 
 function waitError(result: MediaUploadWaitResult, ok: boolean): string | undefined {

--- a/src/page-world/media-upload-result.test.ts
+++ b/src/page-world/media-upload-result.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { extractMediaUploadFailure } from './media-upload-result';
+
+describe('extractMediaUploadFailure', () => {
+  it('extracts Tumblr daily media limits from a completed 403 response', () => {
+    expect(extractMediaUploadFailure({
+      meta: { status: 403, msg: 'Forbidden' },
+      errors: [{
+        title: 'Forbidden',
+        code: 8004,
+        detail: "You've exceeded your daily post or media limit. Please try again tomorrow.",
+      }],
+      response: [],
+    })).toBe("You've exceeded your daily post or media limit. Please try again tomorrow.");
+  });
+
+  it('does not classify successful upload payloads as failures', () => {
+    expect(extractMediaUploadFailure({
+      meta: { status: 201, msg: 'Created' },
+      message: 'Upload accepted',
+      response: [{ url: 'https://media.example/video.mp4' }],
+    })).toBeUndefined();
+  });
+
+  it('falls back to direct API error messages', () => {
+    expect(extractMediaUploadFailure({
+      status: 429,
+      error: 'Upload quota exceeded',
+    })).toBe('Upload quota exceeded');
+  });
+});

--- a/src/page-world/media-upload-result.ts
+++ b/src/page-world/media-upload-result.ts
@@ -1,0 +1,47 @@
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim()
+    ? value.trim()
+    : undefined;
+}
+
+/**
+ * SNS upload APIs often return HTTP errors as JSON while still completing the
+ * browser resource. Extract the user-actionable reason instead of treating
+ * "request finished" as "upload succeeded".
+ */
+export function extractMediaUploadFailure(payload: unknown): string | undefined {
+  const body = record(payload);
+  if (!body) return undefined;
+
+  const meta = record(body.meta);
+  const status = typeof meta?.status === 'number'
+    ? meta.status
+    : typeof body.status === 'number'
+      ? body.status
+      : undefined;
+  const errors = Array.isArray(body.errors)
+    ? body.errors.map(record).filter((entry): entry is Record<string, unknown> => !!entry)
+    : [];
+  const directError = text(body.error);
+  const directMessage = text(body.message);
+  const failed = (status !== undefined && status >= 400) ||
+    errors.length > 0 ||
+    !!directError;
+  if (!failed) return undefined;
+
+  const first = errors[0];
+  const detail = text(first?.detail) ??
+    text(first?.message) ??
+    text(first?.title) ??
+    directError ??
+    (status !== undefined && status >= 400 ? directMessage : undefined) ??
+    text(meta?.msg);
+  return detail?.slice(0, 300) ??
+    (status !== undefined ? `Media upload failed (HTTP ${status}).` : 'Media upload failed.');
+}

--- a/src/page-world/network-observer.test.ts
+++ b/src/page-world/network-observer.test.ts
@@ -57,6 +57,24 @@ describe('page-world network observer', () => {
     ));
   });
 
+  it('captures XHR payloads when the page requests responseType=json', async () => {
+    const capture = vi.fn();
+    const payload = { meta: { status: 403 }, errors: [{ detail: 'daily limit' }] };
+    const FakeXhr = createFakeJsonXhr(payload);
+    const target = createTarget(vi.fn(), FakeXhr);
+
+    installNetworkObserver(target, observerOptions(captureRule(capture)));
+    const xhr = new target.XMLHttpRequest();
+    xhr.open('POST', 'https://example.test/create');
+    xhr.send('before');
+
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledWith(
+      payload,
+      expect.objectContaining({ transport: 'xhr' }),
+      { matched: true },
+    ));
+  });
+
   it('does not wrap again for the same owner and revision', async () => {
     const originalFetch = vi.fn<typeof fetch>(
       async () => jsonResponse({ ok: true }),
@@ -158,7 +176,7 @@ function captureRule(capture: NetworkCaptureRule['capture']): NetworkCaptureRule
 
 function createTarget(
   fetchImplementation: typeof fetch,
-  XMLHttpRequestImplementation = createFakeXhr('{}'),
+  XMLHttpRequestImplementation: unknown = createFakeXhr('{}'),
 ): NetworkObserverTarget {
   return {
     fetch: fetchImplementation,
@@ -182,6 +200,28 @@ function createFakeXhr(responseText: string) {
 
     send(body?: unknown): void {
       FakeXMLHttpRequest.sendBodies.push(body);
+      for (const listener of this.listeners.get('load') ?? []) listener();
+    }
+
+    addEventListener(type: string, listener: () => void): void {
+      this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+    }
+  };
+}
+
+function createFakeJsonXhr(response: unknown) {
+  return class FakeJsonXMLHttpRequest {
+    responseType = 'json';
+    response = response;
+    private listeners = new Map<string, Array<() => void>>();
+
+    get responseText(): string {
+      throw new DOMException('InvalidStateError');
+    }
+
+    open(): void {}
+
+    send(): void {
       for (const listener of this.listeners.get('load') ?? []) listener();
     }
 

--- a/src/page-world/network-observer.ts
+++ b/src/page-world/network-observer.ts
@@ -157,7 +157,11 @@ export function installNetworkObserver(
       });
       if (prepared.captures.length > 0) {
         this.addEventListener('load', () => {
-          captureXhrResponse(options, this.responseText, prepared);
+          captureXhrResponse(
+            options,
+            this.responseType === 'json' ? this.response : this.responseText,
+            prepared,
+          );
         }, { once: true });
       }
       Reflect.apply(
@@ -229,11 +233,14 @@ function captureFetchResponse(
 
 function captureXhrResponse(
   options: InstallNetworkObserverOptions,
-  responseText: string,
+  response: unknown,
   prepared: PreparedRules,
 ): void {
   try {
-    capturePayload(options, JSON.parse(responseText) as unknown, prepared);
+    const payload = typeof response === 'string'
+      ? JSON.parse(response) as unknown
+      : response;
+    capturePayload(options, payload, prepared);
   } catch (error) {
     reportParseFailure(options, prepared.request.transport, error);
   }

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -10,7 +10,13 @@ export interface HistoryPlatformResult {
   userAction?: PostResultMessage['userAction'];
   flow?: Pick<
     NonNullable<PostResultMessage['flow']>,
-    'mode' | 'attempt' | 'lastCompletedStep' | 'failedStep' | 'submitReached'
+    | 'mode'
+    | 'attempt'
+    | 'lastCompletedStep'
+    | 'failedStep'
+    | 'submitReached'
+    | 'totalDurationMs'
+    | 'stageTimings'
   >;
   url?: string;
   error?: string;
@@ -104,6 +110,8 @@ export async function addToPostHistory(
                 lastCompletedStep: result.flow.lastCompletedStep,
                 failedStep: result.flow.failedStep,
                 submitReached: result.flow.submitReached,
+                totalDurationMs: result.flow.totalDurationMs,
+                stageTimings: result.flow.stageTimings,
               }
             : undefined,
           url: result.url,

--- a/src/utils/content-script-bootstrap.ts
+++ b/src/utils/content-script-bootstrap.ts
@@ -28,7 +28,13 @@
  * 集約済 (v0.4.77〜)。 ここでは扱わない。
  */
 
-import type { ImageAttachment, Message, PlatformId, PostResultMessage } from '../messages';
+import type {
+  ImageAttachment,
+  Message,
+  PlatformId,
+  PostImplementationPath,
+  PostResultMessage,
+} from '../messages';
 import { initLogLevelFromSettings, log } from './logger';
 import { buildDiagnosis } from './diagnose';
 import { detectAndReportUser } from './user-detect';
@@ -60,6 +66,7 @@ export interface BootstrapOptions<S extends Record<string, string>> {
     images: ImageAttachment[] | undefined,
     dryRun: boolean | undefined,
     textChunks: string[] | undefined,
+    implementationPath: PostImplementationPath | undefined,
   ) => Promise<PostResultMessage>;
   /**
    * 当 SNS 固有の追加 message handler (例: bluesky の GET_BLUESKY_SESSION)。
@@ -146,7 +153,13 @@ export function bootstrapContentScript<S extends Record<string, string>>(
           `${platform}: POST_TO_PLATFORM received ` +
           `dryRun=${msg.dryRun === true} media=${msg.images?.length ?? 0} chunks=${msg.textChunks?.length ?? 1}`,
         );
-        const result = await runPost(msg.text, msg.images, msg.dryRun, msg.textChunks);
+        const result = await runPost(
+          msg.text,
+          msg.images,
+          msg.dryRun,
+          msg.textChunks,
+          msg.implementationPath,
+        );
         sendResponse({
           ...result,
           flow: {

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -4,6 +4,7 @@ import {
   findClickableByText,
   isElementDisabled,
   normalizeElementText,
+  waitForStableCondition,
 } from './dom';
 
 function el(options: {
@@ -25,6 +26,7 @@ function el(options: {
 
 describe('DOM text helpers', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -53,5 +55,33 @@ describe('DOM text helpers', () => {
 
     expect(findClickableByText('Next')?.textContent).toBe('  Next\n');
   });
-});
 
+  it('resolves after the same event-driven candidate stays stable', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const first = {};
+    const second = {};
+    let candidate: object | null = first;
+    const waiting = waitForStableCondition(
+      () => candidate,
+      {
+        timeoutMs: 1_000,
+        quietMs: 100,
+        intervalMs: 10,
+        root: null,
+        observerInit: false,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(70);
+    candidate = second;
+    await vi.advanceTimersByTimeAsync(90);
+    let settled = false;
+    void waiting.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(waiting).resolves.toBe(second);
+  });
+});

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -31,6 +31,11 @@ export interface WaitForConditionOptions {
   observerInit?: MutationObserverInit | false;
 }
 
+export interface WaitForStableConditionOptions extends WaitForConditionOptions {
+  /** 同じ候補がこの時間維持されたら安定とみなす。 */
+  quietMs: number;
+}
+
 /**
  * 条件が成立するまで待つ。DOM変化があれば即チェックし、DOM変化が起きない
  * 状態変化(value/property/location等)も取りこぼさないよう短いintervalでも見る。
@@ -99,6 +104,79 @@ export function waitForCondition<T>(
     timer = setTimeout(() => finish(null), timeoutMs);
     check();
   });
+}
+
+/**
+ * 条件が一度成立しただけでは進まず、同じ候補が quietMs 維持された時点で返す。
+ * React / Lexical が input や wizard page を遅れて差し替えるケース向け。
+ *
+ * DOM mutation時は waitForCondition の MutationObserver callbackから即再評価し、
+ * intervalはproperty変化とquiet window満了を拾うfallbackとしてだけ使う。
+ */
+export function waitForStableCondition<T>(
+  predicate: () => T | null | undefined | false,
+  options: WaitForStableConditionOptions,
+  identity: (value: T) => unknown = (value) => value,
+): Promise<T | null> {
+  let candidateIdentity: unknown;
+  let candidateSince: number | undefined;
+
+  return waitForCondition<T>(() => {
+    const candidate = predicate();
+    if (!candidate) {
+      candidateIdentity = undefined;
+      candidateSince = undefined;
+      return null;
+    }
+
+    const nextIdentity = identity(candidate);
+    if (candidateSince === undefined || nextIdentity !== candidateIdentity) {
+      candidateIdentity = nextIdentity;
+      candidateSince = Date.now();
+      return null;
+    }
+    return Date.now() - candidateSince >= options.quietMs
+      ? candidate
+      : null;
+  }, options);
+}
+
+export function readEditableText(element: Element | null | undefined): string {
+  if (!element) return '';
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return element.value;
+  }
+  return element.textContent ?? '';
+}
+
+export function normalizedEditableText(element: Element | null | undefined): string {
+  return normalizeElementText(readEditableText(element));
+}
+
+export function waitForStableEditableText(
+  selector: string,
+  expectedText: string,
+  options: Partial<WaitForStableConditionOptions> = {},
+): Promise<HTMLElement | null> {
+  const expected = normalizeElementText(expectedText);
+  return waitForStableCondition<HTMLElement>(
+    () => {
+      const element = document.querySelector<HTMLElement>(selector);
+      return element && normalizedEditableText(element) === expected
+        ? element
+        : null;
+    },
+    {
+      timeoutMs: options.timeoutMs ?? 1_000,
+      quietMs: options.quietMs ?? 150,
+      intervalMs: options.intervalMs ?? 50,
+      root: options.root ?? document.body,
+      observerInit: options.observerInit,
+    },
+  );
 }
 
 /**

--- a/src/utils/error-report.ts
+++ b/src/utils/error-report.ts
@@ -126,6 +126,14 @@ function buildResultSummaryLines(results: readonly PostResultMessage[] | null | 
         flow?.submitReached !== undefined ? `submitReached=${flow.submitReached}` : undefined,
         flow?.lastCompletedStep ? `lastCompletedStep=${flow.lastCompletedStep}` : undefined,
         flow?.failedStep ? `failedStep=${flow.failedStep}` : undefined,
+        flow?.totalDurationMs !== undefined
+          ? `totalMs=${Math.round(flow.totalDurationMs)}`
+          : undefined,
+        flow?.stageTimings?.length
+          ? `stages=${flow.stageTimings
+              .map((timing) => `${timing.step}:${Math.round(timing.durationMs)}`)
+              .join(',')}`
+          : undefined,
       ].filter(Boolean).join(' ').replace(': success=', ': success=');
     }),
   ];

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -20,6 +20,7 @@ interface InjectRequest {
   requireVideoAccepted?: boolean;
   requireMediaAccepted?: boolean;
   requireMediaPreview?: boolean;
+  requireUploadComplete?: boolean;
 }
 
 interface InjectResponse {
@@ -86,6 +87,7 @@ export async function injectImages(
     requireVideoAccepted?: boolean;
     requireMediaAccepted?: boolean;
     requireMediaPreview?: boolean;
+    requireUploadComplete?: boolean;
     implementationPath?: PostImplementationPath;
   } = {},
 ): Promise<void> {
@@ -107,6 +109,7 @@ export async function injectImages(
     requireVideoAccepted: options.requireVideoAccepted,
     requireMediaAccepted: options.requireMediaAccepted,
     requireMediaPreview: options.requireMediaPreview,
+    requireUploadComplete: options.requireUploadComplete,
     files: images.map((img, i) => {
       if (!img.data) {
         throw new Error(
@@ -234,6 +237,7 @@ export async function dropImages(
     requireVideoAccepted?: boolean;
     requireMediaAccepted?: boolean;
     requireMediaPreview?: boolean;
+    requireUploadComplete?: boolean;
     beforeDropDelayMs?: number;
     implementationPath?: PostImplementationPath;
   } = {},
@@ -268,6 +272,7 @@ export async function dropImages(
     requireVideoAccepted: options.requireVideoAccepted,
     requireMediaAccepted: options.requireMediaAccepted,
     requireMediaPreview: options.requireMediaPreview,
+    requireUploadComplete: options.requireUploadComplete,
     files: images.map((img, i) => {
       if (!img.data) {
         throw new Error(

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,5 +1,5 @@
-import type { ImageAttachment } from '../messages';
-import { sleep, waitForElement } from './dom';
+import type { ImageAttachment, PostImplementationPath } from '../messages';
+import { sleep, waitForElement, waitForStableCondition } from './dom';
 import { t } from './i18n';
 import { log } from './logger';
 
@@ -82,7 +82,12 @@ async function sendInjectRequest(req: Omit<InjectRequest, 'source' | 'id'>): Pro
 export async function injectImages(
   rawImages: ImageAttachment[],
   fileInputSelector: string,
-  options: { requireVideoAccepted?: boolean; requireMediaAccepted?: boolean; requireMediaPreview?: boolean } = {},
+  options: {
+    requireVideoAccepted?: boolean;
+    requireMediaAccepted?: boolean;
+    requireMediaPreview?: boolean;
+    implementationPath?: PostImplementationPath;
+  } = {},
 ): Promise<void> {
   await waitForElement<HTMLInputElement>(fileInputSelector, 5000);
   const hasVideo = rawImages.some((m) => m.type.startsWith('video/'));
@@ -121,7 +126,9 @@ export async function injectImages(
   );
   // helper が in-flight = 0 + quiet 800ms を確認した直後。少し追加で
   // SNS フロントエンドの thumbnail 描画反映を待つ
-  await sleep(300);
+  if (options.implementationPath !== 'next') {
+    await sleep(300);
+  }
 }
 
 /**
@@ -172,6 +179,7 @@ export async function injectTumblrTextIntoElement(
 export async function injectTagList(
   tags: string[],
   inputSelector: string,
+  options: { implementationPath?: PostImplementationPath } = {},
 ): Promise<void> {
   await waitForElement<HTMLElement>(inputSelector, 5000);
   const result = await sendInjectRequest({
@@ -183,7 +191,9 @@ export async function injectTagList(
   if (!result.ok) {
     throw new Error(result.error ?? t('runtimeTagInjectFailed'));
   }
-  await sleep(200);
+  if (options.implementationPath !== 'next') {
+    await sleep(200);
+  }
 }
 
 export async function clickElementInMainWorld(selector: string, texts?: string[]): Promise<void> {
@@ -225,11 +235,23 @@ export async function dropImages(
     requireMediaAccepted?: boolean;
     requireMediaPreview?: boolean;
     beforeDropDelayMs?: number;
+    implementationPath?: PostImplementationPath;
   } = {},
 ): Promise<void> {
   await waitForElement<HTMLElement>(dropTargetSelector, 5000);
   if (options.beforeDropDelayMs && options.beforeDropDelayMs > 0) {
-    await sleep(options.beforeDropDelayMs);
+    if (options.implementationPath === 'next') {
+      await waitForStableCondition(
+        () => document.querySelector<HTMLElement>(dropTargetSelector),
+        {
+          timeoutMs: options.beforeDropDelayMs,
+          quietMs: 150,
+          intervalMs: 50,
+        },
+      );
+    } else {
+      await sleep(options.beforeDropDelayMs);
+    }
   }
   const hasVideo = rawImages.some((m) => m.type.startsWith('video/'));
   log.info(`media attach drop start: files=${rawImages.length} video=${hasVideo}`);
@@ -263,5 +285,7 @@ export async function dropImages(
     `media attach drop accepted: files=${result.fileCount ?? rawImages.length} ` +
     `uploads=${result.uploadCount ?? 0} preview=${result.acceptedByPreview === true}`,
   );
-  await sleep(300);
+  if (options.implementationPath !== 'next') {
+    await sleep(300);
+  }
 }

--- a/src/utils/message-decoder.test.ts
+++ b/src/utils/message-decoder.test.ts
@@ -192,6 +192,21 @@ describe('runtime message decoder', () => {
     })).toBeUndefined();
   });
 
+  it('accepts only explicit legacy or next implementation paths on content messages', () => {
+    expect(decodeMessage({
+      type: 'POST_TO_PLATFORM',
+      platform: 'x',
+      text: 'sample',
+      implementationPath: 'next',
+    })).toMatchObject({ implementationPath: 'next' });
+    expect(decodeMessage({
+      type: 'POST_TO_PLATFORM',
+      platform: 'x',
+      text: 'sample',
+      implementationPath: 'future',
+    })).toBeUndefined();
+  });
+
   it.each([
     null,
     [],

--- a/src/utils/message-decoder.ts
+++ b/src/utils/message-decoder.ts
@@ -48,6 +48,11 @@ const MESSAGE_VALIDATORS = {
   POST_TO_PLATFORM: (value) =>
     isPlatformId(value.platform) &&
     isString(value.text) &&
+    optional(
+      value,
+      'implementationPath',
+      (item) => item === 'legacy' || item === 'next',
+    ) &&
     optional(value, 'textChunks', isStringArray) &&
     optional(value, 'images', isAttachmentArray) &&
     optional(value, 'dryRun', isBoolean) &&

--- a/src/utils/message-decoder.ts
+++ b/src/utils/message-decoder.ts
@@ -186,7 +186,22 @@ function isPostFlowTrace(value: unknown): boolean {
     optional(value, 'submissionStartedAt', isFiniteNumber) &&
     optional(value, 'tabUrlBefore', isString) &&
     optional(value, 'tabUrlAfter', isString) &&
-    optional(value, 'urlCaptureTrace', isStringArray);
+    optional(value, 'urlCaptureTrace', isStringArray) &&
+    optional(value, 'totalDurationMs', isFiniteNumber) &&
+    optional(value, 'stageTimings', (item) => (
+      Array.isArray(item) && item.every(isPostStageTiming)
+    ));
+}
+
+function isPostStageTiming(value: unknown): boolean {
+  return isRecord(value) &&
+    isString(value.step) &&
+    isFiniteNumber(value.durationMs) &&
+    optional(
+      value,
+      'outcome',
+      (item) => item === 'completed' || item === 'failed',
+    );
 }
 
 function isSubmissionGuardTrace(value: unknown): boolean {

--- a/src/utils/message-wire-contract.test.ts
+++ b/src/utils/message-wire-contract.test.ts
@@ -86,6 +86,7 @@ describe('additive message wire fixtures', () => {
       ]),
       true,
       undefined,
+      undefined,
     );
     expect(response).toMatchObject({
       type: 'POST_RESULT',
@@ -101,6 +102,26 @@ describe('additive message wire fixtures', () => {
         futureFlowField: 'preserve-me',
       },
     });
+  });
+
+  it('forwards the selected implementation path to the content posting flow', async () => {
+    const runPost = vi.fn(async () => postResultFixture as unknown as PostResultMessage);
+    const listener = installContentBootstrap(runPost);
+
+    await new Promise<unknown>((resolve) => {
+      expect(listener({
+        ...postToPlatformFixture,
+        implementationPath: 'next',
+      }, {}, resolve)).toBe(true);
+    });
+
+    expect(runPost).toHaveBeenCalledWith(
+      'additive contract',
+      expect.any(Array),
+      true,
+      undefined,
+      'next',
+    );
   });
 
   it('ignores an unknown message type without invoking the post handler', () => {

--- a/src/utils/post-flow.test.ts
+++ b/src/utils/post-flow.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { executePostFlow, maybeConfirmDialog, resolvePostButtonTimeoutMs } from './post-flow';
+import * as imageUtils from './image';
 
 describe('maybeConfirmDialog', () => {
   afterEach(() => {
@@ -186,6 +187,47 @@ describe('executePostFlow', () => {
       composeInputTimeoutMs: 10,
       postButtonTimeoutMs: 10,
     })).rejects.toThrow('投稿入力欄が見つかりません');
+  });
+
+  it('forwards strict upload completion to the media injector', async () => {
+    const editor = { tagName: 'DIV' } as HTMLElement;
+    const button = {
+      style: {},
+      getAttribute: vi.fn(() => null),
+      disabled: false,
+    } as unknown as HTMLElement;
+    const injectImages = vi.spyOn(imageUtils, 'injectImages').mockResolvedValue();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.stubGlobal('document', {
+      body: {},
+      querySelector: vi.fn((selector: string) => selector === 'textarea' ? editor : button),
+      querySelectorAll: vi.fn(() => []),
+    });
+
+    await expect(executePostFlow({
+      prefillsViaUrl: true,
+      textareaSelector: 'textarea',
+      postButtonSelector: '.post',
+      fileInputSelector: 'input[type="file"]',
+      text: '',
+      images: [{ name: 'video.mp4', type: 'video/mp4', data: 'AAAA' }],
+      requireMediaAccepted: true,
+      requireMediaPreview: true,
+      requireUploadComplete: true,
+      dryRun: true,
+      composeInputTimeoutMs: 10,
+      postButtonTimeoutMs: 10,
+    })).resolves.toBeUndefined();
+
+    expect(injectImages).toHaveBeenCalledWith(
+      expect.any(Array),
+      'input[type="file"]',
+      expect.objectContaining({
+        requireMediaAccepted: true,
+        requireMediaPreview: true,
+        requireUploadComplete: true,
+      }),
+    );
   });
 
   it('allows a disabled post button only for explicit media preview dry-runs', async () => {

--- a/src/utils/post-flow.ts
+++ b/src/utils/post-flow.ts
@@ -79,6 +79,8 @@ export interface PostFlowOptions {
   requireMediaAccepted?: boolean;
   /** compose preview が出るまで media 注入成功扱いにしない */
   requireMediaPreview?: boolean;
+  /** compose previewだけで進まず、実際のupload request完了を必須にする */
+  requireUploadComplete?: boolean;
   /** drag/drop 型の添付で、drop target 出現後に待つ時間(ms) */
   beforeDropDelayMs?: number;
   /**
@@ -122,6 +124,7 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
     clickPostButton,
     requireMediaAccepted,
     requireMediaPreview,
+    requireUploadComplete,
     beforeDropDelayMs,
     allowDisabledPostButtonInPreview,
     mediaAttachOrder,
@@ -178,6 +181,7 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
       dropTargetSelector,
       requireMediaAccepted,
       requireMediaPreview,
+      requireUploadComplete,
       beforeDropDelayMs,
       mediaAttachOrder,
       implementationPath,
@@ -294,6 +298,7 @@ async function attachMedia(
     'dropTargetSelector' |
     'requireMediaAccepted' |
     'requireMediaPreview' |
+    'requireUploadComplete' |
     'beforeDropDelayMs' |
     'mediaAttachOrder' |
     'implementationPath'
@@ -311,6 +316,7 @@ async function attachMedia(
         await injectImages(images, options.fileInputSelector, {
           requireMediaAccepted: options.requireMediaAccepted,
           requireMediaPreview: options.requireMediaPreview,
+          requireUploadComplete: options.requireUploadComplete,
           implementationPath: options.implementationPath,
         });
         return;
@@ -319,6 +325,7 @@ async function attachMedia(
         await dropImages(images, options.dropTargetSelector, {
           requireMediaAccepted: options.requireMediaAccepted,
           requireMediaPreview: options.requireMediaPreview,
+          requireUploadComplete: options.requireUploadComplete,
           beforeDropDelayMs: options.beforeDropDelayMs,
           implementationPath: options.implementationPath,
         });

--- a/src/utils/post-flow.ts
+++ b/src/utils/post-flow.ts
@@ -1,8 +1,10 @@
 import type { ImageAttachment } from '../messages';
+import type { PostImplementationPath } from '../messages';
 import {
   sleep,
   waitForCondition,
   waitForElement,
+  waitForStableEditableText,
 } from './dom';
 import {
   collectConfirmDialogs,
@@ -89,6 +91,8 @@ export interface PostFlowOptions {
    * drop target first when present, otherwise file input.
    */
   mediaAttachOrder?: ('input' | 'drop')[];
+  /** 欠落時は配布済みlegacyの固定待機を維持する。 */
+  implementationPath?: PostImplementationPath;
 }
 
 /**
@@ -121,6 +125,7 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
     beforeDropDelayMs,
     allowDisabledPostButtonInPreview,
     mediaAttachOrder,
+    implementationPath,
   } = options;
   if (!postButtonSelector && !postButtonTexts?.length && !postButtonFinder) {
     throw new Error('postButtonSelector, postButtonTexts, or postButtonFinder is required');
@@ -143,7 +148,15 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
     if (text) {
       markPostStepStarted('inject-text');
       await textInjector(text, injectSelector);
-      await sleep(300);
+      if (implementationPath === 'next') {
+        await waitForStableEditableText(injectSelector, text, {
+          timeoutMs: 300,
+          quietMs: 75,
+          intervalMs: 25,
+        });
+      } else {
+        await sleep(300);
+      }
       markPostStepCompleted('inject-text');
       markPostStepCompleted('verify-text');
     }
@@ -167,6 +180,7 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
       requireMediaPreview,
       beforeDropDelayMs,
       mediaAttachOrder,
+      implementationPath,
     });
     markPostStepCompleted('attach-media');
     markPostStepCompleted('verify-media');
@@ -269,7 +283,7 @@ export async function executePostFlow(options: PostFlowOptions): Promise<void> {
       excludedButtons: [button],
       composeInputSelector: textareaSelector,
     },
-    afterClickDelayMs,
+    afterClickDelayMs: implementationPath === 'next' ? 0 : afterClickDelayMs,
   });
 }
 
@@ -281,7 +295,8 @@ async function attachMedia(
     'requireMediaAccepted' |
     'requireMediaPreview' |
     'beforeDropDelayMs' |
-    'mediaAttachOrder'
+    'mediaAttachOrder' |
+    'implementationPath'
   >,
 ): Promise<void> {
   const defaultOrder: ('input' | 'drop')[] = options.dropTargetSelector
@@ -296,6 +311,7 @@ async function attachMedia(
         await injectImages(images, options.fileInputSelector, {
           requireMediaAccepted: options.requireMediaAccepted,
           requireMediaPreview: options.requireMediaPreview,
+          implementationPath: options.implementationPath,
         });
         return;
       }
@@ -304,6 +320,7 @@ async function attachMedia(
           requireMediaAccepted: options.requireMediaAccepted,
           requireMediaPreview: options.requireMediaPreview,
           beforeDropDelayMs: options.beforeDropDelayMs,
+          implementationPath: options.implementationPath,
         });
         return;
       }

--- a/src/utils/post-submission-state.test.ts
+++ b/src/utils/post-submission-state.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getPostSubmissionStartedAt,
   hasPostSubmissionStarted,
@@ -11,7 +11,13 @@ import {
 } from './post-submission-state';
 
 describe('post submission state', () => {
-  beforeEach(() => resetPostSubmissionState());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    resetPostSubmissionState();
+  });
+
+  afterEach(() => vi.useRealTimers());
 
   it('starts clear', () => {
     expect(hasPostSubmissionStarted()).toBe(false);
@@ -37,6 +43,8 @@ describe('post submission state', () => {
       submissionStartedAt: undefined,
       lastCompletedStep: undefined,
       failedStep: undefined,
+      totalDurationMs: 0,
+      stageTimings: [],
     });
   });
 
@@ -52,6 +60,23 @@ describe('post submission state', () => {
     expect(getPostSubmissionTrace()).toMatchObject({
       lastCompletedStep: 'attach-media',
       failedStep: 'attach-media',
+    });
+  });
+
+  it('records completed and failed stage durations without content data', () => {
+    markPostStepStarted('inject-text');
+    vi.setSystemTime(1_125);
+    markPostStepCompleted('inject-text');
+    markPostStepStarted('attach-media');
+    vi.setSystemTime(1_400);
+    markPostStepFailed();
+
+    expect(getPostSubmissionTrace()).toMatchObject({
+      totalDurationMs: 400,
+      stageTimings: [
+        { step: 'inject-text', durationMs: 125, outcome: 'completed' },
+        { step: 'attach-media', durationMs: 275, outcome: 'failed' },
+      ],
     });
   });
 });

--- a/src/utils/post-submission-state.ts
+++ b/src/utils/post-submission-state.ts
@@ -1,17 +1,29 @@
-import type { PostFlowStep, PostFlowTrace } from '../messages';
+import type {
+  PostFlowStep,
+  PostFlowTrace,
+  PostStageTiming,
+} from '../messages';
 
 let submissionStarted = false;
 let submissionStartedAt: number | undefined;
 let currentStep: PostFlowStep | undefined;
+let currentStepStartedAt: number | undefined;
 let lastCompletedStep: PostFlowStep | undefined;
 let failedStep: PostFlowStep | undefined;
+let flowStartedAt = 0;
+let stageTimings: PostStageTiming[] = [];
+
+const MAX_STAGE_TIMINGS = 64;
 
 export function resetPostSubmissionState(): void {
   submissionStarted = false;
   submissionStartedAt = undefined;
   currentStep = undefined;
+  currentStepStartedAt = undefined;
   lastCompletedStep = undefined;
   failedStep = undefined;
+  flowStartedAt = Date.now();
+  stageTimings = [];
 }
 
 export function markPostSubmissionStarted(startedAt = Date.now()): void {
@@ -29,24 +41,71 @@ export function getPostSubmissionStartedAt(): number | undefined {
 }
 
 export function markPostStepStarted(step: PostFlowStep): void {
+  if (currentStep && currentStepStartedAt !== undefined) {
+    recordStageTiming(currentStep, currentStepStartedAt, 'failed');
+  }
   currentStep = step;
+  currentStepStartedAt = Date.now();
 }
 
 export function markPostStepCompleted(step: PostFlowStep): void {
+  if (currentStep === step && currentStepStartedAt !== undefined) {
+    recordStageTiming(step, currentStepStartedAt, 'completed');
+  }
   lastCompletedStep = step;
-  if (currentStep === step) currentStep = undefined;
+  if (currentStep === step) {
+    currentStep = undefined;
+    currentStepStartedAt = undefined;
+  }
 }
 
 export function markPostStepFailed(step?: PostFlowStep): void {
-  failedStep = step ?? currentStep ?? failedStep;
+  const resolvedStep = step ?? currentStep ?? failedStep;
+  failedStep = resolvedStep;
+  if (
+    resolvedStep &&
+    currentStep === resolvedStep &&
+    currentStepStartedAt !== undefined
+  ) {
+    recordStageTiming(resolvedStep, currentStepStartedAt, 'failed');
+    currentStep = undefined;
+    currentStepStartedAt = undefined;
+  }
 }
 
 export function getPostSubmissionTrace(overrides: Partial<PostFlowTrace> = {}): PostFlowTrace {
+  const now = Date.now();
+  const pendingTiming = currentStep && currentStepStartedAt !== undefined
+    ? [{
+        step: currentStep,
+        durationMs: normalizeDuration(now - currentStepStartedAt),
+        outcome: 'failed' as const,
+      }]
+    : [];
   return {
     submitReached: submissionStarted,
     submissionStartedAt,
     lastCompletedStep,
     failedStep: failedStep ?? currentStep,
+    totalDurationMs: normalizeDuration(now - flowStartedAt),
+    stageTimings: [...stageTimings, ...pendingTiming],
     ...overrides,
   };
+}
+
+function recordStageTiming(
+  step: PostFlowStep,
+  startedAt: number,
+  outcome: PostStageTiming['outcome'],
+): void {
+  if (stageTimings.length >= MAX_STAGE_TIMINGS) return;
+  stageTimings.push({
+    step,
+    durationMs: normalizeDuration(Date.now() - startedAt),
+    outcome,
+  });
+}
+
+function normalizeDuration(durationMs: number): number {
+  return Math.max(0, Math.round(durationMs));
 }

--- a/src/utils/post-verify-og.ts
+++ b/src/utils/post-verify-og.ts
@@ -25,6 +25,8 @@ export type DescriptionCleaner = (desc: string, html?: string) => string;
 
 /** og:image を「実際の post 画像か placeholder か」 を識別する optional filter */
 export type ImageJudge = (ogImage: string, html?: string) => boolean;
+/** platform固有の公開HTMLから動画実体を識別する optional filter */
+export type VideoJudge = (html: string, postUrl: string) => boolean;
 
 /**
  * MV3 SW では DOMParser が無いので regex で og:* meta tag を抽出する。
@@ -75,6 +77,8 @@ export interface VerifyViaOgOptions {
   cleanDescription?: DescriptionCleaner;
   /** og:image が「実 post image」 か判定。 default: og:image が存在すれば true */
   judgeImage?: ImageJudge;
+  /** 動画evidenceのplatform固有判定。defaultは標準OG/video要素。 */
+  judgeVideo?: VideoJudge;
   /** fetch UA を override (X 等 default UA が block されるとき) */
   userAgent?: string;
   /** fetch timeout (ms)、 default 15000 */
@@ -86,7 +90,13 @@ export async function verifyViaOg(
   expected: VerifyExpectation,
   options: VerifyViaOgOptions = {},
 ): Promise<VerifyResult> {
-  const { cleanDescription, judgeImage, userAgent, timeoutMs = 15000 } = options;
+  const {
+    cleanDescription,
+    judgeImage,
+    judgeVideo,
+    userAgent,
+    timeoutMs = 15000,
+  } = options;
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -110,7 +120,9 @@ export async function verifyViaOg(
 
     const text = cleanDescription ? cleanDescription(ogDesc, html) : ogDesc;
     const hasImages = judgeImage ? judgeImage(ogImage, html) : !!ogImage;
-    const hasVideo = expected.hasVideo ? hasVideoEvidenceInHtml(html) : undefined;
+    const hasVideo = expected.hasVideo
+      ? (judgeVideo ? judgeVideo(html, postUrl) : hasVideoEvidenceInHtml(html))
+      : undefined;
 
     return buildVerifyResult(expected, {
       text,
@@ -184,6 +196,14 @@ export const judgeXImage: ImageJudge = (ogImage) => {
   if (!ogImage) return true; // 判定不能なので false positive を出さない
   return /pbs\.twimg\.com\/media\//i.test(ogImage);
 };
+
+export const judgeTikTokVideo: VideoJudge = (html, postUrl) => (
+  hasVideoEvidenceInHtml(html) ||
+  (
+    /^https:\/\/(?:www\.)?tiktok\.com\/@[^/]+\/video\/\d+/i.test(postUrl) &&
+    /"(?:playAddr|PlayAddrStruct|videoID)"\s*:/i.test(html)
+  )
+);
 
 /**
  * YouTube: og:description は description text の冒頭 (snippet)。

--- a/src/utils/reply-compose.test.ts
+++ b/src/utils/reply-compose.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   findReplyButton,
   isPlatformPostDetailUrl,
+  openReplyComposerIfOnPostPage,
   parseMastodonStatusIdFromUrl,
 } from './reply-compose';
 
@@ -15,6 +16,12 @@ function markVisible(el: HTMLElement): void {
 }
 
 describe('reply compose helpers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+    history.replaceState({}, '', '/');
+  });
+
   it('detects Mastodon and Threads post detail URLs', () => {
     expect(isPlatformPostDetailUrl('mastodon', 'https://mastodon.social/@alice/1234567890')).toBe(true);
     expect(isPlatformPostDetailUrl('mastodon', 'https://mastodon.social/share?text=hello')).toBe(false);
@@ -46,5 +53,24 @@ describe('reply compose helpers', () => {
     document.querySelectorAll<HTMLElement>('button').forEach(markVisible);
 
     expect(findReplyButton('mastodon')?.getAttribute('aria-label')).toBe('返信');
+  });
+
+  it('next waits directly for the reply editor without the legacy fixed delay', async () => {
+    vi.useFakeTimers();
+    history.replaceState({}, '', '/@alice/1234567890');
+    document.body.innerHTML = '<button aria-label="Reply"></button>';
+    const button = document.querySelector<HTMLButtonElement>('button')!;
+    markVisible(button);
+    button.addEventListener('click', () => {
+      const textarea = document.createElement('textarea');
+      textarea.className = 'reply-editor';
+      document.body.appendChild(textarea);
+    });
+
+    await expect(openReplyComposerIfOnPostPage(
+      'mastodon',
+      '.reply-editor',
+      { implementationPath: 'next' },
+    )).resolves.toBe(true);
   });
 });

--- a/src/utils/reply-compose.ts
+++ b/src/utils/reply-compose.ts
@@ -1,4 +1,5 @@
 import type { PlatformId } from '../types/platform';
+import type { PostImplementationPath } from '../messages';
 import {
   elementTextMatches,
   isElementDisabled,
@@ -32,6 +33,7 @@ export async function openReplyComposerIfOnPostPage(
   options: {
     timeoutMs?: number;
     clickInMainWorld?: boolean;
+    implementationPath?: PostImplementationPath;
   } = {},
 ): Promise<boolean> {
   if (!isPlatformPostDetailUrl(platform, location.href)) return false;
@@ -57,7 +59,9 @@ export async function openReplyComposerIfOnPostPage(
     button.click();
   }
 
-  await sleep(300);
+  if (options.implementationPath !== 'next') {
+    await sleep(300);
+  }
   const composeInput = await waitForCondition<HTMLElement>(
     () => document.querySelector<HTMLElement>(textareaSelector),
     { timeoutMs, intervalMs: 250 },

--- a/src/utils/step-runner.test.ts
+++ b/src/utils/step-runner.test.ts
@@ -73,6 +73,82 @@ describe('executeMultiStepFlow', () => {
     expect(log).toContain('finalize.click');
   });
 
+  it('next は固定 settle の代わりに明示された完了条件を順番に待つ', async () => {
+    const log: string[] = [];
+    const steps: Step[] = [
+      {
+        name: 'event-driven',
+        action: async () => { log.push('action'); },
+        settleMs: 60_000,
+        waitAfterAction: async () => { log.push('action.ready'); },
+        advance: { finder: () => makeMockButton('advance', log) },
+        waitAfterAdvance: async () => { log.push('next.ready'); },
+      },
+    ];
+
+    await executeMultiStepFlow({
+      steps,
+      finalize: {
+        finder: () => makeMockButton('finalize', log),
+        afterClickDelayMs: 60_000,
+      },
+      implementationPath: 'next',
+    });
+
+    expect(log).toEqual([
+      'action',
+      'action.ready',
+      'advance.click',
+      'next.ready',
+      'finalize.click',
+    ]);
+  });
+
+  it('legacy は next 用完了条件を呼ばず従来の settle 経路を維持する', async () => {
+    const log: string[] = [];
+    const steps: Step[] = [
+      {
+        name: 'legacy',
+        action: async () => { log.push('action'); },
+        settleMs: 0,
+        waitAfterAction: async () => { log.push('action.ready'); },
+        advance: { finder: () => makeMockButton('advance', log) },
+        waitAfterAdvance: async () => { log.push('next.ready'); },
+      },
+    ];
+
+    await executeMultiStepFlow({
+      steps,
+      finalize: {
+        finder: () => makeMockButton('finalize', log),
+        afterClickDelayMs: 0,
+      },
+    });
+
+    expect(log).toEqual([
+      'action',
+      'advance.click',
+      'finalize.click',
+    ]);
+  });
+
+  it('next の完了条件エラーは step.name を含めて throw', async () => {
+    await expect(
+      executeMultiStepFlow({
+        steps: [
+          {
+            name: 'await-editor',
+            action: async () => {},
+            settleMs: 0,
+            waitAfterAction: async () => { throw new Error('editor unstable'); },
+          },
+        ],
+        finalize: { finder: () => null },
+        implementationPath: 'next',
+      }),
+    ).rejects.toThrow(/await-editor/);
+  });
+
   it('step.action のエラーは step.name を含めて throw', async () => {
     await expect(
       executeMultiStepFlow({

--- a/src/utils/step-runner.ts
+++ b/src/utils/step-runner.ts
@@ -29,6 +29,7 @@
  *   - 単体テストは「dry-run で全 step が走り finalize は click されない」を最低限カバー。
  */
 import { sleep, waitForCondition, waitForElement } from './dom';
+import type { PostImplementationPath } from '../messages';
 import {
   finalizeFlow,
   findFlowButton,
@@ -58,6 +59,11 @@ export interface Step {
   /** action 完了後の DOM settle 待機 (default 300ms)。React の state 反映を待つ */
   settleMs?: number;
   /**
+   * next経路のaction完了条件。指定時は固定settleMsの代わりにこのPromiseを待つ。
+   * 即完了を保証できるactionは `async () => {}` を指定できる。
+   */
+  waitAfterAction?: () => Promise<void>;
+  /**
    * 次のページへ進むボタン。selector / texts / finder のどれか必須。
    * 最終 step は省略 (省略 = MultiStepFlowOptions.finalize に委譲)。
    */
@@ -70,6 +76,8 @@ export interface Step {
     selector: string;
     timeoutMs?: number;
   };
+  /** next経路の画面遷移完了条件。awaitNextDomより具体的な状態判定に使う。 */
+  waitAfterAdvance?: () => Promise<void>;
 }
 
 export interface AdvanceSpec {
@@ -104,6 +112,8 @@ export interface MultiStepFlowOptions {
   finalize: FinalizeSpec;
   /** dry-run: 全 step は実行するが finalize.click は行わない */
   dryRun?: boolean;
+  /** 欠落時は配布済みlegacyの固定待機を維持する。 */
+  implementationPath?: PostImplementationPath;
 }
 
 /**
@@ -124,7 +134,12 @@ export interface MultiStepFlowOptions {
  * (executePostFlow と同じ挙動)。
  */
 export async function executeMultiStepFlow(options: MultiStepFlowOptions): Promise<void> {
-  const { steps, finalize, dryRun = false } = options;
+  const {
+    steps,
+    finalize,
+    dryRun = false,
+    implementationPath,
+  } = options;
   if (steps.length === 0) {
     throw new Error('executeMultiStepFlow: steps must not be empty');
   }
@@ -138,7 +153,17 @@ export async function executeMultiStepFlow(options: MultiStepFlowOptions): Promi
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(t('runtimeStepActionFailed', step.name, msg));
     }
-    await sleep(step.settleMs ?? 300);
+    try {
+      if (implementationPath === 'next' && step.waitAfterAction) {
+        await step.waitAfterAction();
+      } else {
+        await sleep(step.settleMs ?? 300);
+      }
+    } catch (err) {
+      markPostStepFailed(step.name);
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(t('runtimeStepActionFailed', step.name, msg));
+    }
     markPostStepCompleted(step.name);
 
     if (!step.advance) continue;
@@ -159,7 +184,17 @@ export async function executeMultiStepFlow(options: MultiStepFlowOptions): Promi
     advanceBtn.click();
     markPostStepCompleted(`${step.name}:advance`);
 
-    if (step.awaitNextDom) {
+    if (implementationPath === 'next' && step.waitAfterAdvance) {
+      markPostStepStarted(`${step.name}:await-next`);
+      try {
+        await step.waitAfterAdvance();
+      } catch (err) {
+        markPostStepFailed(`${step.name}:await-next`);
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(t('runtimeStepActionFailed', `${step.name}:await-next`, msg));
+      }
+      markPostStepCompleted(`${step.name}:await-next`);
+    } else if (step.awaitNextDom) {
       markPostStepStarted(`${step.name}:await-next`);
       const next = await waitForElement<HTMLElement>(
         step.awaitNextDom.selector,
@@ -200,7 +235,9 @@ export async function executeMultiStepFlow(options: MultiStepFlowOptions): Promi
     button: finalizeBtn,
     confirmDialogButtonTexts: finalize.confirmDialogButtonTexts,
     confirmDialogGraceMs: finalize.confirmDialogGraceMs,
-    afterClickDelayMs: finalize.afterClickDelayMs,
+    afterClickDelayMs: implementationPath === 'next'
+      ? 0
+      : finalize.afterClickDelayMs,
   });
 }
 


### PR DESCRIPTION
Parent: #12
Release PR: #149

## Summary

- add per-stage timing for the next posting path
- replace fixed sleeps with readiness/event-driven waits while leaving the complete legacy controller unchanged
- publish Bluesky threads through one AT Protocol session with root/parent chaining and media on the root
- split next posting into API, background-tab, and foreground lanes
- verify TikTok hydrated video evidence correctly
- reject failed media uploads before submit; Tumblr video now stops on HTTP 403 instead of creating a text-only post
- keep Surface Brave alive across repeated CDP matrix runs

## Verification

- `npm test`: 116 files / 861 tests PASS
- `npm run architecture:check`: 17 files / 115 tests PASS; scripts catalog 252 PASS
- `npm run compile`: PASS
- `npm run build`: PASS
- exact extension version: 0.5.50
- exact Surface ZIP SHA-256: `DDF5E29D785E3EF747098DBCA453C9D9BE31E0B93E1B620BA16F01E7E3F0816C`
- Surface preview, next path, quota-free platforms: 20 runs / 134 supported platform results PASS, `submitReached=true` count 0
- Surface real inactive/background posts PASS: X, Bluesky, Mastodon, Misskey
- Surface minimized Brave X real post PASS: https://x.com/ren_fujimoto/status/2082157180212629950
- Surface X long thread + image: one `Post all`, no per-post submit, PASS: https://x.com/ren_fujimoto/status/2082157011752686007
- Surface Bluesky API 3-post thread + root image PASS: https://bsky.app/profile/ren-fujimoto89.bsky.social/post/3mrpwppxhf62e
- Surface foreground image posts PASS: Threads, Tumblr, Pixiv, DeviantArt, Instagram
- Surface Threads / Instagram real video posts PASS with public visible video
- Surface TikTok exact-artifact real video PASS, visible video count 2: https://www.tiktok.com/@ren.fujimoto4/video/7667641946600508693
- Surface YouTube daily limit detection PASS as expected: explicit `Daily Upload Limit Reached`, `submitReached=false`
- Surface Tumblr daily media limit safety PASS as expected: HTTP 403 detected at `attach-media`, `submitReached=false`; no text-only post

## Release status

No CWS upload or submission. Published version remains 0.5.49. PR #149 must remain draft until the YouTube quota resets and its exact-artifact real upload gate passes.