### PR TITLE
fix(x): synchronize captions with submit payload

### DIFF
--- a/entrypoints/inject-helper.content.ts
+++ b/entrypoints/inject-helper.content.ts
@@ -47,7 +47,7 @@ import {
   injectNativeText,
   resolveTextEditorDriver,
   shouldUseDirectLexicalState,
-  shouldUseXThreadPaste,
+  shouldUseXEditorPaste,
 } from '../src/page-world/editor-drivers';
 import { handleTumblrTextCommand } from '../src/page-world/tumblr-editor-driver';
 
@@ -691,11 +691,11 @@ export default defineContentScript({
             el,
           );
           const shouldRequireStableFrameworkText = isThreadsHost || isXHost;
-          const useXThreadPaste = shouldUseXThreadPaste(location.hostname, el);
-          if (useXThreadPaste) {
-            // X's follow-up thread editors need the framework paste handler.
-            // Direct Lexical state leaves Post all disabled, while execCommand
-            // inserts the text twice in the current composer implementation.
+          const useXEditorPaste = shouldUseXEditorPaste(location.hostname, el);
+          if (useXEditorPaste) {
+            // X's paste handler is the only synthetic path verified to update
+            // CreateTweet.tweet_text. Direct Lexical/DOM state can render the
+            // caption while the eventual request still contains an empty body.
             await injectContentEditableText(el, text, { waitFor });
             editor = null;
           } else if (useDirectLexicalState && editor && typeof editor.parseEditorState === 'function' && typeof editor.setEditorState === 'function') {
@@ -845,7 +845,7 @@ export default defineContentScript({
             editor = null; // X 等は framework event path の方が composer state と同期しやすい
           }
 
-          if (!editor && !useXThreadPaste) {
+          if (!editor && !useXEditorPaste) {
             // editor instance が取れない or setEditorState 失敗 → event-based fallback
             el.focus();
             const sel0 = window.getSelection();

--- a/entrypoints/x.content.ts
+++ b/entrypoints/x.content.ts
@@ -29,6 +29,7 @@ import {
   getXThreadTextareas as getExactXThreadTextareas,
   getXVideoComposeRoot,
   hasXVideoAttachment,
+  readXEditableText,
 } from '../src/adapters/x-compose-dom';
 import { t } from '../src/utils/i18n';
 import { markPostSubmissionStarted } from '../src/utils/post-submission-state';
@@ -252,7 +253,7 @@ async function executeXSinglePost(
     const currentTextarea = getXThreadTextarea(composeRoot, 0, isVisible);
     if (
       text &&
-      normalizeXEditableText(currentTextarea?.textContent) !==
+      normalizeXEditableText(readXEditableText(currentTextarea)) !==
         normalizeXEditableText(text)
     ) {
       await injectTextWithRetry(
@@ -532,7 +533,7 @@ async function injectTextWithRetry(
       await sleep(500 + attempt * 200); // 700 / 900 / 1100ms verify wait
     }
     const el = document.querySelector(selector);
-    const got = (el?.textContent ?? '').trim();
+    const got = readXEditableText(el instanceof HTMLElement ? el : undefined).trim();
     // prefix 一致 + 一定長 で OK 判定
     if (got.length > 0 && got.startsWith(expectedPrefix.slice(0, Math.min(10, expectedPrefix.length)))) {
       if (attempt > 1) log.info(`X: text inject attempt ${attempt}/${maxAttempts} 成功 ("${got.slice(0, 20)}")`);
@@ -561,7 +562,7 @@ async function injectTextIntoXThreadTextarea(
       await sleep(250 + attempt * 150);
       continue;
     }
-    if (normalizeXEditableText(target.textContent) === expected) return;
+    if (normalizeXEditableText(readXEditableText(target)) === expected) return;
     const marker = `tutti-x-chunk-${index}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     target.setAttribute('data-tutti-marker', marker);
     try {
@@ -579,7 +580,7 @@ async function injectTextIntoXThreadTextarea(
       const stable = await waitForStableCondition<HTMLElement>(
         () => {
           const current = getXThreadTextarea(scope, index, isVisible);
-          return current && normalizeXEditableText(current.textContent) === expected
+          return current && normalizeXEditableText(readXEditableText(current)) === expected
             ? current
             : null;
         },
@@ -600,13 +601,13 @@ async function injectTextIntoXThreadTextarea(
       // X can replace the Lexical element repeatedly while preserving its
       // editor state. Element-identity stability is useful, but exact text on
       // the latest editor is sufficient and must not trigger an append retry.
-      if (current && normalizeXEditableText(current.textContent) === expected) {
+      if (current && normalizeXEditableText(readXEditableText(current)) === expected) {
         return;
       }
     } else {
       await sleep(500 + attempt * 200);
       const current = getXThreadTextarea(scope, index, isVisible);
-      if (current && normalizeXEditableText(current.textContent) === expected) return;
+      if (current && normalizeXEditableText(readXEditableText(current)) === expected) return;
     }
 
     lastError = new Error(`X: chunk ${index + 1} editor remounted or lost injected text`);

--- a/src/adapters/x-compose-dom.test.ts
+++ b/src/adapters/x-compose-dom.test.ts
@@ -7,6 +7,7 @@ import {
   getXThreadTextareas,
   getXVideoComposeRoot,
   hasXVideoAttachment,
+  readXEditableText,
 } from './x-compose-dom';
 
 describe('X thread compose DOM selection', () => {
@@ -111,5 +112,17 @@ describe('X thread compose DOM selection', () => {
     `;
 
     expect(getXVideoComposeRoot(document, () => true)?.id).toBe('attached-dialog');
+  });
+
+  it('preserves rendered Draft.js block boundaries when reading X text', () => {
+    const editor = document.createElement('div');
+    editor.innerHTML = '<div>first line</div><div><br></div><div>https://example.com/</div>';
+    Object.defineProperty(editor, 'innerText', {
+      configurable: true,
+      value: 'first line\n\nhttps://example.com/',
+    });
+
+    expect(editor.textContent).toBe('first linehttps://example.com/');
+    expect(readXEditableText(editor)).toBe('first line\n\nhttps://example.com/');
   });
 });

--- a/src/adapters/x-compose-dom.ts
+++ b/src/adapters/x-compose-dom.ts
@@ -30,6 +30,16 @@ export function getXComposeRoot(textarea: HTMLElement): HTMLElement {
     document.body;
 }
 
+/**
+ * Draft.js renders each paragraph in a separate block. textContent joins
+ * those blocks without separators, which makes a correct URL-prefilled draft
+ * look different from the original text. innerText preserves the rendered
+ * line boundaries used by X's composer.
+ */
+export function readXEditableText(element: HTMLElement | undefined): string {
+  return element?.innerText ?? element?.textContent ?? '';
+}
+
 export function getXVideoComposeRoot(
   scope: ParentNode,
   isVisible: (element: HTMLElement) => boolean,

--- a/src/page-world/editor-drivers.test.ts
+++ b/src/page-world/editor-drivers.test.ts
@@ -6,7 +6,7 @@ import {
   injectNativeText,
   resolveTextEditorDriver,
   shouldUseDirectLexicalState,
-  shouldUseXThreadPaste,
+  shouldUseXEditorPaste,
 } from './editor-drivers';
 
 beforeEach(() => {
@@ -21,6 +21,9 @@ describe('page-world editor drivers', () => {
       <textarea id="textarea"></textarea>
       <div data-lexical-editor><div id="lexical" contenteditable="true"></div></div>
       <div id="x-editor" data-testid="tweetTextarea_1" contenteditable="true"></div>
+      <div class="DraftEditor-root">
+        <div id="x-draft" class="public-DraftEditor-content" data-testid="tweetTextarea_0" contenteditable="true"></div>
+      </div>
       <div class="DraftEditor-root"><div id="draft" contenteditable="true"></div></div>
       <div id="generic" contenteditable="true"></div>
     `;
@@ -29,11 +32,12 @@ describe('page-world editor drivers', () => {
     expect(resolveTextEditorDriver(document.querySelector('#textarea')!)).toBe('native');
     expect(resolveTextEditorDriver(document.querySelector('#lexical')!)).toBe('lexical');
     expect(resolveTextEditorDriver(document.querySelector('#x-editor')!)).toBe('lexical');
+    expect(resolveTextEditorDriver(document.querySelector('#x-draft')!)).toBe('draft');
     expect(resolveTextEditorDriver(document.querySelector('#draft')!)).toBe('draft');
     expect(resolveTextEditorDriver(document.querySelector('#generic')!)).toBe('contenteditable');
   });
 
-  it('uses paste instead of direct Lexical state for X follow-up thread editors', () => {
+  it('uses X paste handling for every exact tweet editor', () => {
     document.body.innerHTML = `
       <div id="first" data-testid="tweetTextarea_0" contenteditable="true"></div>
       <div id="follow-up" data-testid="tweetTextarea_1" contenteditable="true"></div>
@@ -43,7 +47,7 @@ describe('page-world editor drivers', () => {
     expect(shouldUseDirectLexicalState(
       'x.com',
       document.querySelector<HTMLElement>('#first')!,
-    )).toBe(true);
+    )).toBe(false);
     expect(shouldUseDirectLexicalState(
       'x.com',
       document.querySelector<HTMLElement>('#follow-up')!,
@@ -52,11 +56,15 @@ describe('page-world editor drivers', () => {
       'x.com',
       document.querySelector<HTMLElement>('#later')!,
     )).toBe(false);
-    expect(shouldUseXThreadPaste(
+    expect(shouldUseXEditorPaste(
+      'x.com',
+      document.querySelector<HTMLElement>('#first')!,
+    )).toBe(true);
+    expect(shouldUseXEditorPaste(
       'x.com',
       document.querySelector<HTMLElement>('#follow-up')!,
     )).toBe(true);
-    expect(shouldUseXThreadPaste(
+    expect(shouldUseXEditorPaste(
       'twitter.com',
       document.querySelector<HTMLElement>('#follow-up')!,
     )).toBe(false);

--- a/src/page-world/editor-drivers.ts
+++ b/src/page-world/editor-drivers.ts
@@ -14,6 +14,12 @@ export function resolveTextEditorDriver(element: HTMLElement): TextEditorDriverK
     return 'native';
   }
   if (
+    element.matches('.public-DraftEditor-content') ||
+    !!element.closest('.DraftEditor-root')
+  ) {
+    return 'draft';
+  }
+  if (
     element.matches('[data-lexical-editor]') ||
     !!element.closest('[data-lexical-editor]') ||
     (
@@ -22,12 +28,6 @@ export function resolveTextEditorDriver(element: HTMLElement): TextEditorDriverK
     )
   ) {
     return 'lexical';
-  }
-  if (
-    element.matches('.public-DraftEditor-content') ||
-    !!element.closest('.DraftEditor-root')
-  ) {
-    return 'draft';
   }
   return 'contenteditable';
 }
@@ -39,21 +39,20 @@ export function shouldUseDirectLexicalState(
   const host = hostname.toLowerCase();
   if (/(?:^|\.)instagram\.com$/.test(host)) return true;
   if (/(?:^|\.)threads\.(?:com|net)$/.test(host)) return true;
-  if (!/(?:^|\.)x\.com$/.test(host)) return false;
-
-  // X's parent thread composer state is not updated when a follow-up editor
-  // is changed only through Lexical setEditorState. Its DOM contains the text,
-  // but Post all stays disabled and the next Add post button disappears.
-  return !shouldUseXThreadPaste(host, element);
+  // X's current composer does not expose a stable Lexical editor instance.
+  // Direct DOM/editor-state mutation can leave tweet_text empty even while the
+  // rendered textarea contains the expected caption. Use X's paste handler for
+  // every exact tweetTextarea_n editor so its submit state owns the text.
+  return false;
 }
 
-export function shouldUseXThreadPaste(
+export function shouldUseXEditorPaste(
   hostname: string,
   element: HTMLElement,
 ): boolean {
   if (!/(?:^|\.)x\.com$/.test(hostname.toLowerCase())) return false;
   const testId = element.getAttribute('data-testid') ?? '';
-  return /^tweetTextarea_[1-9]\d*$/.test(testId);
+  return /^tweetTextarea_\d+$/.test(testId);
 }
 
 export function injectNativeText(


### PR DESCRIPTION
## Summary

- route every fallback X `tweetTextarea_n` through X's framework paste handler so visible captions are synchronized with `CreateTweet.tweet_text`
- prefer rendered `innerText` when comparing X Draft.js blocks, preserving URL paragraph boundaries and avoiding destructive reinjection
- classify current X `public-DraftEditor-content` nodes as Draft.js before the generic tweet-editor fallback

## Root cause

On Surface Chrome 151, X no longer exposed the assumed Lexical editor instance. The fallback could render the caption in the DOM without updating the submit payload. Video made the Post button valid even with empty `tweet_text`, producing a video-only public post. A blocked-network probe confirmed X's paste handler includes the exact marker in `CreateTweet.tweet_text`; the old fallback and raw `execCommand` did not.

## Verification

- `npm run verify:commit`
  - scripts catalog: 253
  - architecture: 117 tests
  - unit/integration: 909 tests
  - compile and production build: PASS
- Surface exact artifact: v0.5.51, SHA-256 `D460D9C319E6471D1866E5D6657B0FDD5F9B1E3165EF0ACFA11181952916B614`
- X full preview matrix: 22/22 PASS, all `submitReached=false`
- X `text-url,text-video` repeat 2: 4/4 PASS
- X real `text-video`: PASS, exact text + visible video verified
  - https://x.com/ren_fujimoto/status/2083596484541550592
- Surface Brave used `--mute-audio --disable-notifications`

CWS remains blocked and unuploaded because the exact artifact still cannot pass Misskey media: the configured Misskey.io test account has `driveCapacityMb=0` and the `投稿禁止` role.
