### PR TITLE
fix(x): stabilize remounted thread composers

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -46,6 +46,8 @@ import {
   injectContentEditableText,
   injectNativeText,
   resolveTextEditorDriver,
+  shouldUseDirectLexicalState,
+  shouldUseXThreadPaste,
 } from '../src/page-world/editor-drivers';
 import { handleTumblrTextCommand } from '../src/page-world/tumblr-editor-driver';
 
@@ -684,12 +686,19 @@ export default defineContentScript({
           // synthetic beforeinput + input の二重処理も避けられる。
           const isThreadsHost = /threads\.(?:com|net)$/.test(location.host);
           const isXHost = /(?:^|\.)x\.com$/.test(location.hostname);
-          const shouldUseDirectLexicalState =
-            /instagram\.com/.test(location.host) ||
-            isThreadsHost ||
-            isXHost;
+          const useDirectLexicalState = shouldUseDirectLexicalState(
+            location.hostname,
+            el,
+          );
           const shouldRequireStableFrameworkText = isThreadsHost || isXHost;
-          if (shouldUseDirectLexicalState && editor && typeof editor.parseEditorState === 'function' && typeof editor.setEditorState === 'function') {
+          const useXThreadPaste = shouldUseXThreadPaste(location.hostname, el);
+          if (useXThreadPaste) {
+            // X's follow-up thread editors need the framework paste handler.
+            // Direct Lexical state leaves Post all disabled, while execCommand
+            // inserts the text twice in the current composer implementation.
+            await injectContentEditableText(el, text, { waitFor });
+            editor = null;
+          } else if (useDirectLexicalState && editor && typeof editor.parseEditorState === 'function' && typeof editor.setEditorState === 'function') {
             try {
               // Threads hydration and X's unfocused-window compose can both
               // replace the editor after input. Require direct Lexical state
@@ -836,7 +845,7 @@ export default defineContentScript({
             editor = null; // X 等は framework event path の方が composer state と同期しやすい
           }
 
-          if (!editor) {
+          if (!editor && !useXThreadPaste) {
             // editor instance が取れない or setEditorState 失敗 → event-based fallback
             el.focus();
             const sel0 = window.getSelection();

--- a/entrypoints/x.content.ts
+++ b/entrypoints/x.content.ts
@@ -399,25 +399,46 @@ async function executeXInlineThread(
 
     // 各 chunk を「+」 click → wait → inject の繰り返し。
     for (let i = 1; i < chunks.length; i++) {
+      // X may remount the entire compose dialog after the previous Lexical
+      // editor settles. Always resolve the live root before looking for the
+      // next add button instead of querying a detached dialog subtree.
+      ({ root: composeRoot, marker: rootMarker } = await reacquireXComposeRoot(
+        composeRoot,
+        rootMarker,
+        'thread',
+        X_THREAD_TEXTAREA_TIMEOUT_MS,
+        hasVideo,
+      ));
       const addBtn = await waitForXAddPostButton(composeRoot, X_THREAD_TEXTAREA_TIMEOUT_MS);
       if (!addBtn) {
-        throw new Error(t('runtimeXAddButtonMissing', i + 1, chunks.length, i));
+        throw new Error(
+          `${t('runtimeXAddButtonMissing', i + 1, chunks.length, i)}; ` +
+          describeXComposeState(composeRoot),
+        );
       }
       await clickElementMarkedInMainWorld(addBtn, 'tutti-x-add-post');
 
-      // 新 textarea (index i) が出現するまで MutationObserver で待つ。
-      const target = await waitForXThreadTextarea(composeRoot, i, X_THREAD_TEXTAREA_TIMEOUT_MS);
+      // Adding an editor can itself remount the dialog. Wait at document scope
+      // for the exact textarea id, then adopt the root that owns that live
+      // editor before injecting text or looking for later controls.
+      const target = await waitForXThreadTextarea(document, i, X_THREAD_TEXTAREA_TIMEOUT_MS);
       if (!target) {
-        const got = getXThreadTextareas(composeRoot).length;
+        const got = getXThreadTextareas(document).length;
         throw new Error(t(
           'runtimeXTextareaTimeout',
           i + 1,
           chunks.length,
           i + 1,
           got,
-          describeXComposeState(composeRoot),
+          describeXComposeState(document),
         ));
       }
+      ({ root: composeRoot, marker: rootMarker } = adoptXComposeRoot(
+        composeRoot,
+        rootMarker,
+        target,
+        'thread',
+      ));
       await injectTextIntoXThreadTextarea(
         composeRoot,
         i,
@@ -465,7 +486,9 @@ async function executeXInlineThread(
       if (hasVideo && !hasXVideoAttachment(composeRoot, isVisible)) {
         throw new Error(t('runtimeXVideoAttachmentLost'));
       }
-      throw new Error(t('runtimeXPostAllButtonMissing'));
+      throw new Error(
+        `${t('runtimeXPostAllButtonMissing')}; ${describeXComposeState(composeRoot)}`,
+      );
     }
     if (dryRun) {
       const orig = postBtn.style.outline;
@@ -683,6 +706,20 @@ async function reacquireXComposeRoot(
       describeXComposeState(document),
     ));
   }
+  return adoptXComposeRoot(
+    previousRoot,
+    previousMarker,
+    currentTextarea,
+    label,
+  );
+}
+
+function adoptXComposeRoot(
+  previousRoot: HTMLElement,
+  previousMarker: string,
+  currentTextarea: HTMLElement,
+  label: string,
+): { root: HTMLElement; marker: string } {
   const currentRoot = getXComposeRoot(currentTextarea);
   if (currentRoot === previousRoot) {
     return { root: previousRoot, marker: previousMarker };

--- a/src/adapters/x-compose-dom.test.ts
+++ b/src/adapters/x-compose-dom.test.ts
@@ -54,6 +54,30 @@ describe('X thread compose DOM selection', () => {
     expect(getXComposeRoot(secondTextarea).id).toBe('second');
   });
 
+  it('finds a later thread editor in the replacement dialog, not the detached root', () => {
+    document.body.innerHTML = `
+      <div role="dialog" id="first">
+        <div data-testid="tweetTextarea_0" role="textbox"></div>
+        <div data-testid="tweetTextarea_1" role="textbox"></div>
+      </div>
+    `;
+    const firstRoot = document.querySelector<HTMLElement>('#first')!;
+
+    firstRoot.remove();
+    document.body.innerHTML = `
+      <div role="dialog" id="replacement">
+        <div data-testid="tweetTextarea_0" role="textbox"></div>
+        <div data-testid="tweetTextarea_1" role="textbox"></div>
+        <div data-testid="tweetTextarea_2" role="textbox"></div>
+      </div>
+    `;
+
+    const thirdTextarea = getXThreadTextarea(document, 2, () => true);
+    expect(thirdTextarea).toBeDefined();
+    expect(getXComposeRoot(thirdTextarea!).id).toBe('replacement');
+    expect(firstRoot.isConnected).toBe(false);
+  });
+
   it('requires a visible video inside the current compose root', () => {
     document.body.innerHTML = `
       <div role="dialog" id="current"><video id="attached"></video></div>

--- a/src/page-world/editor-drivers.test.ts
+++ b/src/page-world/editor-drivers.test.ts
@@ -5,6 +5,8 @@ import {
   injectContentEditableText,
   injectNativeText,
   resolveTextEditorDriver,
+  shouldUseDirectLexicalState,
+  shouldUseXThreadPaste,
 } from './editor-drivers';
 
 beforeEach(() => {
@@ -29,6 +31,44 @@ describe('page-world editor drivers', () => {
     expect(resolveTextEditorDriver(document.querySelector('#x-editor')!)).toBe('lexical');
     expect(resolveTextEditorDriver(document.querySelector('#draft')!)).toBe('draft');
     expect(resolveTextEditorDriver(document.querySelector('#generic')!)).toBe('contenteditable');
+  });
+
+  it('uses paste instead of direct Lexical state for X follow-up thread editors', () => {
+    document.body.innerHTML = `
+      <div id="first" data-testid="tweetTextarea_0" contenteditable="true"></div>
+      <div id="follow-up" data-testid="tweetTextarea_1" contenteditable="true"></div>
+      <div id="later" data-testid="tweetTextarea_12" contenteditable="true"></div>
+    `;
+
+    expect(shouldUseDirectLexicalState(
+      'x.com',
+      document.querySelector<HTMLElement>('#first')!,
+    )).toBe(true);
+    expect(shouldUseDirectLexicalState(
+      'x.com',
+      document.querySelector<HTMLElement>('#follow-up')!,
+    )).toBe(false);
+    expect(shouldUseDirectLexicalState(
+      'x.com',
+      document.querySelector<HTMLElement>('#later')!,
+    )).toBe(false);
+    expect(shouldUseXThreadPaste(
+      'x.com',
+      document.querySelector<HTMLElement>('#follow-up')!,
+    )).toBe(true);
+    expect(shouldUseXThreadPaste(
+      'twitter.com',
+      document.querySelector<HTMLElement>('#follow-up')!,
+    )).toBe(false);
+  });
+
+  it('keeps direct Lexical state for Instagram and Threads editors', () => {
+    document.body.innerHTML = '<div id="editor" contenteditable="true"></div>';
+    const editor = document.querySelector<HTMLElement>('#editor')!;
+
+    expect(shouldUseDirectLexicalState('www.instagram.com', editor)).toBe(true);
+    expect(shouldUseDirectLexicalState('www.threads.com', editor)).toBe(true);
+    expect(shouldUseDirectLexicalState('example.com', editor)).toBe(false);
   });
 
   it.each(['input', 'textarea'])(

--- a/src/page-world/editor-drivers.ts
+++ b/src/page-world/editor-drivers.ts
@@ -32,6 +32,30 @@ export function resolveTextEditorDriver(element: HTMLElement): TextEditorDriverK
   return 'contenteditable';
 }
 
+export function shouldUseDirectLexicalState(
+  hostname: string,
+  element: HTMLElement,
+): boolean {
+  const host = hostname.toLowerCase();
+  if (/(?:^|\.)instagram\.com$/.test(host)) return true;
+  if (/(?:^|\.)threads\.(?:com|net)$/.test(host)) return true;
+  if (!/(?:^|\.)x\.com$/.test(host)) return false;
+
+  // X's parent thread composer state is not updated when a follow-up editor
+  // is changed only through Lexical setEditorState. Its DOM contains the text,
+  // but Post all stays disabled and the next Add post button disappears.
+  return !shouldUseXThreadPaste(host, element);
+}
+
+export function shouldUseXThreadPaste(
+  hostname: string,
+  element: HTMLElement,
+): boolean {
+  if (!/(?:^|\.)x\.com$/.test(hostname.toLowerCase())) return false;
+  const testId = element.getAttribute('data-testid') ?? '';
+  return /^tweetTextarea_[1-9]\d*$/.test(testId);
+}
+
 export function injectNativeText(
   element: HTMLInputElement | HTMLTextAreaElement,
   text: string,


### PR DESCRIPTION
Fixes the Surface release-gate failure found in X multi-chunk drafts. X remounts its composer between follow-up editors, direct Lexical state leaves the parent thread invalid, and execCommand duplicates text. Reacquire the live compose root after each added editor and use X's MAIN-world paste handler for tweetTextarea_1 and later. Adds regression coverage and richer failure diagnostics. Verification: npm run verify:commit (117 architecture, 903 tests); exact 0.5.51 SHA-256 82D05D25FEF842436C54476A34405FFC23C1B7D6F1180AD06086D6D80D68C921 on Surface; long-text-image repeat 2 PASS; long-text-video repeat 2 PASS; preview submitReached=false.