### PR TITLE
test(surface): scope X preview draft detection

### DIFF
--- a/scripts/e2e/surface-posting-matrix-contract.d.mts
+++ b/scripts/e2e/surface-posting-matrix-contract.d.mts
@@ -15,6 +15,20 @@ export function hasSurfaceVideoPreview(mediaState?: {
   progress?: Array<{ ariaValueNow?: string | null }>;
 }): boolean;
 
+export interface SurfacePreviewDraftCandidate {
+  text?: string;
+  hasVideoAttachment?: boolean;
+  [key: string]: unknown;
+}
+
+export function normalizePreviewDraftText(text: unknown): string;
+
+export function findExactPreviewDraftCandidate<T extends SurfacePreviewDraftCandidate>(
+  candidates: readonly T[],
+  expectedText: string,
+  options?: { requireVideoAttachment?: boolean },
+): T | undefined;
+
 export function validateSurfaceResultContract(input: {
   mode: 'preview' | 'post';
   caseName: string;

--- a/scripts/e2e/surface-posting-matrix-contract.mjs
+++ b/scripts/e2e/surface-posting-matrix-contract.mjs
@@ -26,6 +26,22 @@ export function hasSurfaceVideoPreview(mediaState) {
     );
 }
 
+export function normalizePreviewDraftText(text) {
+  return typeof text === 'string' ? text.trim() : '';
+}
+
+export function findExactPreviewDraftCandidate(
+  candidates,
+  expectedText,
+  { requireVideoAttachment = false } = {},
+) {
+  const normalizedExpected = normalizePreviewDraftText(expectedText);
+  return candidates.find((candidate) => (
+    normalizePreviewDraftText(candidate?.text) === normalizedExpected &&
+    (!requireVideoAttachment || candidate?.hasVideoAttachment === true)
+  ));
+}
+
 export function validateSurfaceResultContract({
   mode,
   caseName,

--- a/scripts/e2e/surface-posting-matrix.mjs
+++ b/scripts/e2e/surface-posting-matrix.mjs
@@ -37,8 +37,10 @@ import {
 } from './cdp-harness.mjs';
 import {
   createTimedOutSurfaceSummary,
+  findExactPreviewDraftCandidate,
   formatSurfaceMatrixOutcome,
   hasSurfaceVideoPreview,
+  normalizePreviewDraftText,
   validateSurfaceResultContract,
 } from './surface-posting-matrix-contract.mjs';
 
@@ -78,7 +80,6 @@ const PREVIEW_DRAFT_READERS = {
     selector:
       '[data-testid="tweetTextarea_0"][role="textbox"],' +
       '[data-testid="tweetTextarea_0"][contenteditable="true"]',
-    requireVideoAttachment: true,
   },
   threads: {
     pageUrl: /^https:\/\/(?:www\.)?threads\.(?:com|net)\//,
@@ -144,6 +145,7 @@ const CASES = {
     verifyPostingWindowPlatform: 'x',
     postingWindowFocusPolicy: 'foreground-video',
     verifyPreviewDraftText: true,
+    requirePreviewVideoAttachment: true,
   },
   'image-video': {
     requires: ['shortVideo'],
@@ -457,10 +459,12 @@ for (const caseName of requestedCases) {
       if (!result?.success) continue;
       if (mode === 'preview') {
         if (caseDef.verifyPreviewDraftText && PREVIEW_DRAFT_READERS[platform]) {
-          const draft = await waitForPreviewDraftText(ctx, platform, text);
+          const draft = await waitForPreviewDraftText(ctx, platform, text, {
+            requireVideoAttachment: caseDef.requirePreviewVideoAttachment === true,
+          });
           if (!draft.found) {
             failures.push(`${caseName}/${platform}: preview draft editor was not found`);
-          } else if (draft.text !== text) {
+          } else if (draft.text !== normalizePreviewDraftText(text)) {
             failures.push(
               `${caseName}/${platform}: preview draft text mismatch ` +
               `(expected=${JSON.stringify(text)}, actual=${JSON.stringify(draft.text)}, ` +
@@ -613,7 +617,18 @@ async function readPreviewDraftText(ctx, platform) {
         return readText(state.root ?? state);
       }).catch(() => '');
       const hasVideoAttachment = await draft.evaluate((element) => {
-        const root = element.closest('[role="dialog"]') ?? element.closest('main') ?? document.body;
+        let root = element.closest('[role="dialog"]');
+        let current = element.parentElement;
+        while (!root && current && current !== document.body) {
+          if (current.querySelector(
+            '[data-testid="tweetButton"], [data-testid="tweetButtonInline"]',
+          )) {
+            root = current;
+            break;
+          }
+          current = current.parentElement;
+        }
+        root ??= element.parentElement ?? element;
         return root.querySelector('video, [data-testid="attachments"]') !== null;
       }).catch(() => false);
       candidates.push({
@@ -640,26 +655,32 @@ async function readPreviewDraftText(ctx, platform) {
   };
 }
 
-async function waitForPreviewDraftText(ctx, platform, expectedText, timeoutMs = 5000) {
+async function waitForPreviewDraftText(
+  ctx,
+  platform,
+  expectedText,
+  { requireVideoAttachment = false, timeoutMs = 5000 } = {},
+) {
   const deadline = Date.now() + timeoutMs;
   let last = { found: false };
   do {
     last = await readPreviewDraftText(ctx, platform);
-    const reader = PREVIEW_DRAFT_READERS[platform];
-    const exact = last.candidates?.find((candidate) => (
-      candidate.text === expectedText &&
-      (reader?.requireVideoAttachment !== true || candidate.hasVideoAttachment === true)
-    ));
+    const exact = findExactPreviewDraftCandidate(last.candidates ?? [], expectedText, {
+      requireVideoAttachment,
+    });
     if (exact) {
       return {
         ...last,
-        text: exact.text,
+        text: normalizePreviewDraftText(exact.text),
         url: exact.pageUrl,
       };
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
   } while (Date.now() < deadline);
-  return last;
+  return {
+    ...last,
+    text: normalizePreviewDraftText(last.text),
+  };
 }
 
 function supportsCase(platform, caseDef) {

--- a/tests/surface-posting-matrix-contract.test.ts
+++ b/tests/surface-posting-matrix-contract.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   createTimedOutSurfaceSummary,
+  findExactPreviewDraftCandidate,
   formatSurfaceMatrixOutcome,
   hasSurfaceVideoPreview,
+  normalizePreviewDraftText,
   validateSurfaceResultContract,
 } from '../scripts/e2e/surface-posting-matrix-contract.mjs';
 
@@ -18,6 +20,31 @@ describe('Surface posting matrix CLI contract', () => {
       attachmentContainerCount: 1,
       progress: [{ ariaValueNow: '23' }],
     })).toBe(true);
+  });
+
+  it('matches X draft text after trimming platform-added edge whitespace', () => {
+    const expected = 'matrix emoji 😀 🧑‍💻 ❤️‍🔥 日本語';
+    const candidates = [
+      { text: '\n', hasVideoAttachment: true, source: 'feed video' },
+      { text: `${expected} `, hasVideoAttachment: false, source: 'composer' },
+    ];
+
+    expect(normalizePreviewDraftText(`${expected} `)).toBe(expected);
+    expect(findExactPreviewDraftCandidate(candidates, expected)).toEqual(candidates[1]);
+  });
+
+  it('requires same-composer video evidence only for media draft cases', () => {
+    const candidates = [
+      { text: 'video caption', hasVideoAttachment: false },
+      { text: 'video caption\n', hasVideoAttachment: true },
+    ];
+
+    expect(findExactPreviewDraftCandidate(candidates, 'video caption', {
+      requireVideoAttachment: true,
+    })).toEqual(candidates[1]);
+    expect(findExactPreviewDraftCandidate(candidates.slice(0, 1), 'video caption', {
+      requireVideoAttachment: true,
+    })).toBeUndefined();
   });
 
   it('keeps the successful release-gate output and exit code stable', () => {


### PR DESCRIPTION
Fixes a false-negative found while gating 0.5.51 on Surface. X can append edge whitespace to composer text, and the previous reader could associate a feed video with the draft because it searched a broad main root. This trims platform-added edge whitespace and requires video evidence only for media cases, scoped to the matching composer. Verification: npm run verify:commit; Surface exact 0.5.51 X text-emoji and text-video, repeat 2: PASS.