### PR TITLE
release: bump version to 0.5.51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tutti",
-  "version": "0.5.50",
+  "version": "0.5.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tutti",
-      "version": "0.5.50",
+      "version": "0.5.51",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tutti",
-  "version": "0.5.50",
+  "version": "0.5.51",
   "description": "クロスポストの面倒を全部肩代わりする Chrome 拡張",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

- bump the Chrome extension version from 0.5.50 to 0.5.51 for the X posting-window fix in #156
- preserve the exact code already verified on Surface before the version-only release rebuild

## Verification

- npm run verify:commit
- scripts catalog: 252
- architecture: 117 tests
- unit/integration: 898 tests
- compile and production build: PASS

The merged 0.5.51 artifact will be rebuilt and must pass the exact-artifact Surface gate before CWS upload.